### PR TITLE
fix: security and type safety hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Archive Edit Dialog**: 4 time pickers (2 for day start/end, 2 for task start/end)
 - Removed duplicate `generateTimeOptions()` helper functions from all dialog components
 
+### Security
+- Removed unsafe `as string` type assertions on `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in `src/lib/supabase.ts` — the assertions hid the `string | undefined` type from TypeScript, preventing the compiler from enforcing the existing null-guard; variables are now correctly typed so the `?? ''` fallback and early warn are properly enforced
+- Gated `getDbCallStats`, `resetDbCallStats`, and `clearDbCallLog` window attachments behind `import.meta.env.DEV` in `src/lib/supabase.ts` — internal database call telemetry was previously exposed to anyone with DevTools access in production; Vite now tree-shakes the attachment block out of production bundles
+- Added explicit radix `10` to `parseInt()` call in CSV import (`src/utils/exportUtils.ts`) — implicit radix is deprecated and could silently misparse duration strings with leading zeros
+
 ### Removed
 - Deleted `src/hooks/.useReportSummary-Claude.ts` — unused development dotfile that contained a direct Anthropic API key reference
 - Deleted `src/utils/supabase.ts` — duplicate Supabase client that was never imported, creating a redundant connection

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,6 @@
 import { createClient, User } from '@supabase/supabase-js';
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
-const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   console.warn('Supabase env vars not found. Supabase sync will be disabled.');
@@ -191,8 +191,8 @@ export const resetDbCallStats = () => {
   dbCallLog = [];
 };
 
-// Make these functions available globally for debugging
-if (typeof window !== 'undefined') {
+// Make these functions available globally for debugging (development only)
+if (import.meta.env.DEV && typeof window !== 'undefined') {
   (window as Window & typeof globalThis & {
     getDbCallStats: typeof getDbCallStats;
     resetDbCallStats: typeof resetDbCallStats;

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -314,7 +314,7 @@ export function parseCSVImport(
 				description: taskData.description || undefined,
 				startTime: new Date(taskData.start_time),
 				endTime: taskData.end_time ? new Date(taskData.end_time) : undefined,
-				duration: taskData.duration ? parseInt(taskData.duration) : undefined,
+				duration: taskData.duration ? parseInt(taskData.duration, 10) : undefined,
 				project: taskData.project_name || undefined,
 				client: taskData.client || undefined,
 				category: categoryId


### PR DESCRIPTION
- removed `as string` assertions on env vars
- removed Window debug helpers with Vite's tree-shaker stripping any exposed helpers
- changed `parseInt(value)` to `parseInt(value, 10)` to prevent silent misparse of strings