### PR TITLE
action: add GitHub Action for generating releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,150 @@
+name: Release
+
+on:
+	push:
+		branches:
+			- main
+	pull_request:
+		types:
+			- closed
+		branches:
+			- main
+
+jobs:
+	release:
+		# Only run if PR was merged or direct push to main
+		if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+		runs-on: ubuntu-latest
+		permissions:
+			contents: write
+			pull-requests: read
+
+		steps:
+			- name: Checkout code
+				uses: actions/checkout@v4
+				with:
+					fetch-depth: 0
+					token: ${{ secrets.GITHUB_TOKEN }}
+
+			- name: Setup Node.js
+				uses: actions/setup-node@v4
+				with:
+					node-version: "20"
+					cache: "npm"
+
+			- name: Configure Git
+				run: |
+					git config user.name "github-actions[bot]"
+					git config user.email "github-actions[bot]@users.noreply.github.com"
+
+			- name: Get current version
+				id: current_version
+				run: |
+					CURRENT_VERSION=$(node -p "require('./package.json').version")
+					echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+					echo "Current version: $CURRENT_VERSION"
+
+			- name: Determine version bump type
+				id: bump_type
+				run: |
+					# Get the latest commit message
+					COMMIT_MSG=$(git log -1 --pretty=%B)
+					echo "Commit message: $COMMIT_MSG"
+
+					# Determine bump type based on commit message prefix
+					if echo "$COMMIT_MSG" | grep -qiE "^(feat|feature|fix):"; then
+						echo "type=minor" >> $GITHUB_OUTPUT
+						echo "Version bump: MINOR (feat/fix)"
+					elif echo "$COMMIT_MSG" | grep -qiE "^(patch|bump|maint|chore|refactor):"; then
+						echo "type=patch" >> $GITHUB_OUTPUT
+						echo "Version bump: PATCH"
+					else
+						echo "type=none" >> $GITHUB_OUTPUT
+						echo "No version bump (commit doesn't match versioning patterns)"
+					fi
+
+			- name: Bump version
+				id: new_version
+				if: steps.bump_type.outputs.type != 'none'
+				run: |
+					BUMP_TYPE=${{ steps.bump_type.outputs.type }}
+
+					# Bump the version
+					npm version $BUMP_TYPE --no-git-tag-version
+
+					# Get the new version
+					NEW_VERSION=$(node -p "require('./package.json').version")
+					echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+					echo "New version: $NEW_VERSION"
+
+			- name: Commit version bump
+				if: steps.bump_type.outputs.type != 'none'
+				run: |
+					git add package.json package-lock.json
+					git commit -m "chore: bump version to ${{ steps.new_version.outputs.version }}"
+					git push
+
+			- name: Create Git tag
+				if: steps.bump_type.outputs.type != 'none'
+				run: |
+					git tag "v${{ steps.new_version.outputs.version }}"
+					git push --tags
+
+			- name: Generate changelog
+				id: changelog
+				if: steps.bump_type.outputs.type != 'none'
+				run: |
+					# Get commits since last tag
+					PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+
+					if [ -z "$PREVIOUS_TAG" ]; then
+						COMMITS=$(git log --pretty=format:"- %s (%h)" --no-merges)
+					else
+						COMMITS=$(git log $PREVIOUS_TAG..HEAD --pretty=format:"- %s (%h)" --no-merges)
+					fi
+
+					# Create changelog content
+					CHANGELOG="## Changes in v${{ steps.new_version.outputs.version }}
+
+$COMMITS"
+
+					# Save to output (escape newlines for GitHub Actions)
+					echo "content<<EOF" >> $GITHUB_OUTPUT
+					echo "$CHANGELOG" >> $GITHUB_OUTPUT
+					echo "EOF" >> $GITHUB_OUTPUT
+
+			- name: Create GitHub Release
+				if: steps.bump_type.outputs.type != 'none'
+				uses: actions/create-release@v1
+				env:
+					GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+				with:
+					tag_name: v${{ steps.new_version.outputs.version }}
+					release_name: Release v${{ steps.new_version.outputs.version }}
+					body: ${{ steps.changelog.outputs.content }}
+					draft: false
+					prerelease: false
+
+			- name: Summary
+				if: steps.bump_type.outputs.type != 'none'
+				run: |
+					echo "## 🚀 Release Summary" >> $GITHUB_STEP_SUMMARY
+					echo "" >> $GITHUB_STEP_SUMMARY
+					echo "- **Previous Version:** ${{ steps.current_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+					echo "- **New Version:** ${{ steps.new_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+					echo "- **Bump Type:** ${{ steps.bump_type.outputs.type }}" >> $GITHUB_STEP_SUMMARY
+					echo "- **Tag:** v${{ steps.new_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+					echo "" >> $GITHUB_STEP_SUMMARY
+					echo "### Changelog" >> $GITHUB_STEP_SUMMARY
+					echo "${{ steps.changelog.outputs.content }}" >> $GITHUB_STEP_SUMMARY
+
+			- name: No version bump
+				if: steps.bump_type.outputs.type == 'none'
+				run: |
+					echo "## ℹ️ No Version Bump" >> $GITHUB_STEP_SUMMARY
+					echo "" >> $GITHUB_STEP_SUMMARY
+					echo "The commit message doesn't match any versioning patterns:" >> $GITHUB_STEP_SUMMARY
+					echo "- \`feat:\` or \`fix:\` for minor version bump" >> $GITHUB_STEP_SUMMARY
+					echo "- \`patch:\`, \`bump:\`, \`maint:\`, or \`refactor:\` for patch version bump" >> $GITHUB_STEP_SUMMARY
+					echo "" >> $GITHUB_STEP_SUMMARY
+					echo "Current version remains: **${{ steps.current_version.outputs.version }}**" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
1. Detects the version bump type from the commit message
2. Updates package.json and package-lock.json versions
3. Commits the version bump back to main
4. Creates a Git tag (e.g., v1.2.3)
5. Generates a changelog from commits since the last tag
6. Creates a GitHub Release with the changelog
7. Provides a summary in the workflow run