### PR TITLE
feat: Add task tracking panel with todo list and checklist support

### DIFF
--- a/src/components/TaskTrackingPanel.tsx
+++ b/src/components/TaskTrackingPanel.tsx
@@ -1,0 +1,220 @@
+// src/components/TaskTrackingPanel.tsx
+// A persistent task-tracking panel that combines:
+//   1. A standalone to-do list (stored via DataService, synced across devices for auth users)
+//   2. GFM checklist items extracted from current-day task descriptions
+
+import { useState, KeyboardEvent } from "react";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
+import { parseTaskChecklist, toggleDescriptionChecklistItem } from "@/utils/checklistUtils";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Separator } from "@/components/ui/separator";
+import { CheckboxIcon, TrashIcon, PlusIcon } from "@radix-ui/react-icons";
+
+export function TaskTrackingPanel() {
+	const {
+		todoItems,
+		addTodoItem,
+		toggleTodoItem,
+		deleteTodoItem,
+		clearCompletedTodos,
+		tasks,
+		isDayStarted,
+		updateTask
+	} = useTimeTracking();
+
+	const [inputValue, setInputValue] = useState("");
+
+	const activeTodos = todoItems.filter((item) => !item.completed);
+	const completedTodos = todoItems.filter((item) => item.completed);
+
+	// Gather checklist items from current-day task descriptions
+	const taskChecklists = isDayStarted
+		? tasks
+				.map((task) => ({
+					task,
+					entries: parseTaskChecklist(task.description ?? "")
+				}))
+				.filter(({ entries }) => entries.length > 0)
+		: [];
+
+	function handleAdd() {
+		const trimmed = inputValue.trim();
+		if (!trimmed) return;
+		addTodoItem(trimmed);
+		setInputValue("");
+	}
+
+	function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+		if (e.key === "Enter") handleAdd();
+	}
+
+	function handleTaskChecklistToggle(taskId: string, description: string, lineIndex: number) {
+		const updated = toggleDescriptionChecklistItem(description, lineIndex);
+		updateTask(taskId, { description: updated });
+	}
+
+	return (
+		<Card className="h-fit">
+			<CardHeader className="pb-3">
+				<CardTitle className="flex items-center gap-2 text-base">
+					<CheckboxIcon className="w-4 h-4" />
+					Task Tracking
+				</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				{/* Add new to-do */}
+				<div className="flex gap-2">
+					<Input
+						placeholder="Add a to-do item…"
+						value={inputValue}
+						onChange={(e) => setInputValue(e.target.value)}
+						onKeyDown={handleKeyDown}
+						className="h-8 text-sm"
+					/>
+					<Button
+						size="sm"
+						variant="outline"
+						onClick={handleAdd}
+						disabled={!inputValue.trim()}
+						className="h-8 px-2 shrink-0"
+					>
+						<PlusIcon className="w-4 h-4" />
+					</Button>
+				</div>
+
+				{/* Active to-dos */}
+				{activeTodos.length > 0 && (
+					<ul className="space-y-2">
+						{activeTodos.map((item) => (
+							<li key={item.id} className="flex items-start gap-2 group">
+								<Checkbox
+									id={`todo-${item.id}`}
+									checked={false}
+									onCheckedChange={() => toggleTodoItem(item.id)}
+									className="mt-0.5 shrink-0"
+								/>
+								<label
+									htmlFor={`todo-${item.id}`}
+									className="flex-1 text-sm leading-snug cursor-pointer"
+								>
+									{item.text}
+								</label>
+								<Button
+									size="sm"
+									variant="ghost"
+									onClick={() => deleteTodoItem(item.id)}
+									className="h-5 w-5 p-0 opacity-0 group-hover:opacity-100 shrink-0 text-muted-foreground hover:text-destructive"
+								>
+									<TrashIcon className="w-3 h-3" />
+								</Button>
+							</li>
+						))}
+					</ul>
+				)}
+
+				{activeTodos.length === 0 && completedTodos.length === 0 && taskChecklists.length === 0 && (
+					<p className="text-xs text-muted-foreground text-center py-2">
+						No to-do items yet. Add one above.
+					</p>
+				)}
+
+				{/* Completed to-dos */}
+				{completedTodos.length > 0 && (
+					<div className="space-y-2">
+						<div className="flex items-center justify-between">
+							<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+								Completed ({completedTodos.length})
+							</span>
+							<Button
+								size="sm"
+								variant="ghost"
+								onClick={clearCompletedTodos}
+								className="h-5 text-xs text-muted-foreground hover:text-destructive px-1"
+							>
+								Clear all
+							</Button>
+						</div>
+						<ul className="space-y-2">
+							{completedTodos.map((item) => (
+								<li key={item.id} className="flex items-start gap-2 group">
+									<Checkbox
+										id={`todo-${item.id}`}
+										checked={true}
+										onCheckedChange={() => toggleTodoItem(item.id)}
+										className="mt-0.5 shrink-0"
+									/>
+									<label
+										htmlFor={`todo-${item.id}`}
+										className="flex-1 text-sm leading-snug line-through text-muted-foreground cursor-pointer"
+									>
+										{item.text}
+									</label>
+									<Button
+										size="sm"
+										variant="ghost"
+										onClick={() => deleteTodoItem(item.id)}
+										className="h-5 w-5 p-0 opacity-0 group-hover:opacity-100 shrink-0 text-muted-foreground hover:text-destructive"
+									>
+										<TrashIcon className="w-3 h-3" />
+									</Button>
+								</li>
+							))}
+						</ul>
+					</div>
+				)}
+
+				{/* Checklist items from task descriptions */}
+				{taskChecklists.length > 0 && (
+					<>
+						<Separator />
+						<div className="space-y-3">
+							<span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+								From Tasks
+							</span>
+							{taskChecklists.map(({ task, entries }) => (
+								<div key={task.id} className="space-y-1.5">
+									<p className="text-xs font-medium text-foreground truncate" title={task.title}>
+										{task.title}
+									</p>
+									<ul className="space-y-1.5 pl-1">
+										{entries.map((entry) => (
+											<li
+												key={`${task.id}-${entry.lineIndex}`}
+												className="flex items-start gap-2"
+											>
+												<Checkbox
+													id={`task-check-${task.id}-${entry.lineIndex}`}
+													checked={entry.completed}
+													onCheckedChange={() =>
+														handleTaskChecklistToggle(
+															task.id,
+															task.description ?? "",
+															entry.lineIndex
+														)
+													}
+													className="mt-0.5 shrink-0"
+												/>
+												<label
+													htmlFor={`task-check-${task.id}-${entry.lineIndex}`}
+													className={
+														"flex-1 text-sm leading-snug cursor-pointer" +
+														(entry.completed ? " line-through text-muted-foreground" : "")
+													}
+												>
+													{entry.text}
+												</label>
+											</li>
+										))}
+									</ul>
+								</div>
+							))}
+						</div>
+					</>
+				)}
+			</CardContent>
+		</Card>
+	);
+}

