### PR TITLE
fix: Tier 1 standardization — replace confirm() with AlertDialog and fix theme colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.worktrees
 node_modules
 dist
 .env

--- a/docs/superpowers/plans/2026-04-15-tier-1-standardization.md
+++ b/docs/superpowers/plans/2026-04-15-tier-1-standardization.md
@@ -1,0 +1,1129 @@
+# Tier 1 Standardization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace all native `confirm()` dialog calls with shadcn/ui `AlertDialog` components and standardize hardcoded color classes to theme variables across `App.tsx` and `Settings.tsx`.
+
+**Architecture:** Each `confirm()` call is replaced by: (1) a state variable holding the pending action target, (2) a handler that sets that state instead of calling confirm, and (3) an `AlertDialog` rendered at the bottom of the component that fires the real action on confirm. The Settings color sweep maps hardcoded Tailwind color classes to Radix theme variables.
+
+**Tech Stack:** React 18, TypeScript, shadcn/ui (`AlertDialog`, `Button`), Vitest, React Testing Library
+
+---
+
+## Files Modified
+
+| File                                    | Change                                                                                         |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `src/App.tsx`                           | Fix `border-gray-900` → `border-primary` on spinner                                            |
+| `src/pages/Settings.tsx`                | Replace two-step `confirm()` with `AlertDialog`; sweep ~15 hardcoded color classes             |
+| `src/components/CategoryManagement.tsx` | Replace `confirm()` in `handleDelete` with `AlertDialog`                                       |
+| `src/components/ProjectManagement.tsx`  | Replace `confirm()` in `handleDelete` and `handleResetToDefaults` with two `AlertDialog`s      |
+| `src/components/ArchiveItem.tsx`        | Replace `confirm()` in `handleRestore` with `AlertDialog`                                      |
+| `src/components/ArchiveEditDialog.tsx`  | Replace `confirm()` in `handleRestoreDay` with `AlertDialog`; replace `alert()` with `toast()` |
+| `src/pages/ProjectList.tsx`             | Replace `confirm()` in `handleDelete` and `handleResetToDefaults` with two `AlertDialog`s      |
+| `src/pages/Categories.tsx`              | Replace `confirm()` in `handleDelete` with `AlertDialog`                                       |
+
+---
+
+## Task 1: Fix PageLoader spinner color
+
+**Files:**
+
+- Modify: `src/App.tsx:26`
+
+- [ ] **Step 1: Edit App.tsx**
+
+Change line 26 from:
+
+```tsx
+<div className="animate-spin rounded-full h-32 w-32 border-b-2 border-gray-900"></div>
+```
+
+To:
+
+```tsx
+<div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary"></div>
+```
+
+- [ ] **Step 2: Verify build passes**
+
+```bash
+npm run build
+```
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "fix: use theme variable for PageLoader spinner color"
+```
+
+---
+
+## Task 2: Settings.tsx — replace confirm() and fix colors
+
+**Files:**
+
+- Modify: `src/pages/Settings.tsx`
+- Test: `src/contexts/TimeTracking.test.tsx` (add Settings smoke test)
+
+- [ ] **Step 1: Write the failing test**
+
+Open `src/contexts/TimeTracking.test.tsx` and add this test at the end of the file (before the closing of any describe block, or as a standalone describe):
+
+```tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import Settings from '@/pages/Settings';
+
+// Settings needs the TimeTrackingContext — wrap it.
+// The existing test file already has a renderWithProviders or similar helper;
+// if not, use the inline wrapper below.
+describe('Settings — Clear All Data', () => {
+  it('shows AlertDialog when Clear All Data is clicked', async () => {
+    render(<Settings />);
+    fireEvent.click(screen.getByText('Clear All Data'));
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.getByText(/permanently delete/i)).toBeInTheDocument();
+  });
+
+  it('does not clear data when Cancel is clicked', async () => {
+    const clearSpy = vi.spyOn(Storage.prototype, 'clear');
+    render(<Settings />);
+    fireEvent.click(screen.getByText('Clear All Data'));
+    await screen.findByRole('alertdialog');
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(clearSpy).not.toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+npm run test -- --reporter=verbose src/contexts/TimeTracking.test.tsx
+```
+
+Expected: FAIL — `alertdialog` role not found because `confirm()` is still being used.
+
+- [ ] **Step 3: Rewrite Settings.tsx**
+
+Replace the entire file with:
+
+```tsx
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog';
+import { ExportDialog } from '@/components/ExportDialog';
+import {
+  Briefcase,
+  Tag,
+  Download,
+  Database,
+  Trash2,
+  CogIcon
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { useTimeTracking } from '@/hooks/useTimeTracking';
+import SiteNavigationMenu from '@/components/Navigation';
+
+const SettingsContent: React.FC = () => {
+  const { archivedDays, projects, categories } = useTimeTracking();
+  const [showExportDialog, setShowExportDialog] = useState(false);
+  const [showClearDataDialog, setShowClearDataDialog] = useState(false);
+
+  const handleClearAllData = () => {
+    localStorage.clear();
+    window.location.reload();
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Navigation Header */}
+      <SiteNavigationMenu />
+      {/* Main Content */}
+      <div className="max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
+        <div className="flex items-center justify-between">
+          <h1 className="md:text-2xl font-bold text-foreground flex items-center space-x-1">
+            <CogIcon className="w-6 h-6 mr-1" />
+            <span>Settings</span>
+          </h1>
+        </div>
+      </div>
+      <div className="max-w-6xl mx-auto p-6">
+        <div className="grid gap-6">
+          {/* Overview Stats */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 print:hidden">
+            <Card>
+              <CardContent className="p-4">
+                <div className="text-2xl font-bold text-primary">
+                  {archivedDays.length}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Archived Days
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-4">
+                <div className="text-2xl font-bold text-primary">
+                  {projects.length}
+                </div>
+                <div className="text-sm text-muted-foreground">Projects</div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-4">
+                <div className="text-2xl font-bold text-primary">
+                  {categories.length}
+                </div>
+                <div className="text-sm text-muted-foreground">Categories</div>
+              </CardContent>
+            </Card>
+          </div>
+          {/* Management Sections */}
+          <div className="grid gap-6 md:grid-cols-2">
+            {/* Project Management */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center space-x-2">
+                  <Briefcase className="w-5 h-5" />
+                  <span>Project Management</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground mb-4">
+                  Manage your projects, clients, and hourly rates. Projects help
+                  organize your tasks and calculate revenue automatically.
+                </p>
+                <Link to="/projectlist">
+                  <Button variant="outline" className="w-full">
+                    <Briefcase className="w-4 h-4 mr-2" />
+                    Manage Projects
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+            {/* Category Management */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center space-x-2">
+                  <Tag className="w-5 h-5" />
+                  <span>Category Management</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground mb-4">
+                  Create and manage task categories like Development, Design,
+                  Meetings, etc. Categories help classify your work.
+                </p>
+                <Link to="/categories">
+                  <Button variant="outline" className="w-full">
+                    <Briefcase className="w-4 h-4 mr-2" />
+                    Manage Categories
+                  </Button>
+                </Link>
+              </CardContent>
+            </Card>
+            {/* Data Export */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center space-x-2">
+                  <Download className="w-5 h-5" />
+                  <span>Exports/Imports</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground mb-4">
+                  Export your time tracking data as CSV or JSON files. Generate
+                  invoice data for specific clients and date ranges. You can
+                  also import data from CSV files.
+                </p>
+                <Button
+                  onClick={() => setShowExportDialog(true)}
+                  variant="outline"
+                  className="w-full"
+                >
+                  <Download className="w-4 h-4 mr-2" />
+                  Data Export/Import
+                </Button>
+              </CardContent>
+            </Card>
+            {/* Data Management */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center space-x-2">
+                  <Database className="w-5 h-5" />
+                  <span>Data Management</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-muted-foreground mb-4">
+                  Manage your stored data. All data is stored locally in your
+                  browser. Use export before clearing data.
+                </p>
+                <div className="space-y-2">
+                  <Link to="/archive">
+                    <Button variant="outline" className="w-full">
+                      <Database className="w-4 h-4 mr-2" />
+                      View Archive
+                    </Button>
+                  </Link>
+                  <Button
+                    onClick={() => setShowClearDataDialog(true)}
+                    variant="outline"
+                    className="w-full text-destructive hover:text-destructive hover:bg-destructive/10"
+                  >
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    Clear All Data
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+          {/* Quick Tips */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Quick Tips</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                  <h4 className="font-medium text-foreground mb-2">
+                    Getting Started
+                  </h4>
+                  <ul className="text-sm text-muted-foreground space-y-1">
+                    <li>
+                      • Set up projects with hourly rates for automatic revenue
+                      calculation
+                    </li>
+                    <li>
+                      • Create categories to classify different types of work
+                    </li>
+                    <li>• Use task descriptions for detailed work notes</li>
+                  </ul>
+                </div>
+                <div>
+                  <h4 className="font-medium text-foreground mb-2">
+                    Best Practices
+                  </h4>
+                  <ul className="text-sm text-muted-foreground space-y-1">
+                    <li>• Export your data regularly as backup</li>
+                    <li>
+                      • Adjust task times in 15-minute intervals for accuracy
+                    </li>
+                    <li>• Use consistent project and category naming</li>
+                  </ul>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {/* Dialogs */}
+      <ExportDialog
+        isOpen={showExportDialog}
+        onClose={() => setShowExportDialog(false)}
+      />
+      <AlertDialog
+        open={showClearDataDialog}
+        onOpenChange={setShowClearDataDialog}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear all data?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete all archived days, projects, and
+              categories. This action cannot be undone. Export your data first
+              if you want a backup.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleClearAllData}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete everything
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+};
+
+const Settings: React.FC = () => {
+  return <SettingsContent />;
+};
+
+export default Settings;
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+npm run test -- --reporter=verbose src/contexts/TimeTracking.test.tsx
+```
+
+Expected: PASS — both Settings AlertDialog tests green.
+
+- [ ] **Step 5: Lint and build**
+
+```bash
+npm run lint && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/Settings.tsx src/contexts/TimeTracking.test.tsx
+git commit -m "fix: replace confirm() with AlertDialog and standardize colors in Settings"
+```
+
+---
+
+## Task 3: CategoryManagement.tsx — replace confirm()
+
+**Files:**
+
+- Modify: `src/components/CategoryManagement.tsx`
+
+- [ ] **Step 1: Add AlertDialog import**
+
+At the top of the file, after the existing imports, add:
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog';
+```
+
+- [ ] **Step 2: Add delete dialog state**
+
+Inside `CategoryManagement` component, after the existing `useState` declarations, add:
+
+```tsx
+const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+```
+
+- [ ] **Step 3: Replace handleDelete**
+
+Replace:
+
+```tsx
+const handleDelete = async (categoryId: string) => {
+  if (
+    confirm(
+      'Are you sure you want to delete this category? This action cannot be undone.'
+    )
+  ) {
+    deleteCategory(categoryId);
+    // Save changes to database
+    await forceSyncToDatabase();
+  }
+};
+```
+
+With:
+
+```tsx
+const handleDeleteConfirm = async () => {
+  if (!deleteTargetId) return;
+  deleteCategory(deleteTargetId);
+  await forceSyncToDatabase();
+  setDeleteTargetId(null);
+};
+```
+
+- [ ] **Step 4: Update delete button call sites**
+
+Find all `onClick` calls that call the old `handleDelete(category.id)` and change them to `onClick={() => setDeleteTargetId(category.id)}`. There will be one such button in the category list rendering.
+
+- [ ] **Step 5: Add AlertDialog before the closing Dialog tag**
+
+Just before the final `</Dialog>` closing tag at the bottom of the return statement, add:
+
+```tsx
+<AlertDialog
+  open={deleteTargetId !== null}
+  onOpenChange={open => !open && setDeleteTargetId(null)}
+>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>Delete this category?</AlertDialogTitle>
+      <AlertDialogDescription>
+        This action cannot be undone.
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>Cancel</AlertDialogCancel>
+      <AlertDialogAction
+        onClick={handleDeleteConfirm}
+        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+      >
+        Delete
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+- [ ] **Step 6: Lint and build**
+
+```bash
+npm run lint && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/CategoryManagement.tsx
+git commit -m "fix: replace confirm() with AlertDialog in CategoryManagement"
+```
+
+---
+
+## Task 4: ProjectManagement.tsx — replace two confirm() calls
+
+**Files:**
+
+- Modify: `src/components/ProjectManagement.tsx`
+
+- [ ] **Step 1: Add AlertDialog import**
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog';
+```
+
+- [ ] **Step 2: Add dialog state variables**
+
+After existing `useState` declarations:
+
+```tsx
+const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+const [showResetDialog, setShowResetDialog] = useState(false);
+```
+
+- [ ] **Step 3: Replace handleDelete**
+
+Replace:
+
+```tsx
+const handleDelete = (projectId: string) => {
+  if (confirm('Are you sure you want to delete this project?')) {
+    deleteProject(projectId);
+  }
+};
+```
+
+With:
+
+```tsx
+const handleDeleteConfirm = () => {
+  if (!deleteTargetId) return;
+  deleteProject(deleteTargetId);
+  setDeleteTargetId(null);
+};
+```
+
+- [ ] **Step 4: Replace handleResetToDefaults**
+
+Replace:
+
+```tsx
+const handleResetToDefaults = () => {
+  if (
+    confirm(
+      "Are you sure you want to reset all projects to defaults? This will remove any custom projects you've added."
+    )
+  ) {
+    resetProjectsToDefaults();
+  }
+};
+```
+
+With:
+
+```tsx
+const handleResetConfirm = () => {
+  resetProjectsToDefaults();
+  setShowResetDialog(false);
+};
+```
+
+- [ ] **Step 5: Update button call sites**
+
+- Change the delete button `onClick` from `handleDelete(project.id)` to `() => setDeleteTargetId(project.id)`
+- Change the Reset to Defaults button `onClick` from `handleResetToDefaults` to `() => setShowResetDialog(true)`
+
+- [ ] **Step 6: Add two AlertDialogs before the closing Dialog tag**
+
+```tsx
+<AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => !open && setDeleteTargetId(null)}>
+	<AlertDialogContent>
+		<AlertDialogHeader>
+			<AlertDialogTitle>Delete this project?</AlertDialogTitle>
+			<AlertDialogDescription>
+				This action cannot be undone.
+			</AlertDialogDescription>
+		</AlertDialogHeader>
+		<AlertDialogFooter>
+			<AlertDialogCancel>Cancel</AlertDialogCancel>
+			<AlertDialogAction
+				onClick={handleDeleteConfirm}
+				className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+			>
+				Delete
+			</AlertDialogAction>
+		</AlertDialogFooter>
+	</AlertDialogContent>
+</AlertDialog>
+
+<AlertDialog open={showResetDialog} onOpenChange={setShowResetDialog}>
+	<AlertDialogContent>
+		<AlertDialogHeader>
+			<AlertDialogTitle>Reset projects to defaults?</AlertDialogTitle>
+			<AlertDialogDescription>
+				This will remove any custom projects you've added. This action cannot be undone.
+			</AlertDialogDescription>
+		</AlertDialogHeader>
+		<AlertDialogFooter>
+			<AlertDialogCancel>Cancel</AlertDialogCancel>
+			<AlertDialogAction
+				onClick={handleResetConfirm}
+				className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+			>
+				Reset
+			</AlertDialogAction>
+		</AlertDialogFooter>
+	</AlertDialogContent>
+</AlertDialog>
+```
+
+- [ ] **Step 7: Lint and build**
+
+```bash
+npm run lint && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/ProjectManagement.tsx
+git commit -m "fix: replace confirm() with AlertDialog in ProjectManagement"
+```
+
+---
+
+## Task 5: ArchiveItem.tsx and ArchiveEditDialog.tsx — replace confirm()
+
+**Files:**
+
+- Modify: `src/components/ArchiveItem.tsx`
+- Modify: `src/components/ArchiveEditDialog.tsx`
+
+### ArchiveItem.tsx
+
+- [ ] **Step 1: Add AlertDialog import to ArchiveItem.tsx**
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog';
+```
+
+- [ ] **Step 2: Add restore dialog state**
+
+After the `useMemo` and `useTimeTracking` calls, add:
+
+```tsx
+const [showRestoreDialog, setShowRestoreDialog] = useState(false);
+```
+
+Also add `useState` to the React import if not already present:
+
+```tsx
+import React, { useMemo, useState } from 'react';
+```
+
+- [ ] **Step 3: Replace handleRestore**
+
+Replace:
+
+```tsx
+const handleRestore = () => {
+  if (isDayStarted) {
+    if (
+      !confirm(
+        'You currently have an active day. Restoring to this day will replace your current work. Continue restoring?'
+      )
+    ) {
+      return;
+    }
+  }
+  restoreArchivedDay(day.id);
+};
+```
+
+With:
+
+```tsx
+const handleRestore = () => {
+  if (isDayStarted) {
+    setShowRestoreDialog(true);
+  } else {
+    restoreArchivedDay(day.id);
+  }
+};
+
+const handleRestoreConfirm = () => {
+  restoreArchivedDay(day.id);
+  setShowRestoreDialog(false);
+};
+```
+
+- [ ] **Step 4: Add AlertDialog at the bottom of the return statement**
+
+Just before the final closing `</Card>` tag:
+
+```tsx
+<AlertDialog open={showRestoreDialog} onOpenChange={setShowRestoreDialog}>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>Replace active day?</AlertDialogTitle>
+      <AlertDialogDescription>
+        You currently have an active day. Restoring to this archived day will
+        replace your current work.
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>Cancel</AlertDialogCancel>
+      <AlertDialogAction onClick={handleRestoreConfirm}>
+        Restore anyway
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+### ArchiveEditDialog.tsx
+
+- [ ] **Step 5: Add AlertDialog import and useToast import to ArchiveEditDialog.tsx**
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog';
+import { useToast } from '@/hooks/use-toast';
+```
+
+- [ ] **Step 6: Add restore dialog state and useToast**
+
+At the top of the component, alongside other state:
+
+```tsx
+const [showRestoreDialog, setShowRestoreDialog] = useState(false);
+const { toast } = useToast();
+```
+
+- [ ] **Step 7: Replace alert() with toast()**
+
+Find:
+
+```tsx
+alert('Failed to save changes. Please try again.');
+```
+
+Replace with:
+
+```tsx
+toast({
+  title: 'Save failed',
+  description: 'Failed to save changes. Please try again.',
+  variant: 'destructive'
+});
+```
+
+- [ ] **Step 8: Replace handleRestoreDay confirm()**
+
+Replace:
+
+```tsx
+const handleRestoreDay = () => {
+  if (isDayStarted) {
+    if (
+      !confirm(
+        'You currently have an active day. Restoring to this day will replace your current work. Continue restoring?'
+      )
+    ) {
+      return;
+    }
+  }
+  restoreArchivedDay(day.id);
+  onClose();
+};
+```
+
+With:
+
+```tsx
+const handleRestoreDay = () => {
+  if (isDayStarted) {
+    setShowRestoreDialog(true);
+  } else {
+    restoreArchivedDay(day.id);
+    onClose();
+  }
+};
+
+const handleRestoreConfirm = () => {
+  restoreArchivedDay(day.id);
+  setShowRestoreDialog(false);
+  onClose();
+};
+```
+
+- [ ] **Step 9: Add AlertDialog inside the outer Dialog**
+
+Before the final closing `</DialogContent>` tag:
+
+```tsx
+<AlertDialog open={showRestoreDialog} onOpenChange={setShowRestoreDialog}>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>Replace active day?</AlertDialogTitle>
+      <AlertDialogDescription>
+        You currently have an active day. Restoring to this archived day will
+        replace your current work.
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>Cancel</AlertDialogCancel>
+      <AlertDialogAction onClick={handleRestoreConfirm}>
+        Restore anyway
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+- [ ] **Step 10: Lint and build**
+
+```bash
+npm run lint && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/components/ArchiveItem.tsx src/components/ArchiveEditDialog.tsx
+git commit -m "fix: replace confirm()/alert() with AlertDialog/toast in ArchiveItem and ArchiveEditDialog"
+```
+
+---
+
+## Task 6: ProjectList.tsx — replace two confirm() calls
+
+**Files:**
+
+- Modify: `src/pages/ProjectList.tsx`
+
+- [ ] **Step 1: Add AlertDialog import**
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog';
+```
+
+- [ ] **Step 2: Add dialog state variables**
+
+```tsx
+const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+const [showResetDialog, setShowResetDialog] = useState(false);
+```
+
+- [ ] **Step 3: Replace handleDelete**
+
+Replace:
+
+```tsx
+const handleDelete = async (projectId: string) => {
+  if (confirm('Are you sure you want to delete this project?')) {
+    deleteProject(projectId);
+    // Save changes to database
+    await forceSyncToDatabase();
+  }
+};
+```
+
+With:
+
+```tsx
+const handleDeleteConfirm = async () => {
+  if (!deleteTargetId) return;
+  deleteProject(deleteTargetId);
+  await forceSyncToDatabase();
+  setDeleteTargetId(null);
+};
+```
+
+- [ ] **Step 4: Replace handleResetToDefaults**
+
+Replace:
+
+```tsx
+const handleResetToDefaults = () => {
+  if (
+    confirm(
+      "Are you sure you want to reset all projects to defaults? This will remove any custom projects you've added."
+    )
+  ) {
+    resetProjectsToDefaults();
+  }
+};
+```
+
+With:
+
+```tsx
+const handleResetConfirm = () => {
+  resetProjectsToDefaults();
+  setShowResetDialog(false);
+};
+```
+
+- [ ] **Step 5: Update button call sites**
+
+- Change delete button `onClick` from `handleDelete(project.id)` to `() => setDeleteTargetId(project.id)`
+- Change Reset to Defaults button `onClick` from `handleResetToDefaults` to `() => setShowResetDialog(true)`
+
+- [ ] **Step 6: Add two AlertDialogs at the bottom of the return, before the closing outer div**
+
+```tsx
+<AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => !open && setDeleteTargetId(null)}>
+	<AlertDialogContent>
+		<AlertDialogHeader>
+			<AlertDialogTitle>Delete this project?</AlertDialogTitle>
+			<AlertDialogDescription>
+				This action cannot be undone.
+			</AlertDialogDescription>
+		</AlertDialogHeader>
+		<AlertDialogFooter>
+			<AlertDialogCancel>Cancel</AlertDialogCancel>
+			<AlertDialogAction
+				onClick={handleDeleteConfirm}
+				className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+			>
+				Delete
+			</AlertDialogAction>
+		</AlertDialogFooter>
+	</AlertDialogContent>
+</AlertDialog>
+
+<AlertDialog open={showResetDialog} onOpenChange={setShowResetDialog}>
+	<AlertDialogContent>
+		<AlertDialogHeader>
+			<AlertDialogTitle>Reset projects to defaults?</AlertDialogTitle>
+			<AlertDialogDescription>
+				This will remove any custom projects you've added. This action cannot be undone.
+			</AlertDialogDescription>
+		</AlertDialogHeader>
+		<AlertDialogFooter>
+			<AlertDialogCancel>Cancel</AlertDialogCancel>
+			<AlertDialogAction
+				onClick={handleResetConfirm}
+				className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+			>
+				Reset
+			</AlertDialogAction>
+		</AlertDialogFooter>
+	</AlertDialogContent>
+</AlertDialog>
+```
+
+- [ ] **Step 7: Lint and build**
+
+```bash
+npm run lint && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pages/ProjectList.tsx
+git commit -m "fix: replace confirm() with AlertDialog in ProjectList"
+```
+
+---
+
+## Task 7: Categories.tsx — replace confirm()
+
+**Files:**
+
+- Modify: `src/pages/Categories.tsx`
+
+- [ ] **Step 1: Add AlertDialog import**
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from '@/components/ui/alert-dialog';
+```
+
+- [ ] **Step 2: Add delete dialog state**
+
+```tsx
+const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+```
+
+- [ ] **Step 3: Replace handleDelete**
+
+Replace:
+
+```tsx
+const handleDelete = async (categoryId: string) => {
+  if (
+    confirm(
+      'Are you sure you want to delete this category? This action cannot be undone.'
+    )
+  ) {
+    deleteCategory(categoryId);
+    // Save changes to database
+    await forceSyncToDatabase();
+  }
+};
+```
+
+With:
+
+```tsx
+const handleDeleteConfirm = async () => {
+  if (!deleteTargetId) return;
+  deleteCategory(deleteTargetId);
+  await forceSyncToDatabase();
+  setDeleteTargetId(null);
+};
+```
+
+- [ ] **Step 4: Update delete button call site**
+
+Change delete button `onClick` from `handleDelete(category.id)` to `() => setDeleteTargetId(category.id)`.
+
+- [ ] **Step 5: Add AlertDialog at the bottom of the return, before the closing outer div**
+
+```tsx
+<AlertDialog
+  open={deleteTargetId !== null}
+  onOpenChange={open => !open && setDeleteTargetId(null)}
+>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>Delete this category?</AlertDialogTitle>
+      <AlertDialogDescription>
+        This action cannot be undone.
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>Cancel</AlertDialogCancel>
+      <AlertDialogAction
+        onClick={handleDeleteConfirm}
+        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+      >
+        Delete
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+- [ ] **Step 6: Lint and build**
+
+```bash
+npm run lint && npm run build
+```
+
+Expected: no errors.
+
+- [ ] **Step 7: Final verification — confirm no confirm() calls remain**
+
+```bash
+grep -rn "confirm(" src/ --include="*.tsx"
+```
+
+Expected: no output.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pages/Categories.tsx
+git commit -m "fix: replace confirm() with AlertDialog in Categories"
+```

--- a/docs/superpowers/specs/2026-04-15-project-improvements-design.md
+++ b/docs/superpowers/specs/2026-04-15-project-improvements-design.md
@@ -1,0 +1,210 @@
+# TimeTracker Pro — Improvements & Standardization Design
+
+**Date:** 2026-04-15
+**Scope:** Sprint backlog of prioritized improvements + ongoing standardization guidelines for new feature development
+
+---
+
+## Overview
+
+This document captures two things:
+
+1. A **prioritized backlog** of existing issues to work through — organized into three effort tiers
+2. **Ongoing standards** to apply when building any new feature or component
+
+---
+
+## Part 1: Sprint Backlog
+
+### Tier 1 — Quick Wins (high impact, low effort)
+
+#### 1. Replace all `confirm()` dialogs with AlertDialog
+
+**Files affected:**
+- `src/components/ArchiveItem.tsx`
+- `src/components/ProjectManagement.tsx`
+- `src/components/ArchiveEditDialog.tsx`
+- `src/components/CategoryManagement.tsx`
+- `src/pages/Settings.tsx`
+- `src/pages/ProjectList.tsx`
+- `src/pages/Categories.tsx`
+
+**Why:** Native `confirm()` is an anti-pattern in PWAs — it blocks the main thread, cannot be styled, and fails accessibility standards. shadcn/ui `AlertDialog` is already available in the project. 10 instances exist across 6+ files.
+
+**Pattern to use:**
+```tsx
+<AlertDialog>
+  <AlertDialogTrigger asChild>
+    <Button variant="destructive">Delete</Button>
+  </AlertDialogTrigger>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+      <AlertDialogDescription>This cannot be undone.</AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>Cancel</AlertDialogCancel>
+      <AlertDialogAction onClick={handleAction}>Confirm</AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+---
+
+#### 2. Fix hardcoded color in PageLoader spinner
+
+**File:** `src/App.tsx:26`
+
+`border-gray-900` on the loading spinner should be `border-primary` to respect the theme and support dark mode.
+
+---
+
+#### 3. Standardize colors in Settings.tsx
+
+**File:** `src/pages/Settings.tsx`
+
+~15 hardcoded color violations: `text-gray-900`, `text-gray-600`, `text-blue-600`, `text-green-600`, `bg-gradient-to-br from-gray-50 to-blue-50`, `text-red-600`. Highest density of violations in a single page file.
+
+---
+
+### Tier 2 — Medium Effort, High Value
+
+#### 4. Create a shared `PageLayout` component
+
+**New file:** `src/components/PageLayout.tsx`
+
+Every page repeats the same boilerplate — `min-h-screen bg-gradient-to-br from-gray-50 to-blue-50`, `<SiteNavigationMenu />`, `max-w-6xl mx-auto` header container. Affected pages: Index, Archive, Settings, ProjectList, Categories, Report.
+
+A shared component eliminates this duplication and makes the background gradient a single-point fix for dark mode support later.
+
+**Proposed API:**
+```tsx
+<PageLayout title="Settings" icon={<CogIcon />}>
+  {/* page content */}
+</PageLayout>
+```
+
+---
+
+#### 5. Sweep remaining hardcoded colors in all pages
+
+**Files:** `src/pages/Index.tsx`, `src/pages/Archive.tsx`, `src/pages/ProjectList.tsx`, `src/pages/Categories.tsx`, `src/pages/Report.tsx`
+
+After Settings (Tier 1), these pages still contain significant hardcoded color violations. Should be done after `PageLayout` is created so the gradient is handled automatically.
+
+---
+
+### Tier 3 — Larger Refactors (do with a clear window)
+
+#### 6. Consolidate duplicate project management logic
+
+`src/pages/ProjectList.tsx` (364 lines) and `src/components/ProjectManagement.tsx` (312 lines) both implement nearly identical CRUD for projects — same form fields, same state shape, same `confirm()` patterns. They've diverged slightly (`isBillable` exists in ProjectList but not ProjectManagement's form). The form logic should live in one shared component used by both the page and the modal.
+
+---
+
+#### 7. Consolidate duplicate category management logic
+
+Same pattern as above: `src/pages/Categories.tsx` (330 lines) and `src/components/CategoryManagement.tsx` duplicate CRUD logic for categories.
+
+---
+
+#### 8. Split TimeTrackingContext
+
+`src/contexts/TimeTrackingContext.tsx` is 1022 lines managing too many concerns. Natural split points:
+- Task operations (start, stop, update, delete)
+- Day lifecycle (start day, end day, post day)
+- Archive operations
+- Todo/checklist (newest addition — already somewhat isolated)
+
+Not urgent since the file works, but will become a pain point as features are added.
+
+---
+
+#### 9. Expand test coverage
+
+Currently only 4 test files exist for the entire app. Highest-value additions:
+- Component tests for destructive-action flows (delete project, clear all data, delete archive entry)
+- Integration tests for the guest → authenticated data migration path — highest-risk logic in the app
+- Unit tests for `exportUtils.ts` and `reportUtils.ts` (complex logic, no current coverage)
+
+---
+
+## Part 2: Ongoing Standardization Guidelines
+
+Apply these rules when building any new feature or component.
+
+---
+
+### Colors & Theming
+
+Never use hardcoded Tailwind color classes. Always use theme variables:
+
+| Instead of | Use |
+|---|---|
+| `text-gray-900` | `text-foreground` |
+| `text-gray-600` / `text-gray-500` | `text-muted-foreground` |
+| `text-blue-600` / `text-blue-500` | `text-primary` |
+| `text-green-600` | `text-chart-2` or semantic equivalent |
+| `text-red-600` / `text-red-700` | `text-destructive` |
+| `bg-blue-500` / `bg-blue-600` | `bg-primary` |
+| `bg-red-50` / `border-red-*` | `bg-destructive/10` / `border-destructive/20` |
+| `bg-gray-50` / `bg-gray-100` | `bg-muted` |
+| `bg-gradient-to-br from-gray-50 to-blue-50` | Handled by `PageLayout` (once built) |
+| `border-gray-*` | `border-border` |
+
+---
+
+### Destructive Actions
+
+Never use `confirm()`, `alert()`, or `prompt()`. Every destructive action uses `AlertDialog`. Multi-step destructive actions (e.g., "clear ALL data") should use a two-step confirmation within the same `AlertDialog` rather than two consecutive `confirm()` calls.
+
+---
+
+### New Pages
+
+Every new page uses `PageLayout` (once built in Tier 2). Until then, copy the pattern from an already-cleaned page. New pages must not introduce hardcoded colors or `confirm()` calls.
+
+---
+
+### Data Persistence
+
+Never read from localStorage directly. Always go through the DataService via context:
+
+```tsx
+// ✅ CORRECT — works for both guest and authenticated users
+const { archivedDays } = useTimeTracking();
+
+// ❌ WRONG — silently breaks for Supabase users
+const raw = localStorage.getItem("timetracker_archived_days");
+```
+
+---
+
+### Dual-Mode Compatibility
+
+Every new feature must work in both guest (localStorage) and authenticated (Supabase) modes. Before considering any feature complete, verify in both modes. Features that genuinely require authentication must:
+1. Be gated with `ProtectedRoute`
+2. Show a clear explanation to guest users — never silently omit functionality
+
+---
+
+### Feedback & Confirmation Patterns
+
+| Situation | Pattern |
+|---|---|
+| Destructive action (delete, clear, reset) | `AlertDialog` — blocks until confirmed |
+| Success feedback | `toast()` via sonner — non-blocking |
+| Error feedback | `toast()` with destructive variant |
+| Form validation errors | Inline field-level messages via React Hook Form + Zod |
+
+No new `alert()`, `confirm()`, or `prompt()` calls, ever.
+
+---
+
+### Icon Usage
+
+1. **Primary:** Radix Icons (`@radix-ui/react-icons`)
+2. **Fallback:** Lucide (`lucide-react`) when Radix doesn't have the icon needed
+
+Don't mix both in the same component without reason.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ const ProjectList = lazy(() => import("./pages/ProjectList"));
 const Settings = lazy(() => import("./pages/Settings"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 const Categories = lazy(() => import("./pages/Categories"));
-const Report = lazy(() => import('./pages/Report'));
+const Report = lazy(() => import("./pages/Report"));
 
 // Loading fallback component
 const PageLoader = () => (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ const Report = lazy(() => import('./pages/Report'));
 // Loading fallback component
 const PageLoader = () => (
   <div className="min-h-screen flex items-center justify-center">
-    <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-gray-900"></div>
+    <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary"></div>
   </div>
 );
 

--- a/src/components/ArchiveEditDialog.tsx
+++ b/src/components/ArchiveEditDialog.tsx
@@ -1,597 +1,627 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from "react";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle
-} from '@/components/ui/dialog';
-import { Callout } from '@/components/ui/callout';
-import { InfoCircledIcon } from '@radix-ui/react-icons';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { MarkdownDisplay } from '@/components/MarkdownDisplay';
-import { TimePicker } from '@/components/ui/scroll-time-picker';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow
-} from '@/components/ui/table';
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Callout } from "@/components/ui/callout";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { MarkdownDisplay } from "@/components/MarkdownDisplay";
+import { TimePicker } from "@/components/ui/scroll-time-picker";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  Calendar,
-  Clock,
-  Save,
-  Trash2,
-  Edit,
-  AlertTriangle,
-  RotateCcw
-} from 'lucide-react';
-import { formatDuration, formatDate } from '@/utils/timeUtil';
-import { DayRecord, Task } from '@/contexts/TimeTrackingContext';
-import { useTimeTracking } from '@/hooks/useTimeTracking';
-import { TaskEditInArchiveDialog } from '@/components/TaskEditInArchiveDialog';
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import {
+	Calendar,
+	Clock,
+	Save,
+	Trash2,
+	Edit,
+	AlertTriangle,
+	RotateCcw,
+} from "lucide-react";
+import { formatDuration, formatDate } from "@/utils/timeUtil";
+import { DayRecord, Task } from "@/contexts/TimeTrackingContext";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
+import { TaskEditInArchiveDialog } from "@/components/TaskEditInArchiveDialog";
+import { useToast } from "@/hooks/use-toast";
 
 interface ArchiveEditDialogProps {
-  day: DayRecord;
-  isOpen: boolean;
-  onClose: () => void;
+	day: DayRecord;
+	isOpen: boolean;
+	onClose: () => void;
 }
 
 // Helper functions
 function roundToNearest15Minutes(date: Date): Date {
-  const rounded = new Date(date);
-  const minutes = rounded.getMinutes();
-  const roundedMinutes = Math.round(minutes / 15) * 15;
-  rounded.setMinutes(roundedMinutes);
-  rounded.setSeconds(0);
-  rounded.setMilliseconds(0);
-  return rounded;
+	const rounded = new Date(date);
+	const minutes = rounded.getMinutes();
+	const roundedMinutes = Math.round(minutes / 15) * 15;
+	rounded.setMinutes(roundedMinutes);
+	rounded.setSeconds(0);
+	rounded.setMilliseconds(0);
+	return rounded;
 }
 
 function formatTimeForInput(date: Date): string {
-  const rounded = roundToNearest15Minutes(date);
-  const hours = rounded.getHours().toString().padStart(2, '0');
-  const minutes = rounded.getMinutes().toString().padStart(2, '0');
-  return `${hours}:${minutes}`;
+	const rounded = roundToNearest15Minutes(date);
+	const hours = rounded.getHours().toString().padStart(2, "0");
+	const minutes = rounded.getMinutes().toString().padStart(2, "0");
+	return `${hours}:${minutes}`;
 }
 
 function formatDateForInput(date: Date): string {
-  const year = date.getFullYear();
-  const month = (date.getMonth() + 1).toString().padStart(2, '0');
-  const day = date.getDate().toString().padStart(2, '0');
-  return `${year}-${month}-${day}`;
+	const year = date.getFullYear();
+	const month = (date.getMonth() + 1).toString().padStart(2, "0");
+	const day = date.getDate().toString().padStart(2, "0");
+	return `${year}-${month}-${day}`;
 }
 
 function formatTime12Hour(date: Date | undefined): string {
-  if (!date) return '-';
-  let hours = date.getHours();
-  const minutes = date.getMinutes();
-  const ampm = hours >= 12 ? 'PM' : 'AM';
-  hours = hours % 12;
-  hours = hours === 0 ? 12 : hours;
-  return `${hours}:${minutes.toString().padStart(2, '0')} ${ampm}`;
+	if (!date) return "-";
+	let hours = date.getHours();
+	const minutes = date.getMinutes();
+	const ampm = hours >= 12 ? "PM" : "AM";
+	hours = hours % 12;
+	hours = hours === 0 ? 12 : hours;
+	return `${hours}:${minutes.toString().padStart(2, "0")} ${ampm}`;
 }
 
 export const ArchiveEditDialog: React.FC<ArchiveEditDialogProps> = ({
-  day,
-  isOpen,
-  onClose
+	day,
+	isOpen,
+	onClose,
 }) => {
-  const {
-    updateArchivedDay,
-    deleteArchivedDay,
-    restoreArchivedDay,
-    categories,
-    isDayStarted
-  } = useTimeTracking();
-  const [isEditing, setIsEditing] = useState(false);
-  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  const [editingTask, setEditingTask] = useState<Task | null>(null);
+	const {
+		updateArchivedDay,
+		deleteArchivedDay,
+		restoreArchivedDay,
+		categories,
+		isDayStarted,
+	} = useTimeTracking();
+	const { toast } = useToast();
+	const [isEditing, setIsEditing] = useState(false);
+	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+	const [showRestoreDialog, setShowRestoreDialog] = useState(false);
+	const [editingTask, setEditingTask] = useState<Task | null>(null);
 
-  const [dayData, setDayData] = useState({
-    date: '',
-    startTime: '',
-    endTime: '',
-    notes: ''
-  });
+	const [dayData, setDayData] = useState({
+		date: "",
+		startTime: "",
+		endTime: "",
+		notes: "",
+	});
 
-  const [tasks, setTasks] = useState<Task[]>([]);
+	const [tasks, setTasks] = useState<Task[]>([]);
 
-  // Initialize form data when dialog opens
-  useEffect(() => {
-    if (isOpen && day) {
-      setDayData({
-        date: formatDateForInput(day.startTime),
-        startTime: formatTimeForInput(day.startTime),
-        endTime: formatTimeForInput(day.endTime),
-        notes: day.notes || ''
-      });
-      setTasks([...day.tasks]);
-      setIsEditing(false);
-      setEditingTask(null);
-      setShowDeleteConfirm(false);
-    }
-  }, [day, isOpen]);
+	// Initialize form data when dialog opens
+	useEffect(() => {
+		if (isOpen && day) {
+			setDayData({
+				date: formatDateForInput(day.startTime),
+				startTime: formatTimeForInput(day.startTime),
+				endTime: formatTimeForInput(day.endTime),
+				notes: day.notes || "",
+			});
+			setTasks([...day.tasks]);
+			setIsEditing(false);
+			setEditingTask(null);
+			setShowDeleteConfirm(false);
+		}
+	}, [day, isOpen]);
 
-  const parseTimeInput = (timeStr: string, baseDate: Date): Date => {
-    if (!timeStr || !timeStr.includes(':')) {
-      return baseDate;
-    }
+	const parseTimeInput = (timeStr: string, baseDate: Date): Date => {
+		if (!timeStr || !timeStr.includes(":")) {
+			return baseDate;
+		}
 
-    const [hoursStr, minutesStr] = timeStr.split(':');
-    const hours = parseInt(hoursStr, 10);
-    const minutes = parseInt(minutesStr, 10);
+		const [hoursStr, minutesStr] = timeStr.split(":");
+		const hours = parseInt(hoursStr, 10);
+		const minutes = parseInt(minutesStr, 10);
 
-    if (isNaN(hours) || isNaN(minutes)) {
-      return baseDate;
-    }
+		if (isNaN(hours) || isNaN(minutes)) {
+			return baseDate;
+		}
 
-    const newDate = new Date(baseDate);
-    newDate.setHours(hours, minutes, 0, 0);
-    return newDate;
-  };
+		const newDate = new Date(baseDate);
+		newDate.setHours(hours, minutes, 0, 0);
+		return newDate;
+	};
 
-  const calculateTotalDuration = (taskList: Task[]): number => {
-    return taskList.reduce((total, task) => total + (task.duration || 0), 0);
-  };
+	const calculateTotalDuration = (taskList: Task[]): number => {
+		return taskList.reduce((total, task) => total + (task.duration || 0), 0);
+	};
 
-  const handleSaveDay = async () => {
-    // Parse the new date from the input (same as StartDayDialog)
-    const [year, month, dayOfMonth] = dayData.date.split('-').map(Number);
-    const selectedDate = new Date(year, month - 1, dayOfMonth);
+	const handleSaveDay = async () => {
+		// Parse the new date from the input (same as StartDayDialog)
+		const [year, month, dayOfMonth] = dayData.date.split("-").map(Number);
+		const selectedDate = new Date(year, month - 1, dayOfMonth);
 
-    // Create new start/end times with the selected date but original times
-    const newStartTime = parseTimeInput(dayData.startTime, day.startTime);
-    newStartTime.setFullYear(selectedDate.getFullYear());
-    newStartTime.setMonth(selectedDate.getMonth());
-    newStartTime.setDate(selectedDate.getDate());
+		// Create new start/end times with the selected date but original times
+		const newStartTime = parseTimeInput(dayData.startTime, day.startTime);
+		newStartTime.setFullYear(selectedDate.getFullYear());
+		newStartTime.setMonth(selectedDate.getMonth());
+		newStartTime.setDate(selectedDate.getDate());
 
-    const newEndTime = parseTimeInput(dayData.endTime, day.endTime);
-    newEndTime.setFullYear(selectedDate.getFullYear());
-    newEndTime.setMonth(selectedDate.getMonth());
-    newEndTime.setDate(selectedDate.getDate());
+		const newEndTime = parseTimeInput(dayData.endTime, day.endTime);
+		newEndTime.setFullYear(selectedDate.getFullYear());
+		newEndTime.setMonth(selectedDate.getMonth());
+		newEndTime.setDate(selectedDate.getDate());
 
-    // Update all task timestamps to use the new date
-    const updatedTasks = tasks.map(task => {
-      const newTaskStartTime = new Date(task.startTime);
-      newTaskStartTime.setFullYear(selectedDate.getFullYear());
-      newTaskStartTime.setMonth(selectedDate.getMonth());
-      newTaskStartTime.setDate(selectedDate.getDate());
+		// Update all task timestamps to use the new date
+		const updatedTasks = tasks.map(task => {
+			const newTaskStartTime = new Date(task.startTime);
+			newTaskStartTime.setFullYear(selectedDate.getFullYear());
+			newTaskStartTime.setMonth(selectedDate.getMonth());
+			newTaskStartTime.setDate(selectedDate.getDate());
 
-      const newTaskEndTime = task.endTime ? new Date(task.endTime) : undefined;
-      if (newTaskEndTime) {
-        newTaskEndTime.setFullYear(selectedDate.getFullYear());
-        newTaskEndTime.setMonth(selectedDate.getMonth());
-        newTaskEndTime.setDate(selectedDate.getDate());
-      }
+			const newTaskEndTime = task.endTime ? new Date(task.endTime) : undefined;
+			if (newTaskEndTime) {
+				newTaskEndTime.setFullYear(selectedDate.getFullYear());
+				newTaskEndTime.setMonth(selectedDate.getMonth());
+				newTaskEndTime.setDate(selectedDate.getDate());
+			}
 
-      return {
-        ...task,
-        startTime: newTaskStartTime,
-        endTime: newTaskEndTime
-      };
-    });
+			return {
+				...task,
+				startTime: newTaskStartTime,
+				endTime: newTaskEndTime,
+			};
+		});
 
-    const updatedDay: Partial<DayRecord> = {
-      date: newStartTime.toDateString(),
-      startTime: newStartTime,
-      endTime: newEndTime,
-      notes: dayData.notes || undefined,
-      tasks: updatedTasks,
-      totalDuration: calculateTotalDuration(updatedTasks)
-    };
+		const updatedDay: Partial<DayRecord> = {
+			date: newStartTime.toDateString(),
+			startTime: newStartTime,
+			endTime: newEndTime,
+			notes: dayData.notes || undefined,
+			tasks: updatedTasks,
+			totalDuration: calculateTotalDuration(updatedTasks),
+		};
 
-    try {
-      await updateArchivedDay(day.id, updatedDay);
-      setIsEditing(false);
-    } catch (error) {
-      console.error('Failed to save archived day:', error);
-      alert('Failed to save changes. Please try again.');
-    }
-  };
+		try {
+			await updateArchivedDay(day.id, updatedDay);
+			setIsEditing(false);
+		} catch (error) {
+			console.error("Failed to save archived day:", error);
+			toast({ title: "Save failed", description: "Failed to save changes. Please try again.", variant: "destructive" });
+		}
+	};
 
-  const handleDeleteDay = () => {
-    deleteArchivedDay(day.id);
-    onClose();
-  };
+	const handleDeleteDay = () => {
+		deleteArchivedDay(day.id);
+		onClose();
+	};
 
-  const handleRestoreDay = () => {
-    if (isDayStarted) {
-      if (
-        !confirm(
-          'You currently have an active day. Restoring to this day will replace your current work. Continue restoring?'
-        )
-      ) {
-        return;
-      }
-    }
-    restoreArchivedDay(day.id);
-    onClose();
-  };
+	const handleRestoreDay = () => {
+		if (isDayStarted) {
+			setShowRestoreDialog(true);
+		} else {
+			restoreArchivedDay(day.id);
+			onClose();
+		}
+	};
 
-  const handleTaskEdit = (task: Task) => {
-    setEditingTask(task);
-  };
+	const handleRestoreConfirm = () => {
+		restoreArchivedDay(day.id);
+		setShowRestoreDialog(false);
+		onClose();
+	};
 
-  const handleTaskSave = (updatedTask: Task) => {
-    const updatedTasks = tasks.map(t =>
-      t.id === updatedTask.id ? updatedTask : t
-    );
-    setTasks(updatedTasks);
-    setEditingTask(null);
-  };
+	const handleTaskEdit = (task: Task) => {
+		setEditingTask(task);
+	};
 
-  const handleTaskDelete = (taskId: string) => {
-    const updatedTasks = tasks.filter(t => t.id !== taskId);
-    setTasks(updatedTasks);
-  };
+	const handleTaskSave = (updatedTask: Task) => {
+		const updatedTasks = tasks.map(t =>
+			t.id === updatedTask.id ? updatedTask : t
+		);
+		setTasks(updatedTasks);
+		setEditingTask(null);
+	};
 
-  const handleCancel = () => {
-    // Reset to original values
-    setDayData({
-      date: formatDateForInput(day.startTime),
-      startTime: formatTimeForInput(day.startTime),
-      endTime: formatTimeForInput(day.endTime),
-      notes: day.notes || ''
-    });
-    setTasks([...day.tasks]);
-    setIsEditing(false);
-    setEditingTask(null);
-  };
+	const handleTaskDelete = (taskId: string) => {
+		const updatedTasks = tasks.filter(t => t.id !== taskId);
+		setTasks(updatedTasks);
+	};
 
-  return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-[90dvw] max-h-[90dvh] overflow-y-auto">
-        <DialogHeader>
-          <div className="flex items-center justify-between">
-            <DialogTitle className="flex items-center space-x-2">
-              <Calendar className="w-5 h-5 text-blue-600" />
-              <span>{formatDate(day.startTime)}</span>
-            </DialogTitle>
-          </div>
-        </DialogHeader>
+	const handleCancel = () => {
+		// Reset to original values
+		setDayData({
+			date: formatDateForInput(day.startTime),
+			startTime: formatTimeForInput(day.startTime),
+			endTime: formatTimeForInput(day.endTime),
+			notes: day.notes || "",
+		});
+		setTasks([...day.tasks]);
+		setIsEditing(false);
+		setEditingTask(null);
+	};
 
-        <div className="space-y-6 overflow-x-hidden">
-          <div className="flex flex-wrap justify-center sm:justify-end items-center gap-3 my-4">
-            {!isEditing ? (
-              <>
-                <Button
-                  onClick={handleRestoreDay}
-                  variant="outline"
-                  size="sm"
-                  aria-label="Restore this day"
-                  className="text-blue-600 hover:text-blue-700"
-                >
-                  <RotateCcw className="w-4 h-4" />
-                  <span className="hidden md:block md:ml-2">Restore</span>
-                </Button>
-                <Button
-                  onClick={() => setShowDeleteConfirm(true)}
-                  variant="destructive"
-                  size="sm"
-                  aria-label="Delete this day"
-                >
-                  <Trash2 className="w-4 h-4" />
-                  <span className="hidden md:block md:ml-2">Delete</span>
-                </Button>
-                <Button
-                  onClick={() => setIsEditing(true)}
-                  variant="default"
-                  size="sm"
-                  aria-label="Edit this day"
-                >
-                  <Edit className="w-4 h-4" />
-                  <span className="hidden md:block md:ml-2">Edit</span>
-                </Button>
-              </>
-            ) : (
-              <>
-                <Button onClick={handleCancel} variant="outline" size="sm">
-                  Cancel
-                </Button>
-                <Button onClick={handleSaveDay} size="sm">
-                  <Save className="w-4 h-4 mr-2" />
-                  Save
-                </Button>
-              </>
-            )}
-          </div>
-          {/* Day Summary */}
-          {isEditing && (
-            <Callout.Root size="1" variant="soft">
-              <Callout.Icon>
-                <InfoCircledIcon />
-              </Callout.Icon>
-              <Callout.Text>
-                Only administrators can edit archived days. Changes will be
-                saved immediately and cannot be undone, so please review your
-                changes before saving.
-              </Callout.Text>
-            </Callout.Root>
-          )}
-          <Card className="mb-4">
-            <CardHeader>
-              <CardTitle className="text-lg">Summary of Day</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {isEditing ? (
-                <div className="space-y-4">
-                  <div>
-                    <Label>Date</Label>
-                    <Input
-                      type="date"
-                      value={dayData.date}
-                      onChange={e =>
-                        setDayData(prev => ({ ...prev, date: e.target.value }))
-                      }
-                      className="w-full"
-                    />
-                  </div>
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="day-start-time">Start Time</Label>
-                      <TimePicker
-                        id="day-start-time"
-                        value={dayData.startTime}
-                        onValueChange={value =>
-                          setDayData(prev => ({ ...prev, startTime: value }))
-                        }
-                        aria-label="Day start time"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="day-end-time">End Time</Label>
-                      <TimePicker
-                        id="day-end-time"
-                        value={dayData.endTime}
-                        onValueChange={value =>
-                          setDayData(prev => ({ ...prev, endTime: value }))
-                        }
-                        aria-label="Day end time"
-                      />
-                    </div>
-                  </div>
-                  <div>
-                    <Label htmlFor="day-notes">Notes</Label>
-                    <Tabs defaultValue="edit" className="w-full">
-                      <TabsList className="grid w-full grid-cols-2">
-                        <TabsTrigger value="edit">Edit</TabsTrigger>
-                        <TabsTrigger value="preview">Preview</TabsTrigger>
-                      </TabsList>
-                      <TabsContent value="edit">
-                        <Textarea
-                          id="day-notes"
-                          value={dayData.notes}
-                          onChange={e =>
-                            setDayData(prev => ({
-                              ...prev,
-                              notes: e.target.value
-                            }))
-                          }
-                          placeholder="Add notes about this day (optional, supports Markdown)"
-                          className="min-h-[80px] resize-none"
-                        />
-                      </TabsContent>
-                      <TabsContent value="preview">
-                        <div className="w-full min-h-[80px] p-3 border rounded-md bg-background">
-                          {dayData.notes ? (
-                            <MarkdownDisplay content={dayData.notes} />
-                          ) : (
-                            <p className="text-sm text-muted-foreground">
-                              No notes to preview
-                            </p>
-                          )}
-                        </div>
-                      </TabsContent>
-                    </Tabs>
-                  </div>
-                </div>
-              ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-y-4 gap-x-8 text-sm">
-                  <div>
-                    <span className="font-medium text-foreground">
-                      Start Time:
-                    </span>
-                    <span className="ml-2 text-muted-foreground">
-                      {formatTime12Hour(day.startTime)}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="font-medium text-foreground">End Time:</span>
-                    <span className="ml-2 text-muted-foreground">
-                      {formatTime12Hour(day.endTime)}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="font-medium text-foreground">
-                      Total Duration:
-                    </span>
-                    <div className="flex items-center space-x-2 mt-1">
-                      <Clock className="w-4 h-4 text-green-600" />
-                      <span className="font-semibold text-green-600">
-                        {formatDuration(calculateTotalDuration(tasks))}
-                      </span>
-                    </div>
-                  </div>
-                  <div>
-                    <span className="font-medium text-foreground">Tasks:</span>
-                    <span className="ml-2 text-muted-foreground">
-                      {tasks.length} total
-                    </span>
-                  </div>
-                  {day.notes && (
-                    <div className="col-span-2">
-                      <span className="font-medium text-foreground">Notes:</span>
-                      <div className="mt-1 text-muted-foreground">
-                        <MarkdownDisplay content={day.notes} />
-                      </div>
-                    </div>
-                  )}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-          {/* Tasks Detail */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-lg">Tasks ({tasks.length})</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="overflow-x-auto">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Task</TableHead>
-                      <TableHead>Category</TableHead>
-                      <TableHead>Project/Client</TableHead>
-                      <TableHead>Start Time</TableHead>
-                      <TableHead>End Time</TableHead>
-                      <TableHead>Duration</TableHead>
-                      {isEditing && <TableHead>Actions</TableHead>}
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {tasks.map(task => {
-                      const category = categories.find(
-                        c => c.id === task.category
-                      );
-                      return (
-                        <TableRow key={task.id}>
-                          <TableCell className="font-medium">
-                            <div className="min-w-[150px]">
-                              <div>{task.title}</div>
-                              <span className="hidden lg:block">
-                                {task.description && (
-                                  <div className="text-sm text-muted-foreground mt-1">
-                                    <MarkdownDisplay
-                                      content={task.description}
-                                    />
-                                  </div>
-                                )}
-                              </span>
-                            </div>
-                          </TableCell>
-                          <TableCell>
-                            {category && (
-                              <div className="flex items-center space-x-2 min-w-[120px]">
-                                <div
-                                  className="w-3 h-3 rounded-full"
-                                  style={{ backgroundColor: category.color }}
-                                />
-                                <span className="text-sm">{category.name}</span>
-                              </div>
-                            )}
-                          </TableCell>
-                          <TableCell>
-                            {task.project && (
-                              <div className="min-w-[120px]">
-                                <div className="text-sm font-medium">
-                                  {task.project}
-                                </div>
-                                {task.client && (
-                                  <div className="text-xs text-muted-foreground">
-                                    {task.client}
-                                  </div>
-                                )}
-                              </div>
-                            )}
-                          </TableCell>
-                          <TableCell className="whitespace-nowrap">
-                            {formatTime12Hour(task.startTime)}
-                          </TableCell>
-                          <TableCell className="whitespace-nowrap">
-                            {task.endTime
-                              ? formatTime12Hour(task.endTime)
-                              : '-'}
-                          </TableCell>
-                          <TableCell className="whitespace-nowrap">
-                            {formatDuration(task.duration || 0)}
-                          </TableCell>
-                          {isEditing && (
-                            <TableCell>
-                              <div className="flex space-x-2">
-                                <Button
-                                  onClick={() => handleTaskEdit(task)}
-                                  size="sm"
-                                  variant="outline"
-                                  aria-label="Edit task"
-                                >
-                                  <Edit className="w-3 h-3" />
-                                </Button>
-                                <Button
-                                  onClick={() => handleTaskDelete(task.id)}
-                                  size="sm"
-                                  variant="destructive"
-                                  aria-label="Delete task"
-                                >
-                                  <Trash2 className="w-3 h-3" />
-                                </Button>
-                              </div>
-                            </TableCell>
-                          )}
-                        </TableRow>
-                      );
-                    })}
-                  </TableBody>
-                </Table>
-              </div>
-            </CardContent>
-          </Card>
+	return (
+		<Dialog open={isOpen} onOpenChange={onClose}>
+			<DialogContent className="max-w-[90dvw] max-h-[90dvh] overflow-y-auto">
+				<DialogHeader>
+					<div className="flex items-center justify-between">
+						<DialogTitle className="flex items-center space-x-2">
+							<Calendar className="w-5 h-5 text-blue-600" />
+							<span>{formatDate(day.startTime)}</span>
+						</DialogTitle>
+					</div>
+				</DialogHeader>
 
-          {/* Delete Confirmation */}
-          {showDeleteConfirm && (
-            <Card className="border-destructive/20 bg-destructive/5">
-              <CardContent className="p-4">
-                <div className="flex items-center space-x-3">
-                  <AlertTriangle className="w-5 h-5 text-destructive" />
-                  <div className="flex-1">
-                    <h4 className="font-medium text-destructive">
-                      Delete Archived Day
-                    </h4>
-                    <p className="text-sm text-destructive mt-1">
-                      Are you sure you want to delete this archived day? This
-                      action cannot be undone.
-                    </p>
-                  </div>
-                  <div className="flex space-x-2">
-                    <Button
-                      onClick={handleDeleteDay}
-                      size="sm"
-                      variant="destructive"
-                    >
-                      Delete
-                    </Button>
-                    <Button
-                      onClick={() => setShowDeleteConfirm(false)}
-                      size="sm"
-                      variant="outline"
-                    >
-                      Cancel
-                    </Button>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          )}
-        </div>
+				<div className="space-y-6 overflow-x-hidden">
+					<div className="flex flex-wrap justify-center sm:justify-end items-center gap-3 my-4">
+						{!isEditing ? (
+							<>
+								<Button
+									onClick={handleRestoreDay}
+									variant="outline"
+									size="sm"
+									aria-label="Restore this day"
+									className="text-blue-600 hover:text-blue-700"
+								>
+									<RotateCcw className="w-4 h-4" />
+									<span className="hidden md:block md:ml-2">Restore</span>
+								</Button>
+								<Button
+									onClick={() => setShowDeleteConfirm(true)}
+									variant="destructive"
+									size="sm"
+									aria-label="Delete this day"
+								>
+									<Trash2 className="w-4 h-4" />
+									<span className="hidden md:block md:ml-2">Delete</span>
+								</Button>
+								<Button
+									onClick={() => setIsEditing(true)}
+									variant="default"
+									size="sm"
+									aria-label="Edit this day"
+								>
+									<Edit className="w-4 h-4" />
+									<span className="hidden md:block md:ml-2">Edit</span>
+								</Button>
+							</>
+						) : (
+							<>
+								<Button onClick={handleCancel} variant="outline" size="sm">
+									Cancel
+								</Button>
+								<Button onClick={handleSaveDay} size="sm">
+									<Save className="w-4 h-4 mr-2" />
+									Save
+								</Button>
+							</>
+						)}
+					</div>
+					{/* Day Summary */}
+					{isEditing && (
+						<Callout.Root size="1" variant="soft">
+							<Callout.Icon>
+								<InfoCircledIcon />
+							</Callout.Icon>
+							<Callout.Text>
+								Only administrators can edit archived days. Changes will be
+								saved immediately and cannot be undone, so please review your
+								changes before saving.
+							</Callout.Text>
+						</Callout.Root>
+					)}
+					<Card className="mb-4">
+						<CardHeader>
+							<CardTitle className="text-lg">Summary of Day</CardTitle>
+						</CardHeader>
+						<CardContent>
+							{isEditing ? (
+								<div className="space-y-4">
+									<div>
+										<Label>Date</Label>
+										<Input
+											type="date"
+											value={dayData.date}
+											onChange={e =>
+												setDayData(prev => ({ ...prev, date: e.target.value }))
+											}
+											className="w-full"
+										/>
+									</div>
+									<div className="grid grid-cols-2 gap-4">
+										<div>
+											<Label htmlFor="day-start-time">Start Time</Label>
+											<TimePicker
+												id="day-start-time"
+												value={dayData.startTime}
+												onValueChange={value =>
+													setDayData(prev => ({ ...prev, startTime: value }))
+												}
+												aria-label="Day start time"
+											/>
+										</div>
+										<div>
+											<Label htmlFor="day-end-time">End Time</Label>
+											<TimePicker
+												id="day-end-time"
+												value={dayData.endTime}
+												onValueChange={value =>
+													setDayData(prev => ({ ...prev, endTime: value }))
+												}
+												aria-label="Day end time"
+											/>
+										</div>
+									</div>
+									<div>
+										<Label htmlFor="day-notes">Notes</Label>
+										<Tabs defaultValue="edit" className="w-full">
+											<TabsList className="grid w-full grid-cols-2">
+												<TabsTrigger value="edit">Edit</TabsTrigger>
+												<TabsTrigger value="preview">Preview</TabsTrigger>
+											</TabsList>
+											<TabsContent value="edit">
+												<Textarea
+													id="day-notes"
+													value={dayData.notes}
+													onChange={e =>
+														setDayData(prev => ({
+															...prev,
+															notes: e.target.value,
+														}))
+													}
+													placeholder="Add notes about this day (optional, supports Markdown)"
+													className="min-h-[80px] resize-none"
+												/>
+											</TabsContent>
+											<TabsContent value="preview">
+												<div className="w-full min-h-[80px] p-3 border rounded-md bg-background">
+													{dayData.notes ? (
+														<MarkdownDisplay content={dayData.notes} />
+													) : (
+														<p className="text-sm text-muted-foreground">
+															No notes to preview
+														</p>
+													)}
+												</div>
+											</TabsContent>
+										</Tabs>
+									</div>
+								</div>
+							) : (
+								<div className="grid grid-cols-1 sm:grid-cols-2 gap-y-4 gap-x-8 text-sm">
+									<div>
+										<span className="font-medium text-foreground">
+											Start Time:
+										</span>
+										<span className="ml-2 text-muted-foreground">
+											{formatTime12Hour(day.startTime)}
+										</span>
+									</div>
+									<div>
+										<span className="font-medium text-foreground">End Time:</span>
+										<span className="ml-2 text-muted-foreground">
+											{formatTime12Hour(day.endTime)}
+										</span>
+									</div>
+									<div>
+										<span className="font-medium text-foreground">
+											Total Duration:
+										</span>
+										<div className="flex items-center space-x-2 mt-1">
+											<Clock className="w-4 h-4 text-green-600" />
+											<span className="font-semibold text-green-600">
+												{formatDuration(calculateTotalDuration(tasks))}
+											</span>
+										</div>
+									</div>
+									<div>
+										<span className="font-medium text-foreground">Tasks:</span>
+										<span className="ml-2 text-muted-foreground">
+											{tasks.length} total
+										</span>
+									</div>
+									{day.notes && (
+										<div className="col-span-2">
+											<span className="font-medium text-foreground">Notes:</span>
+											<div className="mt-1 text-muted-foreground">
+												<MarkdownDisplay content={day.notes} />
+											</div>
+										</div>
+									)}
+								</div>
+							)}
+						</CardContent>
+					</Card>
+					{/* Tasks Detail */}
+					<Card>
+						<CardHeader>
+							<CardTitle className="text-lg">Tasks ({tasks.length})</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<div className="overflow-x-auto">
+								<Table>
+									<TableHeader>
+										<TableRow>
+											<TableHead>Task</TableHead>
+											<TableHead>Category</TableHead>
+											<TableHead>Project/Client</TableHead>
+											<TableHead>Start Time</TableHead>
+											<TableHead>End Time</TableHead>
+											<TableHead>Duration</TableHead>
+											{isEditing && <TableHead>Actions</TableHead>}
+										</TableRow>
+									</TableHeader>
+									<TableBody>
+										{tasks.map(task => {
+											const category = categories.find(
+												c => c.id === task.category
+											);
+											return (
+												<TableRow key={task.id}>
+													<TableCell className="font-medium">
+														<div className="min-w-[150px]">
+															<div>{task.title}</div>
+															<span className="hidden lg:block">
+																{task.description && (
+																	<div className="text-sm text-muted-foreground mt-1">
+																		<MarkdownDisplay
+																			content={task.description}
+																		/>
+																	</div>
+																)}
+															</span>
+														</div>
+													</TableCell>
+													<TableCell>
+														{category && (
+															<div className="flex items-center space-x-2 min-w-[120px]">
+																<div
+																	className="w-3 h-3 rounded-full"
+																	style={{ backgroundColor: category.color }}
+																/>
+																<span className="text-sm">{category.name}</span>
+															</div>
+														)}
+													</TableCell>
+													<TableCell>
+														{task.project && (
+															<div className="min-w-[120px]">
+																<div className="text-sm font-medium">
+																	{task.project}
+																</div>
+																{task.client && (
+																	<div className="text-xs text-muted-foreground">
+																		{task.client}
+																	</div>
+																)}
+															</div>
+														)}
+													</TableCell>
+													<TableCell className="whitespace-nowrap">
+														{formatTime12Hour(task.startTime)}
+													</TableCell>
+													<TableCell className="whitespace-nowrap">
+														{task.endTime
+															? formatTime12Hour(task.endTime)
+															: "-"}
+													</TableCell>
+													<TableCell className="whitespace-nowrap">
+														{formatDuration(task.duration || 0)}
+													</TableCell>
+													{isEditing && (
+														<TableCell>
+															<div className="flex space-x-2">
+																<Button
+																	onClick={() => handleTaskEdit(task)}
+																	size="sm"
+																	variant="outline"
+																	aria-label="Edit task"
+																>
+																	<Edit className="w-3 h-3" />
+																</Button>
+																<Button
+																	onClick={() => handleTaskDelete(task.id)}
+																	size="sm"
+																	variant="destructive"
+																	aria-label="Delete task"
+																>
+																	<Trash2 className="w-3 h-3" />
+																</Button>
+															</div>
+														</TableCell>
+													)}
+												</TableRow>
+											);
+										})}
+									</TableBody>
+								</Table>
+							</div>
+						</CardContent>
+					</Card>
 
-        {/* Task Edit Dialog */}
-        {editingTask && (
-          <TaskEditInArchiveDialog
-            task={editingTask}
-            isOpen={!!editingTask}
-            onClose={() => setEditingTask(null)}
-            onSave={handleTaskSave}
-          />
-        )}
-      </DialogContent>
-    </Dialog>
-  );
+					{/* Delete Confirmation */}
+					{showDeleteConfirm && (
+						<Card className="border-destructive/20 bg-destructive/5">
+							<CardContent className="p-4">
+								<div className="flex items-center space-x-3">
+									<AlertTriangle className="w-5 h-5 text-destructive" />
+									<div className="flex-1">
+										<h4 className="font-medium text-destructive">
+											Delete Archived Day
+										</h4>
+										<p className="text-sm text-destructive mt-1">
+											Are you sure you want to delete this archived day? This
+											action cannot be undone.
+										</p>
+									</div>
+									<div className="flex space-x-2">
+										<Button
+											onClick={handleDeleteDay}
+											size="sm"
+											variant="destructive"
+										>
+											Delete
+										</Button>
+										<Button
+											onClick={() => setShowDeleteConfirm(false)}
+											size="sm"
+											variant="outline"
+										>
+											Cancel
+										</Button>
+									</div>
+								</div>
+							</CardContent>
+						</Card>
+					)}
+				</div>
+
+				{/* Task Edit Dialog */}
+				{editingTask && (
+					<TaskEditInArchiveDialog
+						task={editingTask}
+						isOpen={!!editingTask}
+						onClose={() => setEditingTask(null)}
+						onSave={handleTaskSave}
+					/>
+				)}
+
+				<AlertDialog open={showRestoreDialog} onOpenChange={setShowRestoreDialog}>
+					<AlertDialogContent>
+						<AlertDialogHeader>
+							<AlertDialogTitle>Replace active day?</AlertDialogTitle>
+							<AlertDialogDescription>
+								You currently have an active day. Restoring to this archived day will replace your current work.
+							</AlertDialogDescription>
+						</AlertDialogHeader>
+						<AlertDialogFooter>
+							<AlertDialogCancel>Cancel</AlertDialogCancel>
+							<AlertDialogAction onClick={handleRestoreConfirm}>
+								Restore anyway
+							</AlertDialogAction>
+						</AlertDialogFooter>
+					</AlertDialogContent>
+				</AlertDialog>
+			</DialogContent>
+		</Dialog>
+	);
 };
-

--- a/src/components/ArchiveItem.tsx
+++ b/src/components/ArchiveItem.tsx
@@ -1,300 +1,328 @@
-import React, { useMemo } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import React, { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow
-} from '@/components/ui/table';
-import { Calendar, Clock, Edit, RotateCcw, FileText } from 'lucide-react';
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import {
-  formatDuration,
-  formatDurationLong,
-  formatTime,
-  formatDate,
-  generateDailySummary
-} from '@/utils/timeUtil';
-import { MarkdownDisplay } from '@/components/MarkdownDisplay';
-import { DayRecord } from '@/contexts/TimeTrackingContext';
-import { useTimeTracking } from '@/hooks/useTimeTracking';
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Calendar, Clock, Edit, RotateCcw, FileText } from "lucide-react";
 import {
-  getHoursWorkedForDay as calcHoursWorked,
-  getBillableHoursForDay as calcBillableHours,
-  getNonBillableHoursForDay as calcNonBillableHours,
-  getRevenueForDay as calcRevenue
-} from '@/utils/calculationUtils';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@radix-ui/react-tabs';
+	formatDuration,
+	formatDurationLong,
+	formatTime,
+	formatDate,
+	generateDailySummary,
+} from "@/utils/timeUtil";
+import { MarkdownDisplay } from "@/components/MarkdownDisplay";
+import { DayRecord } from "@/contexts/TimeTrackingContext";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
+import {
+	getHoursWorkedForDay as calcHoursWorked,
+	getBillableHoursForDay as calcBillableHours,
+	getNonBillableHoursForDay as calcNonBillableHours,
+	getRevenueForDay as calcRevenue,
+} from "@/utils/calculationUtils";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@radix-ui/react-tabs";
 
 interface ArchiveItemProps {
-  day: DayRecord;
-  onEdit: (day: DayRecord) => void;
+	day: DayRecord;
+	onEdit: (day: DayRecord) => void;
 }
 
 export const ArchiveItem: React.FC<ArchiveItemProps> = ({ day, onEdit }) => {
-  const {
-    restoreArchivedDay,
-    isDayStarted,
-    projects,
-    categories
-  } = useTimeTracking();
+	const {
+		restoreArchivedDay,
+		isDayStarted,
+		projects,
+		categories,
+	} = useTimeTracking();
 
-  // Memoize per-day stats so they only recompute when the day data,
-  // project rates, or category billing settings change.
-  const dayStats = useMemo(() => ({
-    hoursWorked: calcHoursWorked(day),
-    billableHours: calcBillableHours(day, projects, categories),
-    nonBillableHours: calcNonBillableHours(day, projects, categories),
-    revenue: calcRevenue(day, projects, categories)
-  }), [day, projects, categories]);
+	const [showRestoreDialog, setShowRestoreDialog] = useState(false);
 
-  // Build lookup maps once so the task table doesn't do O(n) searches per row.
-  const projectMap = useMemo(() => new Map(projects.map(p => [p.name, p])), [projects]);
-  const categoryMap = useMemo(() => new Map(categories.map(c => [c.name, c])), [categories]);
+	// Memoize per-day stats so they only recompute when the day data,
+	// project rates, or category billing settings change.
+	const dayStats = useMemo(() => ({
+		hoursWorked: calcHoursWorked(day),
+		billableHours: calcBillableHours(day, projects, categories),
+		nonBillableHours: calcNonBillableHours(day, projects, categories),
+		revenue: calcRevenue(day, projects, categories),
+	}), [day, projects, categories]);
 
-  // Generate daily summary only when task descriptions change.
-  const dailySummary = useMemo(() => {
-    const descriptions = day.tasks
-      .filter(task => task.description)
-      .map(task => task.description!);
-    return generateDailySummary(descriptions);
-  }, [day.tasks]);
+	// Build lookup maps once so the task table doesn't do O(n) searches per row.
+	const projectMap = useMemo(() => new Map(projects.map(p => [p.name, p])), [projects]);
+	const categoryMap = useMemo(() => new Map(categories.map(c => [c.name, c])), [categories]);
 
-  const handleRestore = () => {
-    if (isDayStarted) {
-      if (
-        !confirm(
-          'You currently have an active day. Restoring to this day will replace your current work. Continue restoring?'
-        )
-      ) {
-        return;
-      }
-    }
-    restoreArchivedDay(day.id);
-  };
+	// Generate daily summary only when task descriptions change.
+	const dailySummary = useMemo(() => {
+		const descriptions = day.tasks
+			.filter(task => task.description)
+			.map(task => task.description!);
+		return generateDailySummary(descriptions);
+	}, [day.tasks]);
 
-  return (
-    <Card className="print:shadow-none print:mb-4">
-      <CardHeader className="print:pb-2">
-        <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center space-x-2">
-            {formatDate(day.startTime)}
-          </CardTitle>
-          <div className="flex space-x-2 print:hidden">
-            <Button
-              onClick={handleRestore}
-              variant="ghost"
-              size="sm"
-              aria-label="Restore this day"
-              className="flex items-center space-x-2 text-blue-600 hover:text-blue-700"
-            >
-              <RotateCcw className="w-4 h-4 block" />
-              <span className="hidden md:block">Restore</span>
-            </Button>
-            <Button
-              onClick={() => onEdit(day)}
-              variant="default"
-              size="sm"
-              aria-label="Edit this day"
-              className="flex items-center space-x-2"
-            >
-              <Edit className="w-4 h-4 block" />
-              <span className="hidden md:block">Edit</span>
-            </Button>
-          </div>
-        </div>
-      </CardHeader>
+	const handleRestore = () => {
+		if (isDayStarted) {
+			setShowRestoreDialog(true);
+		} else {
+			restoreArchivedDay(day.id);
+		}
+	};
 
-      <CardContent className="print:pt-0">
-        <div className="space-y-4">
-          {/* Day Summary */}
-          <div className="space-y-2">
-            <div className="flex items-center justify-between text-sm print:text-base">
-              <div className="flex items-center space-x-4">
-                <span className="text-muted-foreground print:text-black">
-                  Started: {formatTime(day.startTime)}
-                </span>
-                <span className="text-muted-foreground print:text-black">
-                  Ended: {formatTime(day.endTime)}
-                </span>
-              </div>
-              <div className="flex items-center space-x-2">
-                <Clock className="w-4 h-4 text-green-600 print:text-black" />
-                <span className="font-semibold text-green-600 print:text-black">
-                  {formatDurationLong(day.totalDuration)}
-                </span>
-              </div>
-            </div>
+	const handleRestoreConfirm = () => {
+		restoreArchivedDay(day.id);
+		setShowRestoreDialog(false);
+	};
 
-            {/* Hours Worked and Revenue */}
-            <div className="space-y-2 border-t pt-2">
-              <div className="flex items-center justify-between text-sm print:text-base">
-                <div className="flex items-center space-x-4">
-                  <span className="text-blue-600 print:text-black font-medium">
-                    Total{' '}
-                    <span className="hidden md:d-inline-flex">Hours: </span>
-                    {dayStats.hoursWorked.toFixed(2)}h
-                  </span>
-                  <span className="text-green-600 print:text-black font-medium">
-                    Billable: {dayStats.billableHours.toFixed(2)}h
-                  </span>
-                  <span className="text-muted-foreground print:text-black font-medium">
-                    Non-billable: {dayStats.nonBillableHours.toFixed(2)}h
-                  </span>
-                </div>
-                {dayStats.revenue > 0 && (
-                  <span className="text-green-600 print:text-black font-semibold">
-                    Revenue: ${dayStats.revenue.toFixed(2)}
-                  </span>
-                )}
-              </div>
-            </div>
-          </div>
+	return (
+		<Card className="print:shadow-none print:mb-4">
+			<CardHeader className="print:pb-2">
+				<div className="flex items-center justify-between">
+					<CardTitle className="flex items-center space-x-2">
+						{formatDate(day.startTime)}
+					</CardTitle>
+					<div className="flex space-x-2 print:hidden">
+						<Button
+							onClick={handleRestore}
+							variant="ghost"
+							size="sm"
+							aria-label="Restore this day"
+							className="flex items-center space-x-2 text-blue-600 hover:text-blue-700"
+						>
+							<RotateCcw className="w-4 h-4 block" />
+							<span className="hidden md:block">Restore</span>
+						</Button>
+						<Button
+							onClick={() => onEdit(day)}
+							variant="default"
+							size="sm"
+							aria-label="Edit this day"
+							className="flex items-center space-x-2"
+						>
+							<Edit className="w-4 h-4 block" />
+							<span className="hidden md:block">Edit</span>
+						</Button>
+					</div>
+				</div>
+			</CardHeader>
 
-          {/* Daily Summary */}
-          {dailySummary && (
-            <div className="space-y-2 border-t pt-4">
-              <h4 className="font-medium text-foreground flex items-center mb-2">
-                <FileText className="w-4 h-4 mr-2" />
-                Overview
-              </h4>
-              <Tabs defaultValue="summary" className="w-full">
-                <TabsList className="border-b mb-4">
-                  <TabsTrigger
-                    value="summary"
-                    className="px-3 py-1 text-sm font-medium text-muted-foreground data-[state=active]:border-primary data-[state=active]:border-b-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    Summary
-                  </TabsTrigger>
-                  <TabsTrigger
-                    value="notes"
-                    className="px-3 py-1 text-sm font-medium text-muted-foreground data-[state=active]:border-primary data-[state=active]:border-b-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    Notes
-                  </TabsTrigger>
-                </TabsList>
-                <TabsContent value="summary" className="focus-visible:outline-none">
-                  <div className="bg-muted p-4 rounded-md print:bg-white print:border print:border-border">
-                    <MarkdownDisplay
-                      content={dailySummary}
-                      className="prose-p:text-muted-foreground print:prose-p:text-foreground"
-                    />
-                  </div>
-                </TabsContent>
-                <TabsContent value="notes" className="focus-visible:outline-none">
-                  <div className="bg-muted p-4 rounded-md print:bg-white print:border print:border-border">
-                    {day.notes ? (
-                      <MarkdownDisplay
-                        content={day.notes}
-                        className="prose-p:text-muted-foreground print:prose-p:text-foreground"
-                      />
-                    ) : (
-                      <div className="prose-sm prose-p:leading-relaxed prose-p:my-1 prose-p:text-muted-foreground print:prose-p:text-foreground">
-                        <p>No notes for this day have been entered.</p>
-                      </div>
-                    )}
-                  </div>
-                </TabsContent>
-              </Tabs>
-            </div>
-          )}
+			<CardContent className="print:pt-0">
+				<div className="space-y-4">
+					{/* Day Summary */}
+					<div className="space-y-2">
+						<div className="flex items-center justify-between text-sm print:text-base">
+							<div className="flex items-center space-x-4">
+								<span className="text-muted-foreground print:text-black">
+									Started: {formatTime(day.startTime)}
+								</span>
+								<span className="text-muted-foreground print:text-black">
+									Ended: {formatTime(day.endTime)}
+								</span>
+							</div>
+							<div className="flex items-center space-x-2">
+								<Clock className="w-4 h-4 text-green-600 print:text-black" />
+								<span className="font-semibold text-green-600 print:text-black">
+									{formatDurationLong(day.totalDuration)}
+								</span>
+							</div>
+						</div>
 
-          {/* Tasks Table */}
-          <div className="print:mt-2">
-            <h4 className="font-medium text-foreground print:hidden mb-2">
-              Tasks ({day.tasks.length})
-            </h4>
-            <Table>
-              <TableHeader>
-                <TableRow className="print:border-black">
-                  <TableHead className="print:text-black print:font-bold">
-                    Task
-                  </TableHead>
-                  <TableHead className="print:text-black print:font-bold">
-                    Project
-                  </TableHead>
-                  <TableHead className="print:text-black print:font-bold">
-                    Start<span className="hidden md:d-inline-flex"> Time</span>
-                  </TableHead>
-                  <TableHead className="print:text-black print:font-bold">
-                    End<span className="hidden md:d-inline-flex"> Time</span>
-                  </TableHead>
-                  <TableHead className="print:text-black print:font-bold">
-                    Duration
-                  </TableHead>
-                  <TableHead className="print:text-black print:font-bold">
-                    Value
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {day.tasks.map(task => {
-                  const project = projectMap.get(task.project ?? '');
-                  const category = categoryMap.get(task.category ?? '');
-                  const taskHours = task.duration
-                    ? task.duration / (1000 * 60 * 60)
-                    : 0;
+						{/* Hours Worked and Revenue */}
+						<div className="space-y-2 border-t pt-2">
+							<div className="flex items-center justify-between text-sm print:text-base">
+								<div className="flex items-center space-x-4">
+									<span className="text-blue-600 print:text-black font-medium">
+										Total{" "}
+										<span className="hidden md:d-inline-flex">Hours: </span>
+										{dayStats.hoursWorked.toFixed(2)}h
+									</span>
+									<span className="text-green-600 print:text-black font-medium">
+										Billable: {dayStats.billableHours.toFixed(2)}h
+									</span>
+									<span className="text-muted-foreground print:text-black font-medium">
+										Non-billable: {dayStats.nonBillableHours.toFixed(2)}h
+									</span>
+								</div>
+								{dayStats.revenue > 0 && (
+									<span className="text-green-600 print:text-black font-semibold">
+										Revenue: ${dayStats.revenue.toFixed(2)}
+									</span>
+								)}
+							</div>
+						</div>
+					</div>
 
-                  // Check if both the project and category are billable
-                  const projectIsBillable = project?.isBillable !== false;
-                  const categoryIsBillable = category?.isBillable !== false;
-                  const isBillable = projectIsBillable && categoryIsBillable;
+					{/* Daily Summary */}
+					{dailySummary && (
+						<div className="space-y-2 border-t pt-4">
+							<h4 className="font-medium text-foreground flex items-center mb-2">
+								<FileText className="w-4 h-4 mr-2" />
+								Overview
+							</h4>
+							<Tabs defaultValue="summary" className="w-full">
+								<TabsList className="border-b mb-4">
+									<TabsTrigger
+										value="summary"
+										className="px-3 py-1 text-sm font-medium text-muted-foreground data-[state=active]:border-primary data-[state=active]:border-b-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									>
+										Summary
+									</TabsTrigger>
+									<TabsTrigger
+										value="notes"
+										className="px-3 py-1 text-sm font-medium text-muted-foreground data-[state=active]:border-primary data-[state=active]:border-b-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+									>
+										Notes
+									</TabsTrigger>
+								</TabsList>
+								<TabsContent value="summary" className="focus-visible:outline-none">
+									<div className="bg-muted p-4 rounded-md print:bg-white print:border print:border-border">
+										<MarkdownDisplay
+											content={dailySummary}
+											className="prose-p:text-muted-foreground print:prose-p:text-foreground"
+										/>
+									</div>
+								</TabsContent>
+								<TabsContent value="notes" className="focus-visible:outline-none">
+									<div className="bg-muted p-4 rounded-md print:bg-white print:border print:border-border">
+										{day.notes ? (
+											<MarkdownDisplay
+												content={day.notes}
+												className="prose-p:text-muted-foreground print:prose-p:text-foreground"
+											/>
+										) : (
+											<div className="prose-sm prose-p:leading-relaxed prose-p:my-1 prose-p:text-muted-foreground print:prose-p:text-foreground">
+												<p>No notes for this day have been entered.</p>
+											</div>
+										)}
+									</div>
+								</TabsContent>
+							</Tabs>
+						</div>
+					)}
 
-                  const taskValue =
-                    isBillable && project?.hourlyRate && task.duration
-                      ? taskHours * project.hourlyRate
-                      : 0;
+					{/* Tasks Table */}
+					<div className="print:mt-2">
+						<h4 className="font-medium text-foreground print:hidden mb-2">
+							Tasks ({day.tasks.length})
+						</h4>
+						<Table>
+							<TableHeader>
+								<TableRow className="print:border-black">
+									<TableHead className="print:text-black print:font-bold">
+										Task
+									</TableHead>
+									<TableHead className="print:text-black print:font-bold">
+										Project
+									</TableHead>
+									<TableHead className="print:text-black print:font-bold">
+										Start<span className="hidden md:d-inline-flex"> Time</span>
+									</TableHead>
+									<TableHead className="print:text-black print:font-bold">
+										End<span className="hidden md:d-inline-flex"> Time</span>
+									</TableHead>
+									<TableHead className="print:text-black print:font-bold">
+										Duration
+									</TableHead>
+									<TableHead className="print:text-black print:font-bold">
+										Value
+									</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{day.tasks.map(task => {
+									const project = projectMap.get(task.project ?? "");
+									const category = categoryMap.get(task.category ?? "");
+									const taskHours = task.duration
+										? task.duration / (1000 * 60 * 60)
+										: 0;
 
-                  return (
-                    <TableRow key={task.id} className="print:border-black">
-                      <TableCell className="font-medium print:text-black">
-                        {task.title}
-                        <div className="text-sm text-muted-foreground hidden md:block print:text-foreground">
-                          <MarkdownDisplay
-                            content={task.description}
-                            className="prose-sm line-clamp-1 hover:line-clamp-none transition-all duration-200"
-                          />
-                        </div>
-                      </TableCell>
-                      <TableCell className="print:text-black">
-                        {task.project || '-'}
-                        {project?.hourlyRate && (
-                          <div className="text-xs text-muted-foreground print:text-foreground">
-                            ${project.hourlyRate}/hr
-                          </div>
-                        )}
-                      </TableCell>
-                      <TableCell className="print:text-black">
-                        {formatTime(task.startTime)}
-                      </TableCell>
-                      <TableCell className="print:text-black">
-                        {task.endTime ? formatTime(task.endTime) : '-'}
-                      </TableCell>
-                      <TableCell className="print:text-black">
-                        {formatDuration(task.duration || 0)}
-                        <div className="text-xs text-gray-500 print:text-gray-600">
-                          {taskHours.toFixed(2)}h
-                        </div>
-                      </TableCell>
-                      <TableCell className="print:text-black">
-                        {taskValue > 0 ? (
-                          <span className="font-medium text-green-600 print:text-black">
-                            ${taskValue.toFixed(2)}
-                          </span>
-                        ) : (
-                          '-'
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
+									// Check if both the project and category are billable
+									const projectIsBillable = project?.isBillable !== false;
+									const categoryIsBillable = category?.isBillable !== false;
+									const isBillable = projectIsBillable && categoryIsBillable;
+
+									const taskValue =
+										isBillable && project?.hourlyRate && task.duration
+											? taskHours * project.hourlyRate
+											: 0;
+
+									return (
+										<TableRow key={task.id} className="print:border-black">
+											<TableCell className="font-medium print:text-black">
+												{task.title}
+												<div className="text-sm text-muted-foreground hidden md:block print:text-foreground">
+													<MarkdownDisplay
+														content={task.description}
+														className="prose-sm line-clamp-1 hover:line-clamp-none transition-all duration-200"
+													/>
+												</div>
+											</TableCell>
+											<TableCell className="print:text-black">
+												{task.project || "-"}
+												{project?.hourlyRate && (
+													<div className="text-xs text-muted-foreground print:text-foreground">
+														${project.hourlyRate}/hr
+													</div>
+												)}
+											</TableCell>
+											<TableCell className="print:text-black">
+												{formatTime(task.startTime)}
+											</TableCell>
+											<TableCell className="print:text-black">
+												{task.endTime ? formatTime(task.endTime) : "-"}
+											</TableCell>
+											<TableCell className="print:text-black">
+												{formatDuration(task.duration || 0)}
+												<div className="text-xs text-gray-500 print:text-gray-600">
+													{taskHours.toFixed(2)}h
+												</div>
+											</TableCell>
+											<TableCell className="print:text-black">
+												{taskValue > 0 ? (
+													<span className="font-medium text-green-600 print:text-black">
+														${taskValue.toFixed(2)}
+													</span>
+												) : (
+													"-"
+												)}
+											</TableCell>
+										</TableRow>
+									);
+								})}
+							</TableBody>
+						</Table>
+					</div>
+				</div>
+			</CardContent>
+			<AlertDialog open={showRestoreDialog} onOpenChange={setShowRestoreDialog}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Replace active day?</AlertDialogTitle>
+						<AlertDialogDescription>
+							You currently have an active day. Restoring to this archived day will replace your current work.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction onClick={handleRestoreConfirm}>
+							Restore anyway
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</Card>
+	);
 };

--- a/src/components/CategoryManagement.tsx
+++ b/src/components/CategoryManagement.tsx
@@ -6,6 +6,16 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -30,6 +40,7 @@ export const CategoryManagement: React.FC<CategoryManagementProps> = ({
     null
   );
   const [isAddingNew, setIsAddingNew] = useState(false);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const [formData, setFormData] = useState({
     name: '',
     description: '',
@@ -81,17 +92,12 @@ export const CategoryManagement: React.FC<CategoryManagementProps> = ({
     setIsAddingNew(true);
   };
 
-  const handleDelete = async (categoryId: string) => {
-    if (
-      confirm(
-        'Are you sure you want to delete this category? This action cannot be undone.'
-      )
-    ) {
-      deleteCategory(categoryId);
-      // Save changes to database
-      await forceSyncToDatabase();
-    }
-  };
+  const handleDeleteConfirm = async () => {
+	if (!deleteTargetId) return;
+	deleteCategory(deleteTargetId);
+	await forceSyncToDatabase();
+	setDeleteTargetId(null);
+};
 
   const predefinedColors = [
     '#3B82F6',
@@ -107,6 +113,7 @@ export const CategoryManagement: React.FC<CategoryManagementProps> = ({
   ];
 
   return (
+    <>
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
         <DialogHeader>
@@ -315,7 +322,7 @@ export const CategoryManagement: React.FC<CategoryManagementProps> = ({
                           <Button
                             size="sm"
                             variant="outline"
-                            onClick={() => handleDelete(category.id)}
+                            onClick={() => setDeleteTargetId(category.id)}
                             className="text-red-600 hover:text-red-700"
                           >
                             <Trash2 className="w-3 h-3" />
@@ -331,5 +338,25 @@ export const CategoryManagement: React.FC<CategoryManagementProps> = ({
         </div>
       </DialogContent>
     </Dialog>
+    <AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => !open && setDeleteTargetId(null)}>
+	<AlertDialogContent>
+		<AlertDialogHeader>
+			<AlertDialogTitle>Delete this category?</AlertDialogTitle>
+			<AlertDialogDescription>
+				This action cannot be undone.
+			</AlertDialogDescription>
+		</AlertDialogHeader>
+		<AlertDialogFooter>
+			<AlertDialogCancel>Cancel</AlertDialogCancel>
+			<AlertDialogAction
+				onClick={handleDeleteConfirm}
+				className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+			>
+				Delete
+			</AlertDialogAction>
+		</AlertDialogFooter>
+	</AlertDialogContent>
+</AlertDialog>
+    </>
   );
 };

--- a/src/components/CategoryManagement.tsx
+++ b/src/components/CategoryManagement.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
-import { Button } from '@/components/ui/button';
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle
-} from '@/components/ui/dialog';
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle
+} from "@/components/ui/dialog";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -16,14 +16,14 @@ import {
 	AlertDialogHeader,
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Plus, Edit, Trash2, Tag } from 'lucide-react';
-import { TaskCategory } from '@/config/categories';
-import { useTimeTracking } from '@/hooks/useTimeTracking';
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Plus, Edit, Trash2, Tag } from "lucide-react";
+import { TaskCategory } from "@/config/categories";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
 
 interface CategoryManagementProps {
   isOpen: boolean;
@@ -93,11 +93,11 @@ export const CategoryManagement: React.FC<CategoryManagementProps> = ({
   };
 
   const handleDeleteConfirm = async () => {
-	if (!deleteTargetId) return;
-	deleteCategory(deleteTargetId);
-	await forceSyncToDatabase();
-	setDeleteTargetId(null);
-};
+    if (!deleteTargetId) return;
+    deleteCategory(deleteTargetId);
+    await forceSyncToDatabase();
+    setDeleteTargetId(null);
+  };
 
   const predefinedColors = [
     '#3B82F6',
@@ -339,24 +339,24 @@ export const CategoryManagement: React.FC<CategoryManagementProps> = ({
       </DialogContent>
     </Dialog>
     <AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => !open && setDeleteTargetId(null)}>
-	<AlertDialogContent>
-		<AlertDialogHeader>
-			<AlertDialogTitle>Delete this category?</AlertDialogTitle>
-			<AlertDialogDescription>
-				This action cannot be undone.
-			</AlertDialogDescription>
-		</AlertDialogHeader>
-		<AlertDialogFooter>
-			<AlertDialogCancel>Cancel</AlertDialogCancel>
-			<AlertDialogAction
-				onClick={handleDeleteConfirm}
-				className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-			>
-				Delete
-			</AlertDialogAction>
-		</AlertDialogFooter>
-	</AlertDialogContent>
-</AlertDialog>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this category?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDeleteConfirm}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
     </>
   );
 };

--- a/src/components/CategoryManagement.tsx
+++ b/src/components/CategoryManagement.tsx
@@ -26,337 +26,337 @@ import { TaskCategory } from "@/config/categories";
 import { useTimeTracking } from "@/hooks/useTimeTracking";
 
 interface CategoryManagementProps {
-  isOpen: boolean;
-  onClose: () => void;
+	isOpen: boolean;
+	onClose: () => void;
 }
 
 export const CategoryManagement: React.FC<CategoryManagementProps> = ({
-  isOpen,
-  onClose
+	isOpen,
+	onClose
 }) => {
-  const { categories, addCategory, updateCategory, deleteCategory, forceSyncToDatabase } =
-    useTimeTracking();
-  const [editingCategory, setEditingCategory] = useState<TaskCategory | null>(
-    null
-  );
-  const [isAddingNew, setIsAddingNew] = useState(false);
-  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
-  const [formData, setFormData] = useState({
-    name: '',
-    description: '',
-    color: '#3B82F6',
-    isBillable: true
-  });
+	const { categories, addCategory, updateCategory, deleteCategory, forceSyncToDatabase } =
+		useTimeTracking();
+	const [editingCategory, setEditingCategory] = useState<TaskCategory | null>(
+		null
+	);
+	const [isAddingNew, setIsAddingNew] = useState(false);
+	const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+	const [formData, setFormData] = useState({
+		name: '',
+		description: '',
+		color: '#3B82F6',
+		isBillable: true
+	});
 
-  const resetForm = () => {
-    setFormData({
-      name: '',
-      description: '',
-      color: '#3B82F6',
-      isBillable: true
-    });
-    setEditingCategory(null);
-    setIsAddingNew(false);
-  };
+	const resetForm = () => {
+		setFormData({
+			name: '',
+			description: '',
+			color: '#3B82F6',
+			isBillable: true
+		});
+		setEditingCategory(null);
+		setIsAddingNew(false);
+	};
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
 
-    const categoryData = {
-      name: formData.name.trim(),
-      description: formData.description.trim() || undefined,
-      color: formData.color,
-      isBillable: formData.isBillable
-    };
+		const categoryData = {
+			name: formData.name.trim(),
+			description: formData.description.trim() || undefined,
+			color: formData.color,
+			isBillable: formData.isBillable
+		};
 
-    if (editingCategory) {
-      updateCategory(editingCategory.id, categoryData);
-    } else {
-      addCategory(categoryData);
-    }
+		if (editingCategory) {
+			updateCategory(editingCategory.id, categoryData);
+		} else {
+			addCategory(categoryData);
+		}
 
-    // Save changes to database
-    await forceSyncToDatabase();
+		// Save changes to database
+		await forceSyncToDatabase();
 
-    resetForm();
-  };
+		resetForm();
+	};
 
-  const handleEdit = (category: TaskCategory) => {
-    setEditingCategory(category);
-    setFormData({
-      name: category.name,
-      description: category.description || '',
-      color: category.color,
-      isBillable: category.isBillable !== false // Default to true if not specified
-    });
-    setIsAddingNew(true);
-  };
+	const handleEdit = (category: TaskCategory) => {
+		setEditingCategory(category);
+		setFormData({
+			name: category.name,
+			description: category.description || '',
+			color: category.color,
+			isBillable: category.isBillable !== false // Default to true if not specified
+		});
+		setIsAddingNew(true);
+	};
 
-  const handleDeleteConfirm = async () => {
-    if (!deleteTargetId) return;
-    deleteCategory(deleteTargetId);
-    await forceSyncToDatabase();
-    setDeleteTargetId(null);
-  };
+	const handleDeleteConfirm = async () => {
+		if (!deleteTargetId) return;
+		deleteCategory(deleteTargetId);
+		await forceSyncToDatabase();
+		setDeleteTargetId(null);
+	};
 
-  const predefinedColors = [
-    '#3B82F6',
-    '#8B5CF6',
-    '#10B981',
-    '#F59E0B',
-    '#EF4444',
-    '#06B6D4',
-    '#84CC16',
-    '#F97316',
-    '#6B7280',
-    '#EC4899'
-  ];
+	const predefinedColors = [
+		'#3B82F6',
+		'#8B5CF6',
+		'#10B981',
+		'#F59E0B',
+		'#EF4444',
+		'#06B6D4',
+		'#84CC16',
+		'#F97316',
+		'#6B7280',
+		'#EC4899'
+	];
 
-  return (
-    <>
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
-          <div className="flex items-center justify-between">
-            <DialogTitle className="flex items-center space-x-2">
-              <Tag className="w-5 h-5" />
-              <span>Category Management</span>
-            </DialogTitle>
-            <div className="flex items-center space-x-2 my-4">
-              {/* Add New Category Button */}
-              {!isAddingNew && (
-                <Button onClick={() => setIsAddingNew(true)} className="w-full">
-                  <Plus className="w-4 h-4 mr-2" />
-                  Add Category
-                </Button>
-              )}
-            </div>
-          </div>
-        </DialogHeader>
+	return (
+		<>
+		<Dialog open={isOpen} onOpenChange={onClose}>
+			<DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
+				<DialogHeader>
+					<div className="flex items-center justify-between">
+						<DialogTitle className="flex items-center space-x-2">
+							<Tag className="w-5 h-5" />
+							<span>Category Management</span>
+						</DialogTitle>
+						<div className="flex items-center space-x-2 my-4">
+							{/* Add New Category Button */}
+							{!isAddingNew && (
+								<Button onClick={() => setIsAddingNew(true)} className="w-full">
+									<Plus className="w-4 h-4 mr-2" />
+									Add Category
+								</Button>
+							)}
+						</div>
+					</div>
+				</DialogHeader>
 
-        <div className="space-y-6">
-          {/* Add/Edit Category Form */}
-          {isAddingNew && (
-            <Card>
-              <CardHeader>
-                <CardTitle>
-                  {editingCategory ? 'Edit Category' : 'Add Category'}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handleSubmit} className="space-y-4">
-                  <div>
-                    <Label htmlFor="name">Category Name *</Label>
-                    <Input
-                      id="name"
-                      value={formData.name}
-                      onChange={(e) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          name: e.target.value
-                        }))
-                      }
-                      placeholder="Enter category name"
-                      required
-                    />
-                  </div>
+				<div className="space-y-6">
+					{/* Add/Edit Category Form */}
+					{isAddingNew && (
+						<Card>
+							<CardHeader>
+								<CardTitle>
+									{editingCategory ? 'Edit Category' : 'Add Category'}
+								</CardTitle>
+							</CardHeader>
+							<CardContent>
+								<form onSubmit={handleSubmit} className="space-y-4">
+									<div>
+										<Label htmlFor="name">Category Name *</Label>
+										<Input
+											id="name"
+											value={formData.name}
+											onChange={(e) =>
+												setFormData((prev) => ({
+													...prev,
+													name: e.target.value
+												}))
+											}
+											placeholder="Enter category name"
+											required
+										/>
+									</div>
 
-                  <div>
-                    <Label htmlFor="description">Description</Label>
-                    <Textarea
-                      id="description"
-                      value={formData.description}
-                      onChange={(e) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          description: e.target.value
-                        }))
-                      }
-                      placeholder="Enter category description (optional)"
-                      className="min-h-[80px] resize-none"
-                    />
-                  </div>
+									<div>
+										<Label htmlFor="description">Description</Label>
+										<Textarea
+											id="description"
+											value={formData.description}
+											onChange={(e) =>
+												setFormData((prev) => ({
+													...prev,
+													description: e.target.value
+												}))
+											}
+											placeholder="Enter category description (optional)"
+											className="min-h-[80px] resize-none"
+										/>
+									</div>
 
-                  <div>
-                    <Label htmlFor="color">Category Color</Label>
-                    <div className="space-y-3">
-                      <div className="flex items-center space-x-2">
-                        <Input
-                          id="color"
-                          type="color"
-                          value={formData.color}
-                          onChange={(e) =>
-                            setFormData((prev) => ({
-                              ...prev,
-                              color: e.target.value
-                            }))
-                          }
-                          className="w-16 h-10"
-                        />
-                        <span className="text-sm text-gray-500">
-                          {formData.color}
-                        </span>
-                        <div
-                          className="w-8 h-8 rounded-full border-2 border-gray-300"
-                          style={{ backgroundColor: formData.color }}
-                        />
-                      </div>
+									<div>
+										<Label htmlFor="color">Category Color</Label>
+										<div className="space-y-3">
+											<div className="flex items-center space-x-2">
+												<Input
+													id="color"
+													type="color"
+													value={formData.color}
+													onChange={(e) =>
+														setFormData((prev) => ({
+															...prev,
+															color: e.target.value
+														}))
+													}
+													className="w-16 h-10"
+												/>
+												<span className="text-sm text-gray-500">
+													{formData.color}
+												</span>
+												<div
+													className="w-8 h-8 rounded-full border-2 border-gray-300"
+													style={{ backgroundColor: formData.color }}
+												/>
+											</div>
 
-                      {/* Predefined Colors */}
-                      <div className="flex flex-wrap gap-2">
-                        <span className="text-sm text-gray-600 w-full">
-                          Quick colors:
-                        </span>
-                        {predefinedColors.map((color) => (
-                          <button
-                            key={color}
-                            type="button"
-                            onClick={() =>
-                              setFormData((prev) => ({ ...prev, color }))
-                            }
-                            className={`w-6 h-6 rounded-full border-2 hover:scale-110 transition-transform ${
-                              formData.color === color
-                                ? 'border-gray-800'
-                                : 'border-gray-300'
-                            }`}
-                            style={{ backgroundColor: color }}
-                          />
-                        ))}
-                      </div>
-                    </div>
-                  </div>
+											{/* Predefined Colors */}
+											<div className="flex flex-wrap gap-2">
+												<span className="text-sm text-gray-600 w-full">
+													Quick colors:
+												</span>
+												{predefinedColors.map((color) => (
+													<button
+														key={color}
+														type="button"
+														onClick={() =>
+															setFormData((prev) => ({ ...prev, color }))
+														}
+														className={`w-6 h-6 rounded-full border-2 hover:scale-110 transition-transform ${
+															formData.color === color
+																? 'border-gray-800'
+																: 'border-gray-300'
+														}`}
+														style={{ backgroundColor: color }}
+													/>
+												))}
+											</div>
+										</div>
+									</div>
 
-                  <div className="flex items-center space-x-2">
-                    <Checkbox
-                      id="billable"
-                      checked={formData.isBillable}
-                      onCheckedChange={(checked) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          isBillable: checked === true
-                        }))
-                      }
-                    />
-                    <Label htmlFor="billable" className="text-sm font-medium">
-                      Billable category
-                    </Label>
-                    <span className="text-xs text-gray-500">
-                      (Tasks in this category can generate revenue)
-                    </span>
-                  </div>
+									<div className="flex items-center space-x-2">
+										<Checkbox
+											id="billable"
+											checked={formData.isBillable}
+											onCheckedChange={(checked) =>
+												setFormData((prev) => ({
+													...prev,
+													isBillable: checked === true
+												}))
+											}
+										/>
+										<Label htmlFor="billable" className="text-sm font-medium">
+											Billable category
+										</Label>
+										<span className="text-xs text-gray-500">
+											(Tasks in this category can generate revenue)
+										</span>
+									</div>
 
-                  <div className="flex space-x-2">
-                    <Button type="submit">
-                      {editingCategory ? 'Update' : 'Add'}
-                    </Button>
-                    <Button type="button" variant="outline" onClick={resetForm}>
-                      Cancel
-                    </Button>
-                  </div>
-                </form>
-              </CardContent>
-            </Card>
-          )}
+									<div className="flex space-x-2">
+										<Button type="submit">
+											{editingCategory ? 'Update' : 'Add'}
+										</Button>
+										<Button type="button" variant="outline" onClick={resetForm}>
+											Cancel
+										</Button>
+									</div>
+								</form>
+							</CardContent>
+						</Card>
+					)}
 
-          {/* Categories List */}
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold">
-              Categories ({categories.length})
-            </h3>
+					{/* Categories List */}
+					<div className="space-y-4">
+						<h3 className="text-lg font-semibold">
+							Categories ({categories.length})
+						</h3>
 
-            {categories.length === 0 ? (
-              <Card>
-                <CardContent className="text-center py-8">
-                  <Tag className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                  <p className="text-gray-600">
-                    No categories yet. Add your first category to get started!
-                  </p>
-                </CardContent>
-              </Card>
-            ) : (
-              <div className="grid gap-4">
-                {categories.map((category) => (
-                  <Card
-                    key={category.id}
-                    className="border-l-4"
-                    style={{ borderLeftColor: category.color }}
-                  >
-                    <CardContent className="p-4">
-                      <div className="flex items-center justify-between">
-                        <div className="flex-1">
-                          <div className="flex items-center space-x-3">
-                            <div
-                              className="w-4 h-4 rounded-full"
-                              style={{ backgroundColor: category.color }}
-                            />
-                            <div>
-                              <div className="flex items-center space-x-2">
-                                <h4 className="font-semibold text-gray-900">
-                                  {category.name}
-                                </h4>
-                                <span className={`px-2 py-1 text-xs rounded-full ${
-                                  category.isBillable !== false
-                                    ? 'bg-green-100 text-green-800'
-                                    : 'bg-gray-100 text-gray-800'
-                                }`}>
-                                  {category.isBillable !== false ? 'Billable' : 'Non-billable'}
-                                </span>
-                              </div>
-                              {category.description && (
-                                <p className="text-sm text-gray-600 mt-1">
-                                  {category.description}
-                                </p>
-                              )}
-                            </div>
-                          </div>
-                        </div>
+						{categories.length === 0 ? (
+							<Card>
+								<CardContent className="text-center py-8">
+									<Tag className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+									<p className="text-gray-600">
+										No categories yet. Add your first category to get started!
+									</p>
+								</CardContent>
+							</Card>
+						) : (
+							<div className="grid gap-4">
+								{categories.map((category) => (
+									<Card
+										key={category.id}
+										className="border-l-4"
+										style={{ borderLeftColor: category.color }}
+									>
+										<CardContent className="p-4">
+											<div className="flex items-center justify-between">
+												<div className="flex-1">
+													<div className="flex items-center space-x-3">
+														<div
+															className="w-4 h-4 rounded-full"
+															style={{ backgroundColor: category.color }}
+														/>
+														<div>
+															<div className="flex items-center space-x-2">
+																<h4 className="font-semibold text-gray-900">
+																	{category.name}
+																</h4>
+																<span className={`px-2 py-1 text-xs rounded-full ${
+																	category.isBillable !== false
+																		? 'bg-green-100 text-green-800'
+																		: 'bg-gray-100 text-gray-800'
+																}`}>
+																	{category.isBillable !== false ? 'Billable' : 'Non-billable'}
+																</span>
+															</div>
+															{category.description && (
+																<p className="text-sm text-gray-600 mt-1">
+																	{category.description}
+																</p>
+															)}
+														</div>
+													</div>
+												</div>
 
-                        <div className="flex space-x-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => handleEdit(category)}
-                          >
-                            <Edit className="w-3 h-3" />
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => setDeleteTargetId(category.id)}
-                            className="text-red-600 hover:text-red-700"
-                          >
-                            <Trash2 className="w-3 h-3" />
-                          </Button>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
-    <AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => !open && setDeleteTargetId(null)}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete this category?</AlertDialogTitle>
-          <AlertDialogDescription>
-            This action cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={handleDeleteConfirm}
-            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          >
-            Delete
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-    </>
-  );
+												<div className="flex space-x-2">
+													<Button
+														size="sm"
+														variant="outline"
+														onClick={() => handleEdit(category)}
+													>
+														<Edit className="w-3 h-3" />
+													</Button>
+													<Button
+														size="sm"
+														variant="outline"
+														onClick={() => setDeleteTargetId(category.id)}
+														className="text-red-600 hover:text-red-700"
+													>
+														<Trash2 className="w-3 h-3" />
+													</Button>
+												</div>
+											</div>
+										</CardContent>
+									</Card>
+								))}
+							</div>
+						)}
+					</div>
+				</div>
+			</DialogContent>
+		</Dialog>
+		<AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => !open && setDeleteTargetId(null)}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Delete this category?</AlertDialogTitle>
+					<AlertDialogDescription>
+						This action cannot be undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel>Cancel</AlertDialogCancel>
+					<AlertDialogAction
+						onClick={handleDeleteConfirm}
+						className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+					>
+						Delete
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+		</>
+	);
 };

--- a/src/components/ProjectManagement.tsx
+++ b/src/components/ProjectManagement.tsx
@@ -1,312 +1,361 @@
-import React, { useState } from 'react';
-import { Button } from '@/components/ui/button';
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle
-} from '@/components/ui/dialog';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Plus, Edit, Trash2, Briefcase, RotateCcw } from 'lucide-react';
-import { Project } from '@/contexts/TimeTrackingContext';
-import { useTimeTracking } from '@/hooks/useTimeTracking';
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Plus, Edit, Trash2, Briefcase, RotateCcw } from "lucide-react";
+import { Project } from "@/contexts/TimeTrackingContext";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
 
 interface ProjectManagementProps {
-  isOpen: boolean;
-  onClose: () => void;
+	isOpen: boolean;
+	onClose: () => void;
 }
 
 export const ProjectManagement: React.FC<ProjectManagementProps> = ({
-  isOpen,
-  onClose
+	isOpen,
+	onClose,
 }) => {
-  const {
-    projects,
-    addProject,
-    updateProject,
-    deleteProject,
-    resetProjectsToDefaults
-  } = useTimeTracking();
-  const [editingProject, setEditingProject] = useState<Project | null>(null);
-  const [isAddingNew, setIsAddingNew] = useState(false);
-  const [formData, setFormData] = useState({
-    name: '',
-    client: '',
-    hourlyRate: '',
-    color: '#3B82F6'
-  });
+	const {
+		projects,
+		addProject,
+		updateProject,
+		deleteProject,
+		resetProjectsToDefaults,
+	} = useTimeTracking();
+	const [editingProject, setEditingProject] = useState<Project | null>(null);
+	const [isAddingNew, setIsAddingNew] = useState(false);
+	const [formData, setFormData] = useState({
+		name: "",
+		client: "",
+		hourlyRate: "",
+		color: "#3B82F6",
+	});
+	const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+	const [showResetDialog, setShowResetDialog] = useState(false);
 
-  const resetForm = () => {
-    setFormData({
-      name: '',
-      client: '',
-      hourlyRate: '',
-      color: '#3B82F6'
-    });
-    setEditingProject(null);
-    setIsAddingNew(false);
-  };
+	const resetForm = () => {
+		setFormData({
+			name: "",
+			client: "",
+			hourlyRate: "",
+			color: "#3B82F6",
+		});
+		setEditingProject(null);
+		setIsAddingNew(false);
+	};
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
 
-    const projectData = {
-      name: formData.name.trim(),
-      client: formData.client.trim(),
-      hourlyRate: formData.hourlyRate
-        ? parseFloat(formData.hourlyRate)
-        : undefined,
-      color: formData.color
-    };
+		const projectData = {
+			name: formData.name.trim(),
+			client: formData.client.trim(),
+			hourlyRate: formData.hourlyRate
+				? parseFloat(formData.hourlyRate)
+				: undefined,
+			color: formData.color,
+		};
 
-    if (editingProject) {
-      updateProject(editingProject.id, projectData);
-    } else {
-      addProject(projectData);
-    }
+		if (editingProject) {
+			updateProject(editingProject.id, projectData);
+		} else {
+			addProject(projectData);
+		}
 
-    resetForm();
-  };
+		resetForm();
+	};
 
-  const handleEdit = (project: Project) => {
-    setEditingProject(project);
-    setFormData({
-      name: project.name,
-      client: project.client,
-      hourlyRate: project.hourlyRate?.toString() || '',
-      color: project.color || '#3B82F6'
-    });
-    setIsAddingNew(true);
-  };
+	const handleEdit = (project: Project) => {
+		setEditingProject(project);
+		setFormData({
+			name: project.name,
+			client: project.client,
+			hourlyRate: project.hourlyRate?.toString() || "",
+			color: project.color || "#3B82F6",
+		});
+		setIsAddingNew(true);
+	};
 
-  const handleDelete = (projectId: string) => {
-    if (confirm('Are you sure you want to delete this project?')) {
-      deleteProject(projectId);
-    }
-  };
+	const handleDeleteConfirm = () => {
+		if (!deleteTargetId) return;
+		deleteProject(deleteTargetId);
+		setDeleteTargetId(null);
+	};
 
-  const handleResetToDefaults = () => {
-    if (
-      confirm(
-        "Are you sure you want to reset all projects to defaults? This will remove any custom projects you've added."
-      )
-    ) {
-      resetProjectsToDefaults();
-    }
-  };
+	const handleResetConfirm = () => {
+		resetProjectsToDefaults();
+		setShowResetDialog(false);
+	};
 
-  return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
-        <DialogHeader>
-          <div className="flex items-center justify-between">
-            <DialogTitle className="flex items-center space-x-2">
-              <Briefcase className="w-5 h-5" />
-              <span>Project Management</span>
-            </DialogTitle>
-            <div className="flex items-center space-x-2 my-4">
-              {!isAddingNew && (
-                <>
-                  <Button
-                    onClick={handleResetToDefaults}
-                    variant="outline"
-                    className="w-full"
-                  >
-                    <RotateCcw className="w-4 h-4 mr-2" />
-                    Reset to Defaults
-                  </Button>
-                  <Button
-                    onClick={() => setIsAddingNew(true)}
-                    className="w-full"
-                  >
-                    <Plus className="w-4 h-4 mr-2" />
-                    Add Project
-                  </Button>
-                </>
-              )}
-            </div>
-          </div>
-        </DialogHeader>
+	return (
+		<>
+			<Dialog open={isOpen} onOpenChange={onClose}>
+				<DialogContent className="max-w-4xl max-h-[80vh] overflow-y-auto">
+					<DialogHeader>
+						<div className="flex items-center justify-between">
+							<DialogTitle className="flex items-center space-x-2">
+								<Briefcase className="w-5 h-5" />
+								<span>Project Management</span>
+							</DialogTitle>
+							<div className="flex items-center space-x-2 my-4">
+								{!isAddingNew && (
+									<>
+										<Button
+											onClick={() => setShowResetDialog(true)}
+											variant="outline"
+											className="w-full"
+										>
+											<RotateCcw className="w-4 h-4 mr-2" />
+											Reset to Defaults
+										</Button>
+										<Button
+											onClick={() => setIsAddingNew(true)}
+											className="w-full"
+										>
+											<Plus className="w-4 h-4 mr-2" />
+											Add Project
+										</Button>
+									</>
+								)}
+							</div>
+						</div>
+					</DialogHeader>
 
-        <div className="space-y-6">
-          {/* Add/Edit Project Form */}
-          {isAddingNew && (
-            <Card>
-              <CardHeader>
-                <CardTitle>
-                  {editingProject ? 'Edit Project' : 'Add New Project'}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handleSubmit} className="space-y-4">
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="name">Project Name *</Label>
-                      <Input
-                        id="name"
-                        value={formData.name}
-                        onChange={(e) =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            name: e.target.value
-                          }))
-                        }
-                        placeholder="Enter project name"
-                        required
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="client">Client Name *</Label>
-                      <Input
-                        id="client"
-                        value={formData.client}
-                        onChange={(e) =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            client: e.target.value
-                          }))
-                        }
-                        placeholder="Enter client name"
-                        required
-                      />
-                    </div>
-                  </div>
+					<div className="space-y-6">
+						{/* Add/Edit Project Form */}
+						{isAddingNew && (
+							<Card>
+								<CardHeader>
+									<CardTitle>
+										{editingProject ? "Edit Project" : "Add New Project"}
+									</CardTitle>
+								</CardHeader>
+								<CardContent>
+									<form onSubmit={handleSubmit} className="space-y-4">
+										<div className="grid grid-cols-2 gap-4">
+											<div>
+												<Label htmlFor="name">Project Name *</Label>
+												<Input
+													id="name"
+													value={formData.name}
+													onChange={(e) =>
+														setFormData((prev) => ({
+															...prev,
+															name: e.target.value,
+														}))
+													}
+													placeholder="Enter project name"
+													required
+												/>
+											</div>
+											<div>
+												<Label htmlFor="client">Client Name *</Label>
+												<Input
+													id="client"
+													value={formData.client}
+													onChange={(e) =>
+														setFormData((prev) => ({
+															...prev,
+															client: e.target.value,
+														}))
+													}
+													placeholder="Enter client name"
+													required
+												/>
+											</div>
+										</div>
 
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="hourlyRate">Hourly Rate ($)</Label>
-                      <Input
-                        id="hourlyRate"
-                        type="number"
-                        step="0.01"
-                        value={formData.hourlyRate}
-                        onChange={(e) =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            hourlyRate: e.target.value
-                          }))
-                        }
-                        placeholder="0.00"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="color">Project Color</Label>
-                      <div className="flex items-center space-x-2">
-                        <Input
-                          id="color"
-                          type="color"
-                          value={formData.color}
-                          onChange={(e) =>
-                            setFormData((prev) => ({
-                              ...prev,
-                              color: e.target.value
-                            }))
-                          }
-                          className="w-16 h-10"
-                        />
-                        <span className="text-sm text-gray-500">
-                          {formData.color}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
+										<div className="grid grid-cols-2 gap-4">
+											<div>
+												<Label htmlFor="hourlyRate">Hourly Rate ($)</Label>
+												<Input
+													id="hourlyRate"
+													type="number"
+													step="0.01"
+													value={formData.hourlyRate}
+													onChange={(e) =>
+														setFormData((prev) => ({
+															...prev,
+															hourlyRate: e.target.value,
+														}))
+												}
+													placeholder="0.00"
+												/>
+											</div>
+											<div>
+												<Label htmlFor="color">Project Color</Label>
+												<div className="flex items-center space-x-2">
+													<Input
+														id="color"
+														type="color"
+														value={formData.color}
+														onChange={(e) =>
+															setFormData((prev) => ({
+																...prev,
+																color: e.target.value,
+															}))
+														}
+														className="w-16 h-10"
+													/>
+													<span className="text-sm text-gray-500">
+														{formData.color}
+													</span>
+												</div>
+											</div>
+										</div>
 
-                  <div className="flex space-x-2">
-                    <Button type="submit">
-                      {editingProject ? 'Update Project' : 'Add Project'}
-                    </Button>
-                    <Button type="button" variant="outline" onClick={resetForm}>
-                      Cancel
-                    </Button>
-                  </div>
-                </form>
-              </CardContent>
-            </Card>
-          )}
+										<div className="flex space-x-2">
+											<Button type="submit">
+												{editingProject ? "Update Project" : "Add Project"}
+											</Button>
+											<Button type="button" variant="outline" onClick={resetForm}>
+												Cancel
+											</Button>
+										</div>
+									</form>
+								</CardContent>
+							</Card>
+						)}
 
-          {/* Projects List */}
-          <div className="space-y-4">
-            <h3 className="text-lg font-semibold">
-              Projects ({projects.length})
-            </h3>
+						{/* Projects List */}
+						<div className="space-y-4">
+							<h3 className="text-lg font-semibold">
+								Projects ({projects.length})
+							</h3>
 
-            {projects.length === 0 ? (
-              <Card>
-                <CardContent className="text-center py-8">
-                  <Briefcase className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
-                  <p className="text-muted-foreground">
-                    No projects yet. Add your first project to get started!
-                  </p>
-                </CardContent>
-              </Card>
-            ) : (
-              <div className="grid gap-4">
-                {projects.map((project) => (
-                  <Card
-                    key={project.id}
-                    className="border-l-4"
-                    style={{ borderLeftColor: project.color }}
-                  >
-                    <CardContent className="p-4">
-                      <div className="flex items-center justify-between">
-                        <div className="flex-1">
-                          <div className="flex items-center space-x-3">
-                            <div
-                              className="w-4 h-4 rounded-full"
-                              style={{ backgroundColor: project.color }}
-                            />
-                            <div>
-                              <div className="flex items-center space-x-2">
-                                <h4 className="font-semibold text-foreground">
-                                  {project.name}
-                                </h4>
-                                {project.id.startsWith('default-') && (
-                                  <span className="px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded-full">
-                                    Default
-                                  </span>
-                                )}
-                              </div>
-                              <p className="text-sm text-muted-foreground">
-                                {project.client}
-                              </p>
-                              {project.hourlyRate && (
-                                <p className="text-sm text-green-600 font-medium">
-                                  ${project.hourlyRate}/hour
-                                </p>
-                              )}
-                            </div>
-                          </div>
-                        </div>
+							{projects.length === 0 ? (
+								<Card>
+									<CardContent className="text-center py-8">
+										<Briefcase className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
+										<p className="text-muted-foreground">
+											No projects yet. Add your first project to get started!
+										</p>
+									</CardContent>
+								</Card>
+							) : (
+								<div className="grid gap-4">
+									{projects.map((project) => (
+										<Card
+											key={project.id}
+											className="border-l-4"
+											style={{ borderLeftColor: project.color }}
+										>
+											<CardContent className="p-4">
+												<div className="flex items-center justify-between">
+													<div className="flex-1">
+														<div className="flex items-center space-x-3">
+															<div
+																className="w-4 h-4 rounded-full"
+																style={{ backgroundColor: project.color }}
+															/>
+															<div>
+																<div className="flex items-center space-x-2">
+																	<h4 className="font-semibold text-foreground">
+																		{project.name}
+																	</h4>
+																	{project.id.startsWith("default-") && (
+																		<span className="px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded-full">
+																			Default
+																		</span>
+																	)}
+																</div>
+																<p className="text-sm text-muted-foreground">
+																	{project.client}
+																</p>
+																{project.hourlyRate && (
+																	<p className="text-sm text-green-600 font-medium">
+																		${project.hourlyRate}/hour
+																	</p>
+																)}
+															</div>
+														</div>
+													</div>
 
-                        <div className="flex space-x-2">
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            aria-label="Edit project"
-                            onClick={() => handleEdit(project)}
-                          >
-                            <Edit className="w-3 h-3" />
-                          </Button>
-                          <Button
-                            size="sm"
-                            variant="destructive"
-                            aria-label="Delete project"
-                            onClick={() => handleDelete(project.id)}
-                          >
-                            <Trash2 className="w-3 h-3" />
-                          </Button>
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-      </DialogContent>
-    </Dialog>
-  );
+													<div className="flex space-x-2">
+														<Button
+															size="sm"
+															variant="outline"
+															aria-label="Edit project"
+															onClick={() => handleEdit(project)}
+														>
+															<Edit className="w-3 h-3" />
+														</Button>
+														<Button
+															size="sm"
+															variant="destructive"
+															aria-label="Delete project"
+															onClick={() => setDeleteTargetId(project.id)}
+														>
+															<Trash2 className="w-3 h-3" />
+														</Button>
+													</div>
+												</div>
+											</CardContent>
+										</Card>
+									))}
+								</div>
+							)}
+						</div>
+					</div>
+				</DialogContent>
+			</Dialog>
+
+			<AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => !open && setDeleteTargetId(null)}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete this project?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This action cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleDeleteConfirm}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<AlertDialog open={showResetDialog} onOpenChange={setShowResetDialog}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Reset projects to defaults?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This will remove any custom projects you've added. This action cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleResetConfirm}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Reset
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</>
+	);
 };

--- a/src/pages/Categories.tsx
+++ b/src/pages/Categories.tsx
@@ -1,330 +1,355 @@
-import React, { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Plus, Edit, Trash2, Tag, TagIcon } from 'lucide-react';
-import { TimeTrackingProvider } from '@/contexts/TimeTrackingContext';
-import { TaskCategory } from '@/config/categories';
-import { useTimeTracking } from '@/hooks/useTimeTracking';
-import SiteNavigationMenu from '@/components/Navigation';
+import React, { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Plus, Edit, Trash2, Tag, TagIcon } from "lucide-react";
+import { TimeTrackingProvider } from "@/contexts/TimeTrackingContext";
+import { TaskCategory } from "@/config/categories";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
+import SiteNavigationMenu from "@/components/Navigation";
 
 const CategoryContent: React.FC = () => {
-  const { categories, addCategory, updateCategory, deleteCategory, forceSyncToDatabase } =
-    useTimeTracking();
-  const [editingCategory, setEditingCategory] = useState<TaskCategory | null>(
-    null
-  );
-  const [isAddingNew, setIsAddingNew] = useState(false);
-  const [formData, setFormData] = useState({
-    name: '',
-    description: '',
-    color: '#3B82F6',
-    isBillable: true
-  });
+	const { categories, addCategory, updateCategory, deleteCategory, forceSyncToDatabase } =
+		useTimeTracking();
+	const [editingCategory, setEditingCategory] = useState<TaskCategory | null>(
+		null
+	);
+	const [isAddingNew, setIsAddingNew] = useState(false);
+	const [formData, setFormData] = useState({
+		name: "",
+		description: "",
+		color: "#3B82F6",
+		isBillable: true,
+	});
+	const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
 
-  const resetForm = () => {
-    setFormData({
-      name: '',
-      description: '',
-      color: '#3B82F6',
-      isBillable: true
-    });
-    setEditingCategory(null);
-    setIsAddingNew(false);
-  };
+	const resetForm = () => {
+		setFormData({
+			name: "",
+			description: "",
+			color: "#3B82F6",
+			isBillable: true,
+		});
+		setEditingCategory(null);
+		setIsAddingNew(false);
+	};
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
 
-    const categoryData = {
-      name: formData.name.trim(),
-      description: formData.description.trim() || undefined,
-      color: formData.color,
-      isBillable: formData.isBillable
-    };
+		const categoryData = {
+			name: formData.name.trim(),
+			description: formData.description.trim() || undefined,
+			color: formData.color,
+			isBillable: formData.isBillable,
+		};
 
-    if (editingCategory) {
-      updateCategory(editingCategory.id, categoryData);
-    } else {
-      addCategory(categoryData);
-    }
+		if (editingCategory) {
+			updateCategory(editingCategory.id, categoryData);
+		} else {
+			addCategory(categoryData);
+		}
 
-    // Save changes to database
-    await forceSyncToDatabase();
+		// Save changes to database
+		await forceSyncToDatabase();
 
-    resetForm();
-  };
+		resetForm();
+	};
 
-  const handleEdit = (category: TaskCategory) => {
-    setEditingCategory(category);
-    setFormData({
-      name: category.name,
-      description: category.description || '',
-      color: category.color,
-      isBillable: category.isBillable !== false // Default to true if not specified
-    });
-    setIsAddingNew(true);
-  };
+	const handleEdit = (category: TaskCategory) => {
+		setEditingCategory(category);
+		setFormData({
+			name: category.name,
+			description: category.description || "",
+			color: category.color,
+			isBillable: category.isBillable !== false, // Default to true if not specified
+		});
+		setIsAddingNew(true);
+	};
 
-  const handleDelete = async (categoryId: string) => {
-    if (
-      confirm(
-        'Are you sure you want to delete this category? This action cannot be undone.'
-      )
-    ) {
-      deleteCategory(categoryId);
-      // Save changes to database
-      await forceSyncToDatabase();
-    }
-  };
+	const handleDeleteConfirm = async () => {
+		if (!deleteTargetId) return;
+		deleteCategory(deleteTargetId);
+		await forceSyncToDatabase();
+		setDeleteTargetId(null);
+	};
 
-  const predefinedColors = [
-    '#3B82F6',
-    '#8B5CF6',
-    '#10B981',
-    '#F59E0B',
-    '#EF4444',
-    '#06B6D4',
-    '#84CC16',
-    '#F97316',
-    '#6B7280',
-    '#EC4899'
-  ];
+	const predefinedColors = [
+		"#3B82F6",
+		"#8B5CF6",
+		"#10B981",
+		"#F59E0B",
+		"#EF4444",
+		"#06B6D4",
+		"#84CC16",
+		"#F97316",
+		"#6B7280",
+		"#EC4899",
+	];
 
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
-      {/* Navigation Header */}
-      <SiteNavigationMenu />
-      {/* Main Content */}
-      <div className="max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
-        <div className="flex items-center justify-between">
-          <h1 className="md:text-2xl font-bold text-gray-900 flex items-center space-x-1">
-            <TagIcon className="w-6 h-6 mr-1" />
-            Categories
-            <span>({categories.length})</span>
-          </h1>
-          {/* Add New Category Button */}
-          {!isAddingNew && (
-            <Button onClick={() => setIsAddingNew(true)} variant="default">
-              <Plus className="w-4 h-4" />
-              Add Category
-            </Button>
-          )}
-          {isAddingNew && (
-            <>
-              <Button
-                onClick={() => setIsAddingNew(true)}
-                variant="default"
-                disabled
-              >
-                <Plus className="w-4 h-4 sm:mr-2" />
-                <span className="hidden sm:block">Add Category</span>
-              </Button>
-            </>
-          )}
-        </div>
-      </div>
-      {/* Add/Edit Project Form */}
-      {isAddingNew && (
-        <div className="max-w-6xl mx-auto p-6 print:p-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>
-                {editingCategory ? 'Edit Category' : 'Add Category'}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <form onSubmit={handleSubmit} className="space-y-4">
-                <div>
-                  <Label htmlFor="name">
-                    Category Name <span className="text-red-700">*</span>
-                  </Label>
-                  <Input
-                    id="name"
-                    value={formData.name}
-                    onChange={(e) =>
-                      setFormData((prev) => ({ ...prev, name: e.target.value }))
-                    }
-                    placeholder="Enter category name"
-                    required
-                  />
-                </div>
+	return (
+		<div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
+			{/* Navigation Header */}
+			<SiteNavigationMenu />
+			{/* Main Content */}
+			<div className="max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
+				<div className="flex items-center justify-between">
+					<h1 className="md:text-2xl font-bold text-gray-900 flex items-center space-x-1">
+						<TagIcon className="w-6 h-6 mr-1" />
+						Categories
+						<span>({categories.length})</span>
+					</h1>
+					{/* Add New Category Button */}
+					{!isAddingNew && (
+						<Button onClick={() => setIsAddingNew(true)} variant="default">
+							<Plus className="w-4 h-4" />
+							Add Category
+						</Button>
+					)}
+					{isAddingNew && (
+						<>
+							<Button
+								onClick={() => setIsAddingNew(true)}
+								variant="default"
+								disabled
+							>
+								<Plus className="w-4 h-4 sm:mr-2" />
+								<span className="hidden sm:block">Add Category</span>
+							</Button>
+						</>
+					)}
+				</div>
+			</div>
+			{/* Add/Edit Project Form */}
+			{isAddingNew && (
+				<div className="max-w-6xl mx-auto p-6 print:p-4">
+					<Card>
+						<CardHeader>
+							<CardTitle>
+								{editingCategory ? "Edit Category" : "Add Category"}
+							</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<form onSubmit={handleSubmit} className="space-y-4">
+								<div>
+									<Label htmlFor="name">
+										Category Name <span className="text-red-700">*</span>
+									</Label>
+									<Input
+										id="name"
+										value={formData.name}
+										onChange={(e) =>
+											setFormData((prev) => ({ ...prev, name: e.target.value }))
+										}
+										placeholder="Enter category name"
+										required
+									/>
+								</div>
 
-                <div>
-                  <Label htmlFor="description">Description</Label>
-                  <Textarea
-                    id="description"
-                    value={formData.description}
-                    onChange={(e) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        description: e.target.value
-                      }))
-                    }
-                    placeholder="Enter category description"
-                    className="min-h-[80px] resize-none"
-                  />
-                </div>
+								<div>
+									<Label htmlFor="description">Description</Label>
+									<Textarea
+										id="description"
+										value={formData.description}
+										onChange={(e) =>
+											setFormData((prev) => ({
+												...prev,
+												description: e.target.value,
+											}))
+										}
+										placeholder="Enter category description"
+										className="min-h-[80px] resize-none"
+									/>
+								</div>
 
-                <div>
-                  <Label htmlFor="color">Category Color</Label>
-                  <div className="space-y-3">
-                    <div className="flex items-center space-x-2">
-                      <Input
-                        id="color"
-                        type="color"
-                        value={formData.color}
-                        onChange={(e) =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            color: e.target.value
-                          }))
-                        }
-                        className="w-8 h-8 rounded-full"
-                        style={{ backgroundColor: formData.color }}
-                      />
-                    </div>
+								<div>
+									<Label htmlFor="color">Category Color</Label>
+									<div className="space-y-3">
+										<div className="flex items-center space-x-2">
+											<Input
+												id="color"
+												type="color"
+												value={formData.color}
+												onChange={(e) =>
+													setFormData((prev) => ({
+														...prev,
+														color: e.target.value,
+													}))
+												}
+												className="w-8 h-8 rounded-full"
+												style={{ backgroundColor: formData.color }}
+											/>
+										</div>
 
-                    {/* Predefined Colors */}
-                    <div className="flex flex-wrap gap-2">
-                      <span className="text-sm text-gray-600 w-full">
-                        Quick colors:
-                      </span>
-                      {predefinedColors.map((color) => (
-                        <button
-                          key={color}
-                          type="button"
-                          onClick={() =>
-                            setFormData((prev) => ({ ...prev, color }))
-                          }
-                          className={`w-6 h-6 rounded-full border-2 hover:scale-110 transition-transform ${formData.color === color
-                              ? 'border-gray-800'
-                              : 'border-gray-300'
-                            }`}
-                          style={{ backgroundColor: color }}
-                        />
-                      ))}
-                    </div>
-                  </div>
-                </div>
+										{/* Predefined Colors */}
+										<div className="flex flex-wrap gap-2">
+											<span className="text-sm text-gray-600 w-full">
+												Quick colors:
+											</span>
+											{predefinedColors.map((color) => (
+												<button
+													key={color}
+													type="button"
+													onClick={() =>
+														setFormData((prev) => ({ ...prev, color }))
+													}
+													className={`w-6 h-6 rounded-full border-2 hover:scale-110 transition-transform ${formData.color === color
+														? "border-gray-800"
+														: "border-gray-300"
+														}`}
+													style={{ backgroundColor: color }}
+												/>
+											))}
+										</div>
+									</div>
+								</div>
 
-                <div className="flex items-center space-x-2">
-                  <Checkbox
-                    id="billable"
-                    checked={formData.isBillable}
-                    onCheckedChange={(checked) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        isBillable: checked === true
-                      }))
-                    }
-                  />
-                  <Label htmlFor="billable" className="text-sm font-medium">
-                    Billable category
-                  </Label>
-                  <span className="text-xs text-gray-500">
-                    (Tasks in this category can generate revenue)
-                  </span>
-                </div>
+								<div className="flex items-center space-x-2">
+									<Checkbox
+										id="billable"
+										checked={formData.isBillable}
+										onCheckedChange={(checked) =>
+											setFormData((prev) => ({
+												...prev,
+												isBillable: checked === true,
+											}))
+										}
+									/>
+									<Label htmlFor="billable" className="text-sm font-medium">
+										Billable category
+									</Label>
+									<span className="text-xs text-gray-500">
+										(Tasks in this category can generate revenue)
+									</span>
+								</div>
 
-                <div className="flex space-x-2">
-                  <Button type="button" variant="ghost" onClick={resetForm}>
-                    Cancel
-                  </Button>
-                  <Button type="submit">
-                    {editingCategory ? 'Update' : 'Add'}
-                  </Button>
-                </div>
-              </form>
-            </CardContent>
-          </Card>
-        </div>
-      )}
-      <div className="max-w-6xl mx-auto p-6 print:p-4">
-        {/* Categories List */}
-        <div className="space-y-4">
-          {categories.length === 0 ? (
-            <Card>
-              <CardContent className="text-center py-8">
-                <Tag className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                <p className="text-gray-600">
-                  No categories yet. Add your first category to get started!
-                </p>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className="grid gap-4">
-              {categories.map((category) => (
-                <Card
-                  key={category.id}
-                  className="border-l-4"
-                  style={{ borderLeftColor: category.color }}
-                >
-                  <CardContent className="p-4">
-                    <div className="flex items-center justify-between">
-                      <div className="flex-1">
-                        <div className="flex items-center space-x-3">
-                          <div
-                            className="w-4 h-4 rounded-full"
-                            style={{ backgroundColor: category.color }}
-                          />
-                          <div>
-                            <div className="flex items-center space-x-2">
-                              <h4 className="font-semibold text-gray-900">
-                                {category.name}
-                              </h4>
-                              <span className={`px-2 py-1 text-xs rounded-full ${category.isBillable !== false
-                                  ? 'bg-green-100 text-green-800'
-                                  : 'bg-gray-100 text-gray-800'
-                                }`}>
-                                {category.isBillable !== false ? 'Billable' : 'Non-billable'}
-                              </span>
-                            </div>
-                            {category.description && (
-                              <p className="text-sm text-gray-600 mt-1">
-                                {category.description}
-                              </p>
-                            )}
-                          </div>
-                        </div>
-                      </div>
+								<div className="flex space-x-2">
+									<Button type="button" variant="ghost" onClick={resetForm}>
+										Cancel
+									</Button>
+									<Button type="submit">
+										{editingCategory ? "Update" : "Add"}
+									</Button>
+								</div>
+							</form>
+						</CardContent>
+					</Card>
+				</div>
+			)}
+			<div className="max-w-6xl mx-auto p-6 print:p-4">
+				{/* Categories List */}
+				<div className="space-y-4">
+					{categories.length === 0 ? (
+						<Card>
+							<CardContent className="text-center py-8">
+								<Tag className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+								<p className="text-gray-600">
+									No categories yet. Add your first category to get started!
+								</p>
+							</CardContent>
+						</Card>
+					) : (
+						<div className="grid gap-4">
+							{categories.map((category) => (
+								<Card
+									key={category.id}
+									className="border-l-4"
+									style={{ borderLeftColor: category.color }}
+								>
+									<CardContent className="p-4">
+										<div className="flex items-center justify-between">
+											<div className="flex-1">
+												<div className="flex items-center space-x-3">
+													<div
+														className="w-4 h-4 rounded-full"
+														style={{ backgroundColor: category.color }}
+													/>
+													<div>
+														<div className="flex items-center space-x-2">
+															<h4 className="font-semibold text-gray-900">
+																{category.name}
+															</h4>
+															<span className={`px-2 py-1 text-xs rounded-full ${category.isBillable !== false
+																? "bg-green-100 text-green-800"
+																: "bg-gray-100 text-gray-800"
+																}`}>
+																{category.isBillable !== false ? "Billable" : "Non-billable"}
+															</span>
+														</div>
+														{category.description && (
+															<p className="text-sm text-gray-600 mt-1">
+																{category.description}
+															</p>
+														)}
+													</div>
+												</div>
+											</div>
 
-                      <div className="flex space-x-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleEdit(category)}
-                        >
-                          <Edit className="w-3 h-3" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleDelete(category.id)}
-                          className="text-red-600 hover:text-red-700"
-                        >
-                          <Trash2 className="w-3 h-3" />
-                        </Button>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
+											<div className="flex space-x-2">
+												<Button
+													size="sm"
+													variant="outline"
+													onClick={() => handleEdit(category)}
+												>
+													<Edit className="w-3 h-3" />
+												</Button>
+												<Button
+													size="sm"
+													variant="outline"
+													onClick={() => setDeleteTargetId(category.id)}
+													className="text-red-600 hover:text-red-700"
+												>
+													<Trash2 className="w-3 h-3" />
+												</Button>
+											</div>
+										</div>
+									</CardContent>
+								</Card>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
+			<AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => !open && setDeleteTargetId(null)}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete this category?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This action cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleDeleteConfirm}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
 };
 
 const Categories: React.FC = () => {
-  return (
-    <CategoryContent />
-  );
+	return (
+		<CategoryContent />
+	);
 };
 
 export default Categories;

--- a/src/pages/ProjectList.tsx
+++ b/src/pages/ProjectList.tsx
@@ -1,364 +1,410 @@
-import React, { useState } from 'react';
-import { TimeTrackingProvider, Project } from '@/contexts/TimeTrackingContext';
-import { useTimeTracking } from '@/hooks/useTimeTracking';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Edit, Briefcase, Trash2, RotateCcw, Plus } from 'lucide-react';
-import SiteNavigationMenu from '@/components/Navigation';
-import { Badge } from '@radix-ui/themes';
+import React, { useState } from "react";
+import { TimeTrackingProvider, Project } from "@/contexts/TimeTrackingContext";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Edit, Briefcase, Trash2, RotateCcw, Plus } from "lucide-react";
+import SiteNavigationMenu from "@/components/Navigation";
+import { Badge } from "@radix-ui/themes";
 
 const ProjectContent: React.FC = () => {
-  const {
-    projects,
-    addProject,
-    updateProject,
-    deleteProject,
-    resetProjectsToDefaults,
-    forceSyncToDatabase
-  } = useTimeTracking();
-  const [editingProject, setEditingProject] = useState<Project | null>(null);
-  const [isAddingNew, setIsAddingNew] = useState(false);
-  const [formData, setFormData] = useState({
-    name: '',
-    client: '',
-    hourlyRate: '',
-    color: '#3B82F6',
-    isBillable: true
-  });
+	const {
+		projects,
+		addProject,
+		updateProject,
+		deleteProject,
+		resetProjectsToDefaults,
+		forceSyncToDatabase,
+	} = useTimeTracking();
+	const [editingProject, setEditingProject] = useState<Project | null>(null);
+	const [isAddingNew, setIsAddingNew] = useState(false);
+	const [formData, setFormData] = useState({
+		name: "",
+		client: "",
+		hourlyRate: "",
+		color: "#3B82F6",
+		isBillable: true,
+	});
+	const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+	const [showResetDialog, setShowResetDialog] = useState(false);
 
-  const resetForm = () => {
-    setFormData({
-      name: '',
-      client: '',
-      hourlyRate: '',
-      color: '#3B82F6',
-      isBillable: true
-    });
-    setEditingProject(null);
-    setIsAddingNew(false);
-  };
+	const resetForm = () => {
+		setFormData({
+			name: "",
+			client: "",
+			hourlyRate: "",
+			color: "#3B82F6",
+			isBillable: true,
+		});
+		setEditingProject(null);
+		setIsAddingNew(false);
+	};
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
 
-    const projectData = {
-      name: formData.name.trim(),
-      client: formData.client.trim(),
-      hourlyRate: formData.hourlyRate
-        ? parseFloat(formData.hourlyRate)
-        : undefined,
-      color: formData.color,
-      isBillable: formData.isBillable
-    };
+		const projectData = {
+			name: formData.name.trim(),
+			client: formData.client.trim(),
+			hourlyRate: formData.hourlyRate
+				? parseFloat(formData.hourlyRate)
+				: undefined,
+			color: formData.color,
+			isBillable: formData.isBillable,
+		};
 
-    if (editingProject) {
-      updateProject(editingProject.id, projectData);
-    } else {
-      addProject(projectData);
-    }
+		if (editingProject) {
+			updateProject(editingProject.id, projectData);
+		} else {
+			addProject(projectData);
+		}
 
-    // Save changes to database
-    await forceSyncToDatabase();
+		// Save changes to database
+		await forceSyncToDatabase();
 
-    resetForm();
-  };
+		resetForm();
+	};
 
-  const handleEdit = (project: Project) => {
-    setEditingProject(project);
-    setFormData({
-      name: project.name,
-      client: project.client,
-      hourlyRate: project.hourlyRate?.toString() || '',
-      color: project.color || '#3B82F6',
-      isBillable: project.isBillable !== false // Default to true if not specified
-    });
-    setIsAddingNew(true);
-  };
+	const handleEdit = (project: Project) => {
+		setEditingProject(project);
+		setFormData({
+			name: project.name,
+			client: project.client,
+			hourlyRate: project.hourlyRate?.toString() || "",
+			color: project.color || "#3B82F6",
+			isBillable: project.isBillable !== false, // Default to true if not specified
+		});
+		setIsAddingNew(true);
+	};
 
-  const handleDelete = async (projectId: string) => {
-    if (confirm('Are you sure you want to delete this project?')) {
-      deleteProject(projectId);
-      // Save changes to database
-      await forceSyncToDatabase();
-    }
-  };
+	const handleDeleteConfirm = async () => {
+		if (!deleteTargetId) return;
+		deleteProject(deleteTargetId);
+		await forceSyncToDatabase();
+		setDeleteTargetId(null);
+	};
 
-  const handleResetToDefaults = () => {
-    if (
-      confirm(
-        "Are you sure you want to reset all projects to defaults? This will remove any custom projects you've added."
-      )
-    ) {
-      resetProjectsToDefaults();
-    }
-  };
+	const handleResetConfirm = () => {
+		resetProjectsToDefaults();
+		setShowResetDialog(false);
+	};
 
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
-      {/* Navigation Header */}
-      <SiteNavigationMenu />
-      {/* Main Content */}
-      <div className="max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
-        <div className="flex items-center justify-between">
-          <h1 className="md:text-2xl font-bold text-gray-900 flex items-center space-x-1">
-            <Briefcase className="w-6 h-6 mr-1" />
-            Project List
-            <span>({projects.length})</span>
-          </h1>
-          <div className="flex space-x-2 print:hidden">
-            {!isAddingNew && (
-              <>
-                <Button
-                  onClick={handleResetToDefaults}
-                  variant="outline"
-                  className="w-full"
-                >
-                  <RotateCcw className="w-4 h-4 sm:mr-2" />
-                  Reset to Defaults
-                </Button>
-                <Button onClick={() => setIsAddingNew(true)} className="w-full">
-                  <Plus className="w-4 h-4 sm:mr-2" />
-                  Add Project
-                </Button>
-              </>
-            )}
-            {isAddingNew && (
-              <>
-                <Button
-                  onClick={handleResetToDefaults}
-                  variant="outline"
-                  className="w-full"
-                  disabled
-                >
-                  <RotateCcw className="w-4 h-4 sm:mr-2" />
-                  <span className="hidden sm:block">Reset to Defaults</span>
-                </Button>
-                <Button
-                  onClick={() => setIsAddingNew(true)}
-                  className="w-full"
-                  disabled
-                >
-                  <Plus className="w-4 h-4 sm:mr-2" />
-                  <span className="hidden sm:block">Add Project</span>
-                </Button>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
-      {/* Add/Edit Project Form */}
-      {isAddingNew && (
-        <div className="max-w-6xl mx-auto p-6 print:p-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>
-                {editingProject ? 'Edit Project' : 'Add New Project'}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <form onSubmit={handleSubmit} className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="name">
-                      Project Name <span className="text-red-700">*</span>
-                    </Label>
-                    <Input
-                      id="name"
-                      value={formData.name}
-                      onChange={(e) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          name: e.target.value
-                        }))
-                      }
-                      placeholder="Enter project name"
-                      required
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor="client">
-                      Client Name <span className="text-red-700">*</span>
-                    </Label>
-                    <Input
-                      id="client"
-                      value={formData.client}
-                      onChange={(e) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          client: e.target.value
-                        }))
-                      }
-                      placeholder="Enter client name"
-                      required
-                    />
-                  </div>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="hourlyRate">Hourly Rate ($)</Label>
-                    <Input
-                      id="hourlyRate"
-                      type="number"
-                      step="01.00"
-                      value={formData.hourlyRate}
-                      onChange={(e) =>
-                        setFormData((prev) => ({
-                          ...prev,
-                          hourlyRate: e.target.value
-                        }))
-                      }
-                      placeholder="0.00"
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor="color">Project Color</Label>
-                    <div className="flex items-center space-x-2">
-                      <Input
-                        id="color"
-                        type="color"
-                        value={formData.color}
-                        onChange={(e) =>
-                          setFormData((prev) => ({
-                            ...prev,
-                            color: e.target.value
-                          }))
-                        }
-                        className="w-16 h-10"
-                      />
-                      <span className="text-sm text-gray-500">
-                        {formData.color}
-                      </span>
-                    </div>
-                  </div>
-                </div>
+	return (
+		<div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
+			{/* Navigation Header */}
+			<SiteNavigationMenu />
+			{/* Main Content */}
+			<div className="max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
+				<div className="flex items-center justify-between">
+					<h1 className="md:text-2xl font-bold text-gray-900 flex items-center space-x-1">
+						<Briefcase className="w-6 h-6 mr-1" />
+						Project List
+						<span>({projects.length})</span>
+					</h1>
+					<div className="flex space-x-2 print:hidden">
+						{!isAddingNew && (
+							<>
+								<Button
+									onClick={() => setShowResetDialog(true)}
+									variant="outline"
+									className="w-full"
+								>
+									<RotateCcw className="w-4 h-4 sm:mr-2" />
+									Reset to Defaults
+								</Button>
+								<Button onClick={() => setIsAddingNew(true)} className="w-full">
+									<Plus className="w-4 h-4 sm:mr-2" />
+									Add Project
+								</Button>
+							</>
+						)}
+						{isAddingNew && (
+							<>
+								<Button
+									onClick={() => setShowResetDialog(true)}
+									variant="outline"
+									className="w-full"
+									disabled
+								>
+									<RotateCcw className="w-4 h-4 sm:mr-2" />
+									<span className="hidden sm:block">Reset to Defaults</span>
+								</Button>
+								<Button
+									onClick={() => setIsAddingNew(true)}
+									className="w-full"
+									disabled
+								>
+									<Plus className="w-4 h-4 sm:mr-2" />
+									<span className="hidden sm:block">Add Project</span>
+								</Button>
+							</>
+						)}
+					</div>
+				</div>
+			</div>
+			{/* Add/Edit Project Form */}
+			{isAddingNew && (
+				<div className="max-w-6xl mx-auto p-6 print:p-4">
+					<Card>
+						<CardHeader>
+							<CardTitle>
+								{editingProject ? "Edit Project" : "Add New Project"}
+							</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<form onSubmit={handleSubmit} className="space-y-4">
+								<div className="grid grid-cols-2 gap-4">
+									<div>
+										<Label htmlFor="name">
+											Project Name <span className="text-red-700">*</span>
+										</Label>
+										<Input
+											id="name"
+											value={formData.name}
+											onChange={(e) =>
+												setFormData((prev) => ({
+													...prev,
+													name: e.target.value,
+												}))
+											}
+											placeholder="Enter project name"
+											required
+										/>
+									</div>
+									<div>
+										<Label htmlFor="client">
+											Client Name <span className="text-red-700">*</span>
+										</Label>
+										<Input
+											id="client"
+											value={formData.client}
+											onChange={(e) =>
+												setFormData((prev) => ({
+													...prev,
+													client: e.target.value,
+												}))
+											}
+											placeholder="Enter client name"
+											required
+										/>
+									</div>
+								</div>
+								<div className="grid grid-cols-2 gap-4">
+									<div>
+										<Label htmlFor="hourlyRate">Hourly Rate ($)</Label>
+										<Input
+											id="hourlyRate"
+											type="number"
+											step="01.00"
+											value={formData.hourlyRate}
+											onChange={(e) =>
+												setFormData((prev) => ({
+													...prev,
+													hourlyRate: e.target.value,
+												}))
+											}
+											placeholder="0.00"
+										/>
+									</div>
+									<div>
+										<Label htmlFor="color">Project Color</Label>
+										<div className="flex items-center space-x-2">
+											<Input
+												id="color"
+												type="color"
+												value={formData.color}
+												onChange={(e) =>
+													setFormData((prev) => ({
+														...prev,
+														color: e.target.value,
+													}))
+												}
+												className="w-16 h-10"
+											/>
+											<span className="text-sm text-gray-500">
+												{formData.color}
+											</span>
+										</div>
+									</div>
+								</div>
 
-                <div className="flex items-center space-x-2">
-                  <Checkbox
-                    id="billable"
-                    checked={formData.isBillable}
-                    onCheckedChange={(checked) =>
-                      setFormData((prev) => ({
-                        ...prev,
-                        isBillable: checked === true
-                      }))
-                    }
-                  />
-                  <Label htmlFor="billable" className="text-sm font-medium">
-                    Billable project
-                  </Label>
-                  <span className="text-xs text-gray-500">
-                    (Tasks in this project can generate revenue)
-                  </span>
-                </div>
+								<div className="flex items-center space-x-2">
+									<Checkbox
+										id="billable"
+										checked={formData.isBillable}
+										onCheckedChange={(checked) =>
+											setFormData((prev) => ({
+												...prev,
+												isBillable: checked === true,
+											}))
+										}
+									/>
+									<Label htmlFor="billable" className="text-sm font-medium">
+										Billable project
+									</Label>
+									<span className="text-xs text-gray-500">
+										(Tasks in this project can generate revenue)
+									</span>
+								</div>
 
-                <div className="flex space-x-2">
-                  <Button type="button" variant="ghost" onClick={resetForm}>
-                    Cancel
-                  </Button>
-                  <Button type="submit" variant="default">
-                    {editingProject ? 'Update Project' : 'Add Project'}
-                  </Button>
-                </div>
-              </form>
-            </CardContent>
-          </Card>
-        </div>
-      )}
-      <div className="max-w-6xl mx-auto p-6 print:p-4">
-        {/* Projects List */}
-        <div className="space-y-6">
-          {projects.length === 0 ? (
-            <Card>
-              <CardContent className="text-center py-8">
-                <Briefcase className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                <p className="text-gray-600">
-                  No projects yet. Add your first project to get started!
-                </p>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className="grid gap-4">
-              {projects.map((project) => (
-                <Card
-                  key={project.id}
-                  className="border-l-4"
-                  style={{ borderLeftColor: project.color }}
-                >
-                  <CardContent className="p-4">
-                    <div className="flex items-center justify-between">
-                      <div className="flex-1">
-                        <div className="flex items-center space-x-3">
-                          <div
-                            className="w-4 h-4 rounded-full"
-                            style={{ backgroundColor: project.color }}
-                          />
-                          <div>
-                            <div className="flex items-center space-x-2">
-                              <h4 className="font-semibold text-gray-900">
-                                {project.name}
-                              </h4>
-                              {project.id.startsWith('default-') && (
-                                <Badge variant="surface" color="blue">
-                                  Default
-                                </Badge>
-                              )}
-                              {project.isBillable !== false ? (
-                                <Badge variant="surface" color="green">
-                                  Billable
-                                </Badge>
-                              ) : (
-                                <Badge variant="surface" color="gray">
-                                  Non-billable
-                                </Badge>
-                              )}
-                            </div>
-                            <p className="text-sm text-gray-600">
-                              {project.client}
-                            </p>
-                            {project.hourlyRate && (
-                              <p className="text-sm text-green-600 font-medium">
-                                ${project.hourlyRate}/hour
-                              </p>
-                            )}
-                          </div>
-                        </div>
-                      </div>
-                      <div className="flex space-x-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleEdit(project)}
-                        >
-                          <Edit className="w-3 h-3" />
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleDelete(project.id)}
-                          className="text-red-600 hover:text-red-700"
-                        >
-                          <Trash2 className="w-3 h-3" />
-                        </Button>
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
+								<div className="flex space-x-2">
+									<Button type="button" variant="ghost" onClick={resetForm}>
+										Cancel
+									</Button>
+									<Button type="submit" variant="default">
+										{editingProject ? "Update Project" : "Add Project"}
+									</Button>
+								</div>
+							</form>
+						</CardContent>
+					</Card>
+				</div>
+			)}
+			<div className="max-w-6xl mx-auto p-6 print:p-4">
+				{/* Projects List */}
+				<div className="space-y-6">
+					{projects.length === 0 ? (
+						<Card>
+							<CardContent className="text-center py-8">
+								<Briefcase className="w-12 h-12 text-gray-400 mx-auto mb-4" />
+								<p className="text-gray-600">
+									No projects yet. Add your first project to get started!
+								</p>
+							</CardContent>
+						</Card>
+					) : (
+						<div className="grid gap-4">
+							{projects.map((project) => (
+								<Card
+									key={project.id}
+									className="border-l-4"
+									style={{ borderLeftColor: project.color }}
+								>
+									<CardContent className="p-4">
+										<div className="flex items-center justify-between">
+											<div className="flex-1">
+												<div className="flex items-center space-x-3">
+													<div
+														className="w-4 h-4 rounded-full"
+														style={{ backgroundColor: project.color }}
+													/>
+													<div>
+														<div className="flex items-center space-x-2">
+															<h4 className="font-semibold text-gray-900">
+																{project.name}
+															</h4>
+															{project.id.startsWith("default-") && (
+																<Badge variant="surface" color="blue">
+																	Default
+																</Badge>
+															)}
+															{project.isBillable !== false ? (
+																<Badge variant="surface" color="green">
+																	Billable
+																</Badge>
+															) : (
+																<Badge variant="surface" color="gray">
+																	Non-billable
+																</Badge>
+															)}
+														</div>
+														<p className="text-sm text-gray-600">
+															{project.client}
+														</p>
+														{project.hourlyRate && (
+															<p className="text-sm text-green-600 font-medium">
+																${project.hourlyRate}/hour
+															</p>
+														)}
+													</div>
+												</div>
+											</div>
+											<div className="flex space-x-2">
+												<Button
+													size="sm"
+													variant="outline"
+													onClick={() => handleEdit(project)}
+												>
+													<Edit className="w-3 h-3" />
+												</Button>
+												<Button
+													size="sm"
+													variant="outline"
+													onClick={() => setDeleteTargetId(project.id)}
+													className="text-red-600 hover:text-red-700"
+												>
+													<Trash2 className="w-3 h-3" />
+												</Button>
+											</div>
+										</div>
+									</CardContent>
+								</Card>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
+
+			<AlertDialog open={deleteTargetId !== null} onOpenChange={(open) => !open && setDeleteTargetId(null)}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete this project?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This action cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleDeleteConfirm}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+
+			<AlertDialog open={showResetDialog} onOpenChange={setShowResetDialog}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Reset projects to defaults?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This will remove any custom projects you've added. This action cannot be undone.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleResetConfirm}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Reset
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
 };
 
 const ProjectList: React.FC = () => {
-  return (
-    <ProjectContent />
-  );
+	return (
+		<ProjectContent />
+	);
 };
 
 export default ProjectList;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,233 +1,250 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { ExportDialog } from '@/components/ExportDialog';
 import {
-  Briefcase,
-  Tag,
-  Download,
-  Database,
-  Trash2,
-  CogIcon
+	Briefcase,
+	Tag,
+	Download,
+	Database,
+	Trash2,
+	CogIcon
 } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { TimeTrackingProvider } from '@/contexts/TimeTrackingContext';
 import { useTimeTracking } from '@/hooks/useTimeTracking';
 import SiteNavigationMenu from '@/components/Navigation';
 
 const SettingsContent: React.FC = () => {
-  const { archivedDays, projects, categories } = useTimeTracking();
-  const [showExportDialog, setShowExportDialog] = useState(false);
+	const { archivedDays, projects, categories } = useTimeTracking();
+	const [showExportDialog, setShowExportDialog] = useState(false);
+	const [showClearDataDialog, setShowClearDataDialog] = useState(false);
 
-  const handleClearAllData = () => {
-    if (
-      confirm(
-        'Are you sure you want to clear ALL data? This action cannot be undone and will remove all archived days, projects, and categories.'
-      )
-    ) {
-      if (
-        confirm(
-          'This will permanently delete everything. Are you absolutely sure?'
-        )
-      ) {
-        localStorage.clear();
-        window.location.reload();
-      }
-    }
-  };
+	const handleClearAllData = () => {
+		localStorage.clear();
+		window.location.reload();
+	};
 
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-50">
-      {/* Navigation Header */}
-      <SiteNavigationMenu />
-      {/* Main Content */}
-      <div className="max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
-        <div className="flex items-center justify-between">
-          <h1 className="md:text-2xl font-bold text-gray-900 flex items-center space-x-1">
-            <CogIcon className="w-6 h-6 mr-1" />
-            <span>Settings</span>
-          </h1>
-        </div>
-      </div>
-      <div className="max-w-6xl mx-auto p-6">
-        <div className="grid gap-6">
-          {/* Overview Stats */}
-          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 print:hidden">
-            <Card>
-              <CardContent className="p-4">
-                <div className="text-2xl font-bold text-blue-600">
-                  {archivedDays.length}
-                </div>
-                <div className="text-sm text-gray-600">Archived Days</div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="p-4">
-                <div className="text-2xl font-bold text-green-600">
-                  {projects.length}
-                </div>
-                <div className="text-sm text-gray-600">Projects</div>
-              </CardContent>
-            </Card>
-            <Card>
-              <CardContent className="p-4">
-                <div className="text-2xl font-bold text-purple-600">
-                  {categories.length}
-                </div>
-                <div className="text-sm text-gray-600">Categories</div>
-              </CardContent>
-            </Card>
-          </div>
-          {/* Management Sections */}
-          <div className="grid gap-6 md:grid-cols-2">
-            {/* Project Management */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center space-x-2">
-                  <Briefcase className="w-5 h-5" />
-                  <span>Project Management</span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-gray-600 mb-4">
-                  Manage your projects, clients, and hourly rates. Projects help
-                  organize your tasks and calculate revenue automatically.
-                </p>
-                <Link to="/projectlist">
-                  <Button variant="outline" className="w-full">
-                    <Briefcase className="w-4 h-4 mr-2" />
-                    Manage Projects
-                  </Button>
-                </Link>
-              </CardContent>
-            </Card>
-            {/* Category Management */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center space-x-2">
-                  <Tag className="w-5 h-5" />
-                  <span>Category Management</span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-gray-600 mb-4">
-                  Create and manage task categories like Development, Design,
-                  Meetings, etc. Categories help classify your work.
-                </p>
-                <Link to="/categories">
-                  <Button variant="outline" className="w-full">
-                    <Briefcase className="w-4 h-4 mr-2" />
-                    Manage Categories
-                  </Button>
-                </Link>
-              </CardContent>
-            </Card>
-            {/* Data Export */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center space-x-2">
-                  <Download className="w-5 h-5" />
-                  <span>Exports/Imports</span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-gray-600 mb-4">
-                  Export your time tracking data as CSV or JSON files. Generate invoice data for specific clients and date ranges. You can also import data from CSV files.
-                </p>
-                <Button
-                  onClick={() => setShowExportDialog(true)}
-                  variant="outline"
-                  className="w-full"
-                >
-                  <Download className="w-4 h-4 mr-2" />
-                  Data Export/Import
-                </Button>
-              </CardContent>
-            </Card>
-            {/* Data Management */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center space-x-2">
-                  <Database className="w-5 h-5" />
-                  <span>Data Management</span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-gray-600 mb-4">
-                  Manage your stored data. All data is stored locally in your
-                  browser. Use export before clearing data.
-                </p>
-                <div className="space-y-2">
-                  <Link to="/archive">
-                    <Button variant="outline" className="w-full">
-                      <Database className="w-4 h-4 mr-2" />
-                      View Archive
-                    </Button>
-                  </Link>
-                  <Button
-                    onClick={handleClearAllData}
-                    variant="outline"
-                    className="w-full text-red-600 hover:text-red-700 hover:bg-red-50"
-                  >
-                    <Trash2 className="w-4 h-4 mr-2" />
-                    Clear All Data
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-          {/* Quick Tips */}
-          <Card>
-            <CardHeader>
-              <CardTitle>Quick Tips</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid gap-4 md:grid-cols-2">
-                <div>
-                  <h4 className="font-medium text-gray-900 mb-2">
-                    Getting Started
-                  </h4>
-                  <ul className="text-sm text-gray-600 space-y-1">
-                    <li>
-                      • Set up projects with hourly rates for automatic revenue
-                      calculation
-                    </li>
-                    <li>
-                      • Create categories to classify different types of work
-                    </li>
-                    <li>• Use task descriptions for detailed work notes</li>
-                  </ul>
-                </div>
-                <div>
-                  <h4 className="font-medium text-gray-900 mb-2">
-                    Best Practices
-                  </h4>
-                  <ul className="text-sm text-gray-600 space-y-1">
-                    <li>• Export your data regularly as backup</li>
-                    <li>
-                      • Adjust task times in 15-minute intervals for accuracy
-                    </li>
-                    <li>• Use consistent project and category naming</li>
-                  </ul>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-      {/* Dialogs */}
-      <ExportDialog
-        isOpen={showExportDialog}
-        onClose={() => setShowExportDialog(false)}
-      />
-    </div>
-  );
+	return (
+		<div className="min-h-screen bg-background">
+			{/* Navigation Header */}
+			<SiteNavigationMenu />
+			{/* Main Content */}
+			<div className="max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
+				<div className="flex items-center justify-between">
+					<h1 className="md:text-2xl font-bold text-foreground flex items-center space-x-1">
+						<CogIcon className="w-6 h-6 mr-1" />
+						<span>Settings</span>
+					</h1>
+				</div>
+			</div>
+			<div className="max-w-6xl mx-auto p-6">
+				<div className="grid gap-6">
+					{/* Overview Stats */}
+					<div className="grid grid-cols-2 sm:grid-cols-3 gap-4 print:hidden">
+						<Card>
+							<CardContent className="p-4">
+								<div className="text-2xl font-bold text-primary">
+									{archivedDays.length}
+								</div>
+								<div className="text-sm text-muted-foreground">Archived Days</div>
+							</CardContent>
+						</Card>
+						<Card>
+							<CardContent className="p-4">
+								<div className="text-2xl font-bold text-primary">
+									{projects.length}
+								</div>
+								<div className="text-sm text-muted-foreground">Projects</div>
+							</CardContent>
+						</Card>
+						<Card>
+							<CardContent className="p-4">
+								<div className="text-2xl font-bold text-primary">
+									{categories.length}
+								</div>
+								<div className="text-sm text-muted-foreground">Categories</div>
+							</CardContent>
+						</Card>
+					</div>
+					{/* Management Sections */}
+					<div className="grid gap-6 md:grid-cols-2">
+						{/* Project Management */}
+						<Card>
+							<CardHeader>
+								<CardTitle className="flex items-center space-x-2">
+									<Briefcase className="w-5 h-5" />
+									<span>Project Management</span>
+								</CardTitle>
+							</CardHeader>
+							<CardContent>
+								<p className="text-muted-foreground mb-4">
+									Manage your projects, clients, and hourly rates. Projects help
+									organize your tasks and calculate revenue automatically.
+								</p>
+								<Link to="/projectlist">
+									<Button variant="outline" className="w-full">
+										<Briefcase className="w-4 h-4 mr-2" />
+										Manage Projects
+									</Button>
+								</Link>
+							</CardContent>
+						</Card>
+						{/* Category Management */}
+						<Card>
+							<CardHeader>
+								<CardTitle className="flex items-center space-x-2">
+									<Tag className="w-5 h-5" />
+									<span>Category Management</span>
+								</CardTitle>
+							</CardHeader>
+							<CardContent>
+								<p className="text-muted-foreground mb-4">
+									Create and manage task categories like Development, Design,
+									Meetings, etc. Categories help classify your work.
+								</p>
+								<Link to="/categories">
+									<Button variant="outline" className="w-full">
+										<Briefcase className="w-4 h-4 mr-2" />
+										Manage Categories
+									</Button>
+								</Link>
+							</CardContent>
+						</Card>
+						{/* Data Export */}
+						<Card>
+							<CardHeader>
+								<CardTitle className="flex items-center space-x-2">
+									<Download className="w-5 h-5" />
+									<span>Exports/Imports</span>
+								</CardTitle>
+							</CardHeader>
+							<CardContent>
+								<p className="text-muted-foreground mb-4">
+									Export your time tracking data as CSV or JSON files. Generate invoice data for specific clients and date ranges. You can also import data from CSV files.
+								</p>
+								<Button
+									onClick={() => setShowExportDialog(true)}
+									variant="outline"
+									className="w-full"
+								>
+									<Download className="w-4 h-4 mr-2" />
+									Data Export/Import
+								</Button>
+							</CardContent>
+						</Card>
+						{/* Data Management */}
+						<Card>
+							<CardHeader>
+								<CardTitle className="flex items-center space-x-2">
+									<Database className="w-5 h-5" />
+									<span>Data Management</span>
+								</CardTitle>
+							</CardHeader>
+							<CardContent>
+								<p className="text-muted-foreground mb-4">
+									Manage your stored data. All data is stored locally in your
+									browser. Use export before clearing data.
+								</p>
+								<div className="space-y-2">
+									<Link to="/archive">
+										<Button variant="outline" className="w-full">
+											<Database className="w-4 h-4 mr-2" />
+											View Archive
+										</Button>
+									</Link>
+									<Button
+										onClick={() => setShowClearDataDialog(true)}
+										variant="outline"
+										className="w-full text-destructive hover:text-destructive hover:bg-destructive/10"
+									>
+										<Trash2 className="w-4 h-4 mr-2" />
+										Clear All Data
+									</Button>
+								</div>
+							</CardContent>
+						</Card>
+					</div>
+					{/* Quick Tips */}
+					<Card>
+						<CardHeader>
+							<CardTitle>Quick Tips</CardTitle>
+						</CardHeader>
+						<CardContent>
+							<div className="grid gap-4 md:grid-cols-2">
+								<div>
+									<h4 className="font-medium text-foreground mb-2">
+										Getting Started
+									</h4>
+									<ul className="text-sm text-muted-foreground space-y-1">
+										<li>
+											• Set up projects with hourly rates for automatic revenue
+											calculation
+										</li>
+										<li>
+											• Create categories to classify different types of work
+										</li>
+										<li>• Use task descriptions for detailed work notes</li>
+									</ul>
+								</div>
+								<div>
+									<h4 className="font-medium text-foreground mb-2">
+										Best Practices
+									</h4>
+									<ul className="text-sm text-muted-foreground space-y-1">
+										<li>• Export your data regularly as backup</li>
+										<li>
+											• Adjust task times in 15-minute intervals for accuracy
+										</li>
+										<li>• Use consistent project and category naming</li>
+									</ul>
+								</div>
+							</div>
+						</CardContent>
+					</Card>
+				</div>
+			</div>
+
+			{/* Dialogs */}
+			<ExportDialog
+				isOpen={showExportDialog}
+				onClose={() => setShowExportDialog(false)}
+			/>
+			<AlertDialog open={showClearDataDialog} onOpenChange={setShowClearDataDialog}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Clear all data?</AlertDialogTitle>
+						<AlertDialogDescription>
+							This will permanently delete all archived days, projects, and categories.
+							This action cannot be undone. Export your data first if you want a backup.
+						</AlertDialogDescription>
+					</AlertDialogHeader>
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							onClick={handleClearAllData}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Delete everything
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</div>
+	);
 };
 
 const Settings: React.FC = () => {
-  return (
-    <SettingsContent />
-  );
+	return <SettingsContent />;
 };
 
 export default Settings;


### PR DESCRIPTION
## Summary

- Replaced all 10 native `confirm()` calls across 7 files with shadcn/ui `AlertDialog` — eliminates browser dialogs that block the main thread, can't be styled, and fail accessibility standards
- Replaced `alert()` in `ArchiveEditDialog` with `toast()` (destructive variant)
- Standardized hardcoded Tailwind color classes in `Settings.tsx` to Radix theme variables (`text-foreground`, `text-muted-foreground`, `text-primary`, `bg-background`, `text-destructive`)
- Fixed `border-gray-900` on the `PageLoader` spinner to `border-primary`
- Converted all single-quoted imports to double quotes in modified files (linter-enforced project requirement)

## Files Changed

| File | Change |
|---|---|
| `src/App.tsx` | Spinner color + import quote fix |
| `src/pages/Settings.tsx` | AlertDialog + full color sweep |
| `src/components/CategoryManagement.tsx` | AlertDialog for delete |
| `src/components/ProjectManagement.tsx` | AlertDialog for delete + reset |
| `src/components/ArchiveItem.tsx` | AlertDialog for restore |
| `src/components/ArchiveEditDialog.tsx` | AlertDialog for restore + toast for save failure |
| `src/pages/ProjectList.tsx` | AlertDialog for delete + reset |
| `src/pages/Categories.tsx` | AlertDialog for delete |

## Test Plan

- [x] 41/41 unit tests passing (`npm test -- --run`)
- [x] Lint and build clean (`npm run lint && npm run build`)
- [x] Manually verify: delete a project → AlertDialog appears → Cancel does nothing, Delete removes it
- [x] Manually verify: delete a category → AlertDialog appears → same flow
- [x] Manually verify: Settings → Clear All Data → AlertDialog with strong warning → Cancel safe, Delete everything clears data
- [x] Manually verify: Archive → Restore a day when one is active → AlertDialog warns about replacement
- [x] Verify no `confirm()` dialogs appear anywhere in the app