### PR TITLE
Use selected start time for first task

### DIFF
--- a/src/contexts/TimeTrackingContext.tsx
+++ b/src/contexts/TimeTrackingContext.tsx
@@ -545,12 +545,15 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
       );
     }
 
+    // Determine start time: use dayStartTime for first task, otherwise use current time
+    const taskStartTime = tasks.length === 0 && dayStartTime ? dayStartTime : now;
+
     // Create new task
     const newTask: Task = {
       id: Date.now().toString(),
       title,
       description,
-      startTime: now,
+      startTime: taskStartTime,
       project,
       client,
       category
@@ -558,7 +561,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
 
     setTasks((prev) => [...prev, newTask]);
     setCurrentTask(newTask);
-    console.log('New task started:', title);
+    console.log('New task started:', title, 'at', taskStartTime);
     // Save immediately since this is a critical action
     saveImmediately();
   };


### PR DESCRIPTION
When a user selects a custom date/time for when their day starts, the first task created will now automatically use that start time instead of the current time. Subsequent tasks continue to use the current time when created.

- Modified startNewTask() to check if this is the first task (tasks.length === 0)
- If first task and dayStartTime exists, use dayStartTime as the task start time
- Otherwise, use current time as before