--- a/src/contexts/TimeTrackingContext.tsx
+++ b/src/contexts/TimeTrackingContext.tsx
@@ -61,6 +61,14 @@ export interface Project {
   isBillable?: boolean;
 }
 
+export interface TodoItem {
+  id: string;
+  text: string;
+  completed: boolean;
+  createdAt: string;    // ISO string
+  completedAt?: string; // ISO string — set when toggled to done, cleared when toggled back
+}
+
 export interface TimeEntry {
   id: string;
   date: string;
@@ -102,6 +110,13 @@ interface TimeTrackingContextType {
 
   // Archive state
   archivedDays: DayRecord[];
+
+  // Todo items
+  todoItems: TodoItem[];
+  addTodoItem: (text: string) => void;
+  toggleTodoItem: (id: string) => void;
+  deleteTodoItem: (id: string) => void;
+  clearCompletedTodos: () => void;
 
   // Projects and clients
   projects: Project[];
@@ -206,6 +221,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     convertDefaultProjects(DEFAULT_PROJECTS)
   );
   const [categories, setCategories] = useState<TaskCategory[]>([]);
+  const [todoItems, setTodoItems] = useState<TodoItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [isSyncing, setIsSyncing] = useState(false);
   const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null);
@@ -302,6 +318,10 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
           setCategories(DEFAULT_CATEGORIES);
         }
 
+        // Load todos
+        const loadedTodos = await dataService.getTodos();
+        setTodoItems(loadedTodos);
+
         // If switching from localStorage to Supabase, migrate data
         if (currentAuthStateRef.current && dataService) {
           await dataService.migrateFromLocalStorage();
@@ -383,7 +403,8 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
         stableSaveCurrentDay(),
         dataService.saveProjects(projects),
         dataService.saveCategories(categories),
-        dataService.saveArchivedDays(archivedDays)
+        dataService.saveArchivedDays(archivedDays),
+        dataService.saveTodos(todoItems)
       ]);
 
       const failed = results.filter((r) => r.status === "rejected");
@@ -403,7 +424,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     } finally {
       setIsSyncing(false);
     }
