### PR TITLE
Fix bottom navigation on iOS PWA

### DIFF
--- a/public/pwa.css
+++ b/public/pwa.css
@@ -11,14 +11,14 @@
 /* Ensure body accounts for safe areas */
 body {
 	padding-top: var(--safe-area-inset-top);
-	padding-bottom: var(--safe-area-inset-bottom);
 	padding-left: var(--safe-area-inset-left);
 	padding-right: var(--safe-area-inset-right);
 }
 
 /* Add padding bottom for mobile nav on mobile devices */
+/* Note: iOS-specific padding is handled in the iOS section below */
 @media (max-width: 768px) {
-	body {
+	body:not(.ios-device) {
 		padding-bottom: calc(4rem + var(--safe-area-inset-bottom));
 	}
 }
@@ -156,6 +156,38 @@ body {
 	select,
 	textarea {
 		font-size: 16px !important;
+	}
+
+	/* iOS PWA bottom navigation fix */
+	.mobile-nav-ios {
+		position: fixed;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		/* Ensure navigation is always visible above content */
+		z-index: 9999;
+		/* Use safe area insets for iOS notch/home indicator */
+		padding-bottom: env(safe-area-inset-bottom);
+		/* Add backdrop for better visibility */
+		backdrop-filter: blur(10px);
+		-webkit-backdrop-filter: blur(10px);
+		background-color: rgba(255, 255, 255, 0.95);
+	}
+
+	/* Dark mode support for iOS navigation */
+	.dark .mobile-nav-ios {
+		background-color: rgba(9, 9, 11, 0.95);
+	}
+
+	/* Ensure body padding accounts for nav + safe area */
+	@media (max-width: 768px) {
+		body {
+			padding-bottom: 0 !important;
+		}
+
+		#root {
+			padding-bottom: calc(4rem + env(safe-area-inset-bottom, 0px));
+		}
 	}
 }
 

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -34,8 +34,10 @@ export const MobileNav = memo(function MobileNav() {
 
 	return (
 		<nav
-			className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 md:hidden z-40 safe-area-inset-bottom"
-			style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+			className="fixed bottom-0 left-0 right-0 bg-background border-t border-border md:hidden z-40 mobile-nav-ios"
+			style={{
+				paddingBottom: "max(env(safe-area-inset-bottom, 0px), 0px)",
+			}}
 		>
 			<div className="grid grid-cols-4 h-16">
 				{navItems.map(({ path, icon: Icon, label }) => (
@@ -45,7 +47,7 @@ export const MobileNav = memo(function MobileNav() {
 						className={`flex flex-col items-center justify-center space-y-1 transition-colors touch-manipulation ${
 							isActive(path)
 								? "text-primary"
-								: "text-gray-500 hover:text-gray-700"
+								: "text-muted-foreground hover:text-foreground"
 						}`}
 						aria-label={label}
 						aria-current={isActive(path) ? "page" : undefined}


### PR DESCRIPTION
- Update MobileNav to use theme-aware colors (bg-background, border-border)
- Replace hardcoded grays with theme variables for dark mode support
- Add iOS-specific styling with backdrop blur and proper z-index
- Fix safe area inset handling for iOS home indicator
- Resolve body padding conflicts by moving to #root on iOS
- Add transparent background with blur effect for better visibility