### PR TITLE
Auto-open New Task form when starting a day

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md - AI Assistant Codebase Guide
 
-**Last Updated:** 2025-11-21
-**Version:** 1.0.1
+**Last Updated:** 2026-02-02
+**Version:** 1.0.2
 
 This document provides comprehensive guidance for AI assistants working with the TimeTracker Pro codebase. It covers architecture, conventions, workflows, and best practices.
 
@@ -306,17 +306,19 @@ TimeTrackerPro/
 ### Time Tracking Flow
 
 ```
-1. User starts day
+1. User starts day (via StartDayDialog)
    ↓
 2. TimeTrackingContext updates state
    ↓
-3. User creates tasks
+3. New Task form auto-opens (defaultOpen prop)
    ↓
-4. Tasks saved to state (in-memory)
+4. User creates tasks
    ↓
-5. Manual sync OR critical events (end day, window close)
+5. Tasks saved to state (in-memory)
    ↓
-6. DataService persists to localStorage or Supabase
+6. Manual sync OR critical events (end day, window close)
+   ↓
+7. DataService persists to localStorage or Supabase
 ```
 
 ### Data Service Selection
@@ -984,6 +986,7 @@ Before making changes, verify:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.0.2 | 2026-02-02 | Added auto-open New Task form feature when day starts |
 | 1.0.1 | 2025-11-21 | Updated component list, documentation references, and current state |
 | 1.0.0 | 2025-11-18 | Initial CLAUDE.md creation |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4186,7 +4186,7 @@
       "version": "1.13.5",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.5.tgz",
       "integrity": "sha512-WezcBo8a0Dg2rnR82zhwoR6aRNxeTGfK5QCD6TQ+kg3xx/zNT02s/0o+81h/3zhvFSB24NtqEr8FTw88O5W/JQ==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4228,6 +4228,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4244,6 +4245,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4260,6 +4262,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4276,6 +4279,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4292,6 +4296,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4308,6 +4313,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4324,6 +4330,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4340,6 +4347,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4356,6 +4364,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4372,6 +4381,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4385,14 +4395,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/src/components/NewTaskForm.tsx
+++ b/src/components/NewTaskForm.tsx
@@ -22,15 +22,16 @@ interface NewTaskFormProps {
     client?: string,
     category?: string
   ) => void;
+  defaultOpen?: boolean;
 }
 
-export const NewTaskForm: React.FC<NewTaskFormProps> = ({ onSubmit }) => {
+export const NewTaskForm: React.FC<NewTaskFormProps> = ({ onSubmit, defaultOpen = false }) => {
   const { projects, categories } = useTimeTracking();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [selectedProject, setSelectedProject] = useState<string>("");
   const [selectedCategory, setSelectedCategory] = useState<string>("");
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(defaultOpen);
 
   const selectedProjectData = projects.find((p) => p.id === selectedProject);
   const selectedCategoryData = categories.find(

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -27,6 +27,7 @@ const TimeTrackerContent = () => {
   } = useTimeTracking();
 
   const [showStartDayDialog, setShowStartDayDialog] = useState(false);
+  const [autoOpenTaskForm, setAutoOpenTaskForm] = useState(false);
 
   const handleStartDay = () => {
     setShowStartDayDialog(true);
@@ -34,6 +35,7 @@ const TimeTrackerContent = () => {
 
   const handleStartDayWithDateTime = (startDateTime: Date) => {
     startDay(startDateTime);
+    setAutoOpenTaskForm(true);
   };
 
   const handleEndDay = () => {
@@ -159,7 +161,7 @@ const TimeTrackerContent = () => {
           </Card>
         ) : (
           <>
-            <NewTaskForm onSubmit={handleNewTask} />
+            <NewTaskForm onSubmit={handleNewTask} defaultOpen={autoOpenTaskForm} />
             {tasks.length > 0 && (
               <div className="space-y-4">
                 <h2 className="flex justify-between text-lg font-semibold text-gray-900">Tasks ({tasks.length})


### PR DESCRIPTION
## Summary
This PR implements an auto-open feature for the New Task form when users start a new day, improving the workflow by immediately presenting the task creation interface without requiring an additional click.

## Key Changes
- **NewTaskForm Component**: Added `defaultOpen` prop to control initial open state of the form dialog
- **Index Page**: Introduced `autoOpenTaskForm` state that triggers when `startDay()` is called, passing this state to the NewTaskForm via the `defaultOpen` prop
- **Documentation**: Updated CLAUDE.md to reflect the new auto-open behavior in the time tracking flow diagram and added version 1.0.2 changelog entry
- **Dependencies**: Corrected `devOptional` flags to `dev: true` for @swc packages in package-lock.json for consistency

## Implementation Details
- The `defaultOpen` prop defaults to `false` to maintain backward compatibility
- When a user confirms the StartDayDialog and `handleStartDayWithDateTime()` is called, `autoOpenTaskForm` is set to `true`
- This state is passed to NewTaskForm, which initializes its dialog in the open state
- The flow now reads: Start Day → TimeTrackingContext updates → New Task form auto-opens → User creates tasks

## Testing Recommendations
- Verify the New Task form opens automatically after starting a day
- Confirm the form can be closed and reopened normally
- Test that the form still works with `defaultOpen={false}` in other contexts

https://claude.ai/code/session_01G7jBqP6aRrYSLsiC82pEZW