-  }, [dataService, stableSaveCurrentDay, projects, categories, archivedDays]);
+  }, [dataService, stableSaveCurrentDay, projects, categories, archivedDays, todoItems]);
 
   // Load current day data (for periodic sync)
   const loadCurrentDay = useCallback(async () => {
@@ -866,6 +887,46 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
   ): InvoiceData =>
     utilGenerateInvoiceData(archivedDays, projects, categories, clientName, startDate, endDate);
 
+  const addTodoItem = useCallback(async (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const newItem: TodoItem = {
+      id: `todo-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      text: trimmed,
+      completed: false,
+      createdAt: new Date().toISOString()
+    };
+    const updated = [...todoItems, newItem];
+    setTodoItems(updated);
+    if (dataService) await dataService.saveTodos(updated);
+  }, [todoItems, dataService]);
+
+  const toggleTodoItem = useCallback(async (id: string) => {
+    const updated = todoItems.map((item) => {
+      if (item.id !== id) return item;
+      const nowCompleted = !item.completed;
+      return {
+        ...item,
+        completed: nowCompleted,
+        completedAt: nowCompleted ? new Date().toISOString() : undefined
+      };
+    });
+    setTodoItems(updated);
+    if (dataService) await dataService.saveTodos(updated);
+  }, [todoItems, dataService]);
+
+  const deleteTodoItem = useCallback(async (id: string) => {
+    const updated = todoItems.filter((item) => item.id !== id);
+    setTodoItems(updated);
+    if (dataService) await dataService.saveTodos(updated);
+  }, [todoItems, dataService]);
+
+  const clearCompletedTodos = useCallback(async () => {
+    const updated = todoItems.filter((item) => !item.completed);
+    setTodoItems(updated);
+    if (dataService) await dataService.saveTodos(updated);
+  }, [todoItems, dataService]);
+
   const importFromCSV = async (
     csvContent: string
   ): Promise<{ success: boolean; message: string; importedCount: number }> => {
@@ -917,6 +978,11 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
         refreshFromDatabase: loadCurrentDay,
         forceSyncToDatabase,
         archivedDays,
+        todoItems,
+        addTodoItem,
+        toggleTodoItem,
+        deleteTodoItem,
+        clearCompletedTodos,
         projects,
         categories,
         startDay,

--- a/src/hooks/useReportSummary.ts
+++ b/src/hooks/useReportSummary.ts
@@ -14,6 +14,7 @@ import {
   ReportTone,
   buildSummaryPrompt,
 } from "@/utils/reportUtils";
+import { TodoItem } from "@/contexts/TimeTrackingContext";
 import { supabase } from "@/lib/supabase";
 
 // ---------------------------------------------------------------------------
@@ -30,7 +31,7 @@ export interface UseReportSummaryReturn {
   summary: string;
   state: GenerationState;
   error: string | null;
-  generate: (week: WeekGroup, tone: ReportTone) => Promise<void>;
+  generate: (week: WeekGroup, tone: ReportTone, todos?: TodoItem[]) => Promise<void>;
   updateSummary: (value: string) => void;
   reset: () => void;
 }
@@ -142,13 +143,13 @@ export function useReportSummary(): UseReportSummaryReturn {
   const [error, setError] = useState<string | null>(null);
 
   const generate = useCallback(
-    async (week: WeekGroup, tone: ReportTone) => {
+    async (week: WeekGroup, tone: ReportTone, todos?: TodoItem[]) => {
       setState("loading");
       setError(null);
       setSummary("");
 
       try {
-        const { system, userMessage } = buildSummaryPrompt(week, tone);
+        const { system, userMessage } = buildSummaryPrompt(week, tone, todos);
 
         // API key stays server-side in the Edge Function.
         // The client posts the prompt; the proxy injects the key and forwards to Gemini.

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { CirclePlay, CircleStop, Archive as Play } from 'lucide-react';
 import { DashboardIcon } from '@radix-ui/react-icons';
 import SiteNavigationMenu from '@/components/Navigation';
+import { TaskTrackingPanel } from '@/components/TaskTrackingPanel';
 import { useState } from 'react';
 
 const TimeTrackerContent = () => {
@@ -91,9 +92,15 @@ const TimeTrackerContent = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
       <SiteNavigationMenu />
-      {/* Main Content */}
-      {!isDayStarted ? (
-        <div className="max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
+      <div className="max-w-6xl mx-auto pt-4 pb-6 px-4 md:p-6 print:p-4 space-y-6">
+        <StartDayDialog
+          isOpen={showStartDayDialog}
+          onClose={() => setShowStartDayDialog(false)}
+          onStartDay={handleStartDayWithDateTime}
+        />
+
+        {/* Dashboard header + stats (day not started) */}
+        {!isDayStarted && (
           <div className="space-y-6">
             <div className="flex items-center justify-between">
               <h1 className="md:text-2xl font-bold text-gray-900 flex items-center space-x-1">
@@ -101,7 +108,6 @@ const TimeTrackerContent = () => {
                 <span>Dashboard</span>
               </h1>
             </div>
-            {/* Summary Stats */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4 print:hidden">
               <Card>
                 <CardContent className="p-4">
@@ -121,71 +127,77 @@ const TimeTrackerContent = () => {
               </Card>
             </div>
           </div>
-        </div>
-      ) : null}
-      <div className="max-w-4xl mx-auto p-6 space-y-6">
-        <StartDayDialog
-          isOpen={showStartDayDialog}
-          onClose={() => setShowStartDayDialog(false)}
-          onStartDay={handleStartDayWithDateTime}
-        />
-        {!isDayStarted ? (
-          <Card className="bg-gradient-to-r from-blue-50 to-green-50 border-blue-200">
-            <CardHeader>
-              <CardTitle className="flex items-center space-x-2 text-blue-800">
-                <Play className="w-5 h-5" />
-                <span>Start Your Work Day</span>
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <p className="text-gray-600 mb-4">
-                Click the button below to start tracking your work time for
-                today.
-              </p>
-              <Button
-                onClick={handleStartDay}
-                className="w-full bg-blue-600 hover:bg-blue-700 text-white flex items-center justify-center space-x-2 py-3"
-              >
-                <CirclePlay className="w-4 h-4" />
-                <span>Start Day</span>
-              </Button>
-            </CardContent>
-          </Card>
-        ) : (
-          <>
-            <NewTaskForm onSubmit={handleNewTask} defaultOpen={autoOpenTaskForm} />
-            {tasks.length > 0 && (
-              <div className="space-y-4">
-                <h2 className="flex justify-between text-lg font-semibold text-gray-900">Tasks ({tasks.length})
-                  {dayStartTime && (
-                    <p className="text-sm text-gray-600">
-                      Day started at: {dayStartTime.toLocaleTimeString()}
-                    </p>
-                  )}
-                </h2>
-                {tasks.map((task) => (
-                  <TaskItem
-                    key={task.id}
-                    task={task}
-                    isActive={currentTask?.id === task.id}
-                    currentDuration={
-                      currentTask?.id === task.id ? getCurrentTaskDuration() : 0
-                    }
-                    onDelete={handleTaskDelete}
-                  />
-                ))}
-              </div>
-            )}
-            <Button
-              variant="outline"
-              onClick={handleEndDay}
-              className="w-full font-bold bg-red-50 border-red-700 text-red-700 hover:bg-red-100 hover:text-red-700"
-            >
-              <CircleStop className="w-4 h-4" />
-              End Day
-            </Button>
-          </>
         )}
+
+        {/* Two-column layout: main content + tracking panel */}
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-6 items-start">
+          {/* Left column: day actions + tasks */}
+          <div className="space-y-6">
+            {!isDayStarted ? (
+              <Card className="bg-gradient-to-r from-blue-50 to-green-50 border-blue-200">
+                <CardHeader>
+                  <CardTitle className="flex items-center space-x-2 text-blue-800">
+                    <Play className="w-5 h-5" />
+                    <span>Start Your Work Day</span>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-gray-600 mb-4">
+                    Click the button below to start tracking your work time for
+                    today.
+                  </p>
+                  <Button
+                    onClick={handleStartDay}
+                    className="w-full bg-blue-600 hover:bg-blue-700 text-white flex items-center justify-center space-x-2 py-3"
+                  >
+                    <CirclePlay className="w-4 h-4" />
+                    <span>Start Day</span>
+                  </Button>
+                </CardContent>
+              </Card>
+            ) : (
+              <>
+                <NewTaskForm onSubmit={handleNewTask} defaultOpen={autoOpenTaskForm} />
+                {tasks.length > 0 && (
+                  <div className="space-y-4">
+                    <h2 className="flex justify-between text-lg font-semibold text-gray-900">
+                      Tasks ({tasks.length})
+                      {dayStartTime && (
+                        <p className="text-sm text-gray-600">
+                          Day started at: {dayStartTime.toLocaleTimeString()}
+                        </p>
+                      )}
+                    </h2>
+                    {tasks.map((task) => (
+                      <TaskItem
+                        key={task.id}
+                        task={task}
+                        isActive={currentTask?.id === task.id}
+                        currentDuration={
+                          currentTask?.id === task.id ? getCurrentTaskDuration() : 0
+                        }
+                        onDelete={handleTaskDelete}
+                      />
+                    ))}
+                  </div>
+                )}
+                <Button
+                  variant="outline"
+                  onClick={handleEndDay}
+                  className="w-full font-bold bg-red-50 border-red-700 text-red-700 hover:bg-red-100 hover:text-red-700"
+                >
+                  <CircleStop className="w-4 h-4" />
+                  End Day
+                </Button>
+              </>
+            )}
+          </div>
+
+          {/* Right column: task tracking panel (always visible) */}
+          <div className="lg:sticky lg:top-6">
+            <TaskTrackingPanel />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Report.tsx
+++ b/src/pages/Report.tsx
@@ -388,7 +388,7 @@ function ErrorState({
 // ---------------------------------------------------------------------------
 
 export default function Report() {
-  const { archivedDays: rawArchivedDays } = useTimeTracking();
+  const { archivedDays: rawArchivedDays, todoItems } = useTimeTracking();
   const archivedDays = useMemo(
     () => dayRecordsToArchivedDays(rawArchivedDays),
     [rawArchivedDays]
@@ -445,7 +445,7 @@ export default function Report() {
 
   function handleGenerate() {
     if (!selectedWeek) return;
-    generate(selectedWeek, tone);
+    generate(selectedWeek, tone, todoItems);
   }
 
   const canGoPrev = !isCustomRange && calendarIndex < calendarWeeks.length - 1;

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -1,4 +1,4 @@
-import { DayRecord, Project } from "@/contexts/TimeTrackingContext";
+import { DayRecord, Project, TodoItem } from "@/contexts/TimeTrackingContext";
 import { Task } from "@/contexts/TimeTrackingContext";
 import { TaskCategory } from "@/config/categories";
 import { LocalStorageService } from "@/services/localStorageService";
@@ -33,6 +33,10 @@ export interface DataService {
 	// Categories operations
 	saveCategories: (categories: TaskCategory[]) => Promise<void>;
 	getCategories: () => Promise<TaskCategory[]>;
+
+	// Todo items operations
+	saveTodos: (todos: TodoItem[]) => Promise<void>;
+	getTodos: () => Promise<TodoItem[]>;
 
 	// Migration operations
 	migrateFromLocalStorage: () => Promise<void>;

--- a/src/services/localStorageService.ts
+++ b/src/services/localStorageService.ts
@@ -1,4 +1,4 @@
-import { Task, DayRecord, Project } from "@/contexts/TimeTrackingContext";
+import { Task, DayRecord, Project, TodoItem } from "@/contexts/TimeTrackingContext";
 import { TaskCategory } from "@/config/categories";
 import { DataService, CurrentDayData } from "@/services/dataService";
 
@@ -6,7 +6,8 @@ export const STORAGE_KEYS = {
 	CURRENT_DAY: "timetracker_current_day",
 	ARCHIVED_DAYS: "timetracker_archived_days",
 	PROJECTS: "timetracker_projects",
-	CATEGORIES: "timetracker_categories"
+	CATEGORIES: "timetracker_categories",
+	TODOS: "timetracker_todos"
 };
 
 // Increment this when the stored data format changes in a breaking way.
@@ -161,6 +162,32 @@ export class LocalStorageService implements DataService {
 			return Array.isArray(data) ? data : [];
 		} catch (error) {
 			console.error("Error loading categories from localStorage:", error);
+			return [];
+		}
+	}
+
+	async saveTodos(todos: TodoItem[]): Promise<void> {
+		try {
+			localStorage.setItem(STORAGE_KEYS.TODOS, JSON.stringify({ data: todos, _v: SCHEMA_VERSION }));
+		} catch (error) {
+			console.warn("Failed to save todos to localStorage:", error);
+		}
+	}
+
+	async getTodos(): Promise<TodoItem[]> {
+		try {
+			const saved = localStorage.getItem(STORAGE_KEYS.TODOS);
+			if (!saved) return [];
+			const parsed = JSON.parse(saved);
+			const data: TodoItem[] = Array.isArray(parsed) ? parsed : parsed?.data;
+			if (!Array.isArray(parsed) && parsed?._v !== SCHEMA_VERSION) {
+				console.warn("localStorage todos schema mismatch — clearing stale data");
+				localStorage.removeItem(STORAGE_KEYS.TODOS);
+				return [];
+			}
+			return Array.isArray(data) ? data : [];
+		} catch (error) {
+			console.error("Error loading todos from localStorage:", error);
 			return [];
 		}
 	}

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -9,7 +9,7 @@ import {
 	clearDataCaches,
 	trackAuthCall
 } from "@/lib/supabase";
-import { Task, DayRecord, Project } from "@/contexts/TimeTrackingContext";
+import { Task, DayRecord, Project, TodoItem } from "@/contexts/TimeTrackingContext";
 import { TaskCategory } from "@/config/categories";
 import { DataService, CurrentDayData } from "@/services/dataService";
 import { LocalStorageService } from "@/services/localStorageService";
@@ -795,6 +795,81 @@ export class SupabaseService implements DataService {
 		return result;
 	}
 
+	async saveTodos(todos: TodoItem[]): Promise<void> {
+		const user = await this.requireUser();
+
+		if (todos.length === 0) {
+			await supabase.from("todo_items").delete().eq("user_id", user.id);
+			trackDbCall("delete", "todo_items");
+			return;
+		}
+
+		const { data: existingTodos } = await supabase
+			.from("todo_items")
+			.select("id")
+			.eq("user_id", user.id);
+		trackDbCall("select", "todo_items");
+
+		const existingIds = new Set(existingTodos?.map((t: { id: string }) => t.id) || []);
+		const newIds = new Set(todos.map((t) => t.id));
+
+		const toDelete = Array.from(existingIds).filter((id) => !newIds.has(id));
+		if (toDelete.length > 0) {
+			const { error: deleteError } = await supabase
+				.from("todo_items")
+				.delete()
+				.eq("user_id", user.id)
+				.in("id", toDelete);
+			trackDbCall("delete", "todo_items");
+			if (deleteError) throw deleteError;
+		}
+
+		const toUpsert = todos.map((item) => ({
+			id: item.id,
+			user_id: user.id,
+			text: item.text,
+			completed: item.completed,
+			created_at: item.createdAt,
+			completed_at: item.completedAt ?? null
+		}));
+
+		const { error } = await supabase
+			.from("todo_items")
+			.upsert(toUpsert, { onConflict: "id" });
+		trackDbCall("upsert", "todo_items");
+		if (error) throw error;
+	}
+
+	async getTodos(): Promise<TodoItem[]> {
+		const user = await this.requireUser();
+
+		const { data, error } = await supabase
+			.from("todo_items")
+			.select("*")
+			.eq("user_id", user.id)
+			.order("created_at", { ascending: true });
+		trackDbCall("select", "todo_items");
+
+		if (error) {
+			console.error("❌ Error loading todos:", error);
+			throw error;
+		}
+
+		return (data || []).map((row: {
+			id: string;
+			text: string;
+			completed: boolean;
+			created_at: string;
+			completed_at: string | null;
+		}) => ({
+			id: row.id,
+			text: row.text,
+			completed: row.completed,
+			createdAt: row.created_at,
+			completedAt: row.completed_at ?? undefined
+		}));
+	}
+
 	async migrateFromLocalStorage(): Promise<void> {
 		try {
 			const localService = new LocalStorageService();
@@ -803,14 +878,16 @@ export class SupabaseService implements DataService {
 			const categories = await localService.getCategories();
 			const currentDay = await localService.getCurrentDay();
 			const archivedDays = await localService.getArchivedDays();
+			const todos = await localService.getTodos();
 
 			const hasProjects = projects.length > 0;
 			const hasCategories = categories.length > 0;
 			const hasCurrentDay =
 				currentDay && (currentDay.tasks.length > 0 || currentDay.isDayStarted);
 			const hasArchivedDays = archivedDays.length > 0;
+			const hasTodos = todos.length > 0;
 
-			if (!hasProjects && !hasCategories && !hasCurrentDay && !hasArchivedDays) {
+			if (!hasProjects && !hasCategories && !hasCurrentDay && !hasArchivedDays && !hasTodos) {
 				return;
 			}
 
@@ -854,12 +931,17 @@ export class SupabaseService implements DataService {
 				if (hasCategories && existingCategories.length === 0) {
 					await this.saveCategories(categories);
 				}
+
+				if (hasTodos) {
+					await this.saveTodos(todos);
+				}
 			} else {
 
 				if (hasProjects) await this.saveProjects(projects);
 				if (hasCategories) await this.saveCategories(categories);
 				if (hasCurrentDay) await this.saveCurrentDay(currentDay);
 				if (hasArchivedDays) await this.saveArchivedDays(archivedDays);
+				if (hasTodos) await this.saveTodos(todos);
 			}
 
 		} catch (error) {
@@ -875,6 +957,7 @@ export class SupabaseService implements DataService {
 			const archivedDays = await this.getArchivedDays();
 			const projects = await this.getProjects();
 			const categories = await this.getCategories();
+			const todos = await this.getTodos();
 
 			if (currentDay) {
 				await localService.saveCurrentDay(currentDay);
@@ -890,6 +973,10 @@ export class SupabaseService implements DataService {
 
 			if (categories.length > 0) {
 				await localService.saveCategories(categories);
+			}
+
+			if (todos.length > 0) {
+				await localService.saveTodos(todos);
 			}
 
 		} catch (error) {

--- a/src/utils/checklistUtils.ts
+++ b/src/utils/checklistUtils.ts
@@ -1,0 +1,47 @@
+// src/utils/checklistUtils.ts
+// Utilities for parsing and toggling GFM task-list items inside task descriptions.
+// Supports the `- [ ] text` (unchecked) and `- [x] text` (checked) syntax.
+
+export interface ChecklistEntry {
+	text: string;
+	completed: boolean;
+	lineIndex: number; // index into description.split('\n') — used for toggling
+}
+
+/**
+ * Extracts all GFM task-list items from a markdown description string.
+ * Returns entries in the order they appear in the text.
+ */
+export function parseTaskChecklist(description: string): ChecklistEntry[] {
+	if (!description) return [];
+
+	return description.split("\n").flatMap((line, lineIndex) => {
+		const unchecked = line.match(/^(\s*)-\s\[ \]\s(.+)/);
+		const checked = line.match(/^(\s*)-\s\[x\]\s(.+)/i);
+		if (unchecked) {
+			return [{ text: unchecked[2].trim(), completed: false, lineIndex }];
+		}
+		if (checked) {
+			return [{ text: checked[2].trim(), completed: true, lineIndex }];
+		}
+		return [];
+	});
+}
+
+/**
+ * Toggles the checked/unchecked state of a task-list item at `lineIndex`
+ * in the given description string. Returns the updated description.
+ */
+export function toggleDescriptionChecklistItem(description: string, lineIndex: number): string {
+	const lines = description.split("\n");
+	const line = lines[lineIndex];
+	if (!line) return description;
+
+	if (line.match(/^(\s*)-\s\[ \]\s/)) {
+		lines[lineIndex] = line.replace(/^(\s*)-\s\[ \]\s/, "$1- [x] ");
+	} else if (line.match(/^(\s*)-\s\[x\]\s/i)) {
+		lines[lineIndex] = line.replace(/^(\s*)-\s\[x\]\s/i, "$1- [ ] ");
+	}
+
+	return lines.join("\n");
+}

--- a/src/utils/reportUtils.ts
+++ b/src/utils/reportUtils.ts
@@ -3,7 +3,7 @@
 // Data is sourced via the TimeTrackingContext (which handles both localStorage
 // and Supabase depending on auth state).
 
-import { DayRecord } from '@/contexts/TimeTrackingContext';
+import { DayRecord, TodoItem } from '@/contexts/TimeTrackingContext';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -257,8 +257,10 @@ const EXCLUDED_CATEGORIES = new Set([
  * Serializes a WeekGroup into a lean, human-readable string suitable
  * for inclusion in the Anthropic API prompt. Strips IDs, timestamps,
  * and non-work tasks. Preserves the narrative content of descriptions.
+ *
+ * Optionally appends a section listing todos completed during the week.
  */
-export function serializeWeekForPrompt(week: WeekGroup): string {
+export function serializeWeekForPrompt(week: WeekGroup, todos?: TodoItem[]): string {
   const lines: string[] = [`Week of ${week.label}`, ''];
 
   for (const day of week.days) {
@@ -286,6 +288,25 @@ export function serializeWeekForPrompt(week: WeekGroup): string {
     lines.push('');
   }
 
+  // Append completed todos that fall within this week's date range
+  if (todos && todos.length > 0) {
+    const weekStartMs = week.weekStart.getTime();
+    const weekEndMs = week.weekEnd.getTime();
+    const completedThisWeek = todos.filter((t) => {
+      if (!t.completed || !t.completedAt) return false;
+      const ts = new Date(t.completedAt).getTime();
+      return ts >= weekStartMs && ts <= weekEndMs;
+    });
+
+    if (completedThisWeek.length > 0) {
+      lines.push('Completed to-dos this week:');
+      for (const item of completedThisWeek) {
+        lines.push(`- ${item.text}`);
+      }
+      lines.push('');
+    }
+  }
+
   return lines.join('\n').trim();
 }
 
@@ -308,7 +329,8 @@ const TONE_INSTRUCTIONS: Record<ReportTone, string> = {
  */
 export function buildSummaryPrompt(
   week: WeekGroup,
-  tone: ReportTone = 'standup'
+  tone: ReportTone = 'standup',
+  todos?: TodoItem[]
 ): { system: string; userMessage: string } {
   const system = `You are a professional writing assistant that creates concise weekly work summaries from time tracking data.
 
@@ -323,7 +345,7 @@ ${TONE_INSTRUCTIONS[tone]}
 
 Omit breaks, lunch, and any purely administrative tasks. If multiple days covered the same project or theme, synthesize them into a single coherent statement rather than repeating.`;
 
-  const userMessage = `Please summarize the following work week:\n\n${serializeWeekForPrompt(week)}`;
+  const userMessage = `Please summarize the following work week:\n\n${serializeWeekForPrompt(week, todos)}`;
 
   return { system, userMessage };
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -193,6 +193,37 @@ CREATE POLICY "Users can update their own current day" ON current_day
 CREATE POLICY "Users can delete their own current day" ON current_day
   FOR DELETE USING (auth.uid() = user_id);
 
+-- Create todo_items table
+CREATE TABLE IF NOT EXISTS todo_items (
+  id text PRIMARY KEY,
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  text text NOT NULL,
+  completed boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  inserted_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_todo_items_user_id ON todo_items(user_id);
+CREATE INDEX IF NOT EXISTS idx_todo_items_created_at ON todo_items(created_at);
+
+CREATE TRIGGER trg_update_todo_items_updated_at
+BEFORE UPDATE ON todo_items
+FOR EACH ROW
+EXECUTE PROCEDURE update_updated_at_column();
+
+ALTER TABLE todo_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own todos" ON todo_items
+  FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY "Users can insert their own todos" ON todo_items
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+CREATE POLICY "Users can update their own todos" ON todo_items
+  FOR UPDATE USING (auth.uid() = user_id);
+CREATE POLICY "Users can delete their own todos" ON todo_items
+  FOR DELETE USING (auth.uid() = user_id);
+
 -- Migration: Add is_billable columns if they don't exist
 DO $$
 BEGIN


### PR DESCRIPTION
## Summary
Introduces a persistent task tracking panel that combines a standalone to-do list (synced across devices for authenticated users) with GitHub Flavored Markdown (GFM) checklist items extracted from task descriptions. The panel appears as a sticky sidebar on the main dashboard.

## Key Changes

- **New TaskTrackingPanel component** (`src/components/TaskTrackingPanel.tsx`)
  - Displays active and completed to-do items with add/toggle/delete functionality
  - Extracts and displays GFM checklist items (`- [ ]` / `- [x]`) from current-day task descriptions
  - Provides visual separation between standalone todos and task-embedded checklists

- **Checklist utilities** (`src/utils/checklistUtils.ts`)
  - `parseTaskChecklist()`: Extracts GFM task-list items from markdown descriptions
  - `toggleDescriptionChecklistItem()`: Toggles checkbox state within task descriptions

- **Todo item persistence**
  - Added `TodoItem` interface to `TimeTrackingContext` with id, text, completed status, and timestamps
  - Implemented `saveTodos()` and `getTodos()` in both `SupabaseService` and `LocalStorageService`
  - New `todo_items` table in Supabase with RLS policies and proper indexing
  - Todo operations (add, toggle, delete, clear completed) integrated into context

- **Layout restructuring** (`src/pages/Index.tsx`)
  - Converted main content to a two-column grid layout (1fr + 300px sidebar on lg screens)
  - TaskTrackingPanel positioned as sticky sidebar on the right
  - Dashboard stats now display only when day hasn't started
  - Improved responsive design with proper spacing

- **Report integration** (`src/utils/reportUtils.ts`, `src/hooks/useReportSummary.ts`)
  - Extended `serializeWeekForPrompt()` to include completed todos from the week
  - Updated `buildSummaryPrompt()` to accept optional todos parameter
  - Todos completed within a week's date range are now included in AI-generated summaries

- **Data service updates**
  - Added `saveTodos()` and `getTodos()` abstract methods to `DataService` interface
  - Migration logic updated to handle todos during localStorage→Supabase transitions
  - LocalStorage schema versioning applied to todos

## Implementation Details

- Todo items use ISO timestamp strings for `createdAt` and optional `completedAt` fields
- Checklist parsing uses regex to match both checked (`[x]`) and unchecked (`[ ]`) states (case-insensitive)
- Line indices are preserved during checklist parsing to enable precise toggling within descriptions
- All todo operations trigger immediate database saves via the data service
- Panel remains visible whether day is started or not, providing persistent task tracking