### PR TITLE
[codex] automate NAS auto-time full loop

### DIFF
--- a/deploy/auto-time/.env.auto-time.prod.example
+++ b/deploy/auto-time/.env.auto-time.prod.example
@@ -1,0 +1,8 @@
+# Server-side only. Do not expose these values to any Vite or frontend env file.
+SA_TIME_SUPABASE_URL=http://192.168.1.111:8000
+SA_TIME_SUPABASE_SERVICE_ROLE_KEY=__FILL_ON_SERVER__
+SA_TIME_ORG_ID=34e533f1-2dc1-4593-945b-009deee41d8a
+SA_TIME_TIMEZONE=Asia/Shanghai
+SA_TIME_NAS_ROOT_LOOKBACK_DAYS=7
+SA_TIME_IGNORE_WEEKENDS=true
+SA_TIME_ALLOCATION_MODE=interval_to_previous_project

--- a/deploy/auto-time/docker-compose.auto-time.yml
+++ b/deploy/auto-time/docker-compose.auto-time.yml
@@ -1,0 +1,11 @@
+﻿services:
+  sa-time-auto-time-worker:
+    image: node:20-bullseye
+    working_dir: /workspace
+    command: ["bash", "deploy/auto-time/run-auto-time.sh"]
+    env_file:
+      - .env.auto-time.prod
+    volumes:
+      - ../../:/workspace
+      - /opt/sa-time/auto-time/logs:/logs
+    restart: "no"

--- a/deploy/auto-time/run-auto-time.sh
+++ b/deploy/auto-time/run-auto-time.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspace
+
+mkdir -p /logs
+export npm_config_cache="${npm_config_cache:-/tmp/npm-cache}"
+
+timestamp="$(date '+%Y-%m-%d_%H-%M-%S')"
+log_file="/logs/auto-time-${timestamp}.log"
+
+echo "[auto-time] starting run at $(date --iso-8601=seconds)" | tee -a "${log_file}"
+npm ci | tee -a "${log_file}"
+echo "[auto-time] running full auto-time loop at $(date --iso-8601=seconds)" | tee -a "${log_file}"
+npx --yes tsx scripts/asset-log-time-capture/fullLoopRunner.ts --org-id="${SA_TIME_ORG_ID}" "$@" | tee -a "${log_file}"
+echo "[auto-time] finished run at $(date --iso-8601=seconds)" | tee -a "${log_file}"

--- a/deploy/auto-time/systemd/sa-time-auto-time.service
+++ b/deploy/auto-time/systemd/sa-time-auto-time.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=SA-TIME auto time worker
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=ubuntu
+WorkingDirectory=/home/ubuntu/sa-time-auto-time/deploy/auto-time
+ExecStart=/usr/bin/docker compose --env-file .env.auto-time.prod -f docker-compose.auto-time.yml run --rm sa-time-auto-time-worker

--- a/deploy/auto-time/systemd/sa-time-auto-time.timer
+++ b/deploy/auto-time/systemd/sa-time-auto-time.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run SA-TIME auto time worker daily
+
+[Timer]
+OnCalendar=*-*-* 04:10:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/docs/superpowers/plans/2026-04-24-auto-time-full-loop.md
+++ b/docs/superpowers/plans/2026-04-24-auto-time-full-loop.md
@@ -1,0 +1,74 @@
+# Auto Time Full Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the NAS auto-time loop by automatically creating missing project masters, inserting roots, rebuilding affected dates, and writing health reports.
+
+**Architecture:** Extend the existing `scripts/asset-log-time-capture` worker rather than adding a new service. `nasRootAutoParserCore` owns candidate parsing, rule decisions, project/root creation, and rebuild date calculation; `core` owns target-date generation and rebuild mode; a new health-report helper turns parser/runner results into persisted and exported reports.
+
+**Tech Stack:** TypeScript, Vitest, Supabase JS, PostgreSQL migration drafts, existing systemd/docker worker scripts.
+
+---
+
+### Task 1: Database Foundation
+
+**Files:**
+- Create: `supabase/migrations_draft_time_tracker/018_time_tracker_auto_time_full_loop.sql`
+
+- [ ] Add candidate statuses, action audit table, health report table, RLS, indexes, and comments.
+- [ ] Keep the migration idempotent with `IF NOT EXISTS` and drop/recreate check constraints by name.
+
+### Task 2: Auto Project Creation
+
+**Files:**
+- Modify: `scripts/asset-log-time-capture/nasRootAutoParserCore.ts`
+- Modify: `scripts/asset-log-time-capture/repository.ts`
+- Test: `src/autoTime/nasRootAutoParserCore.test.ts`
+
+- [ ] Write failing tests for `C20260413_友谊商店二期` auto project creation and root insertion.
+- [ ] Write failing tests for rejecting `server-backup`, `chat-images`, `console.log`, and `000000-项目梳理`.
+- [ ] Write failing tests for duplicate-code conflicts.
+- [ ] Implement eligibility decisions, project creation payloads, audit action rows, and promoted root linking.
+
+### Task 3: Rebuild Mode
+
+**Files:**
+- Modify: `scripts/asset-log-time-capture/config.ts`
+- Modify: `scripts/asset-log-time-capture/core.ts`
+- Modify: `scripts/asset-log-time-capture/repository.ts`
+- Test: `src/autoTime/runnerConfig.test.ts`
+- Test: `src/autoTime/runnerCore.test.ts`
+
+- [ ] Write failing config test for `--rebuild-nas-auto`.
+- [ ] Write failing core test proving rebuild clears existing `nas_auto` duplicates before writing fresh tasks.
+- [ ] Implement repository method that deletes target-date `entry_source = nas_auto` rows and returns deleted ids for audit metadata.
+
+### Task 4: Health Reports
+
+**Files:**
+- Create: `scripts/asset-log-time-capture/healthReportCore.ts`
+- Modify: `scripts/asset-log-time-capture/repository.ts`
+- Modify: `scripts/asset-log-time-capture/runner.ts`
+- Modify: `scripts/asset-log-time-capture/nasRootAutoParser.ts`
+- Test: `src/autoTime/healthReportCore.test.ts`
+
+- [ ] Write failing tests for zero-project and high-unattributed detection.
+- [ ] Write failing tests for Markdown and JSON health report content.
+- [ ] Implement health summary builder and repository insert method.
+
+### Task 5: Worker Orchestration
+
+**Files:**
+- Create: `scripts/asset-log-time-capture/fullLoopRunner.ts`
+- Modify: `deploy/auto-time/run-auto-time.sh`
+- Test: `src/autoTime/fullLoopRunner.test.ts`
+
+- [ ] Write failing orchestration test for parser -> rebuild affected dates -> normal target run -> health report.
+- [ ] Implement a single full-loop entry point and update the deploy script to call it.
+- [ ] Keep existing parser and runner commands available for manual debugging.
+
+### Verification
+
+- [ ] Run `npm run test -- --run src/autoTime/nasRootAutoParserCore.test.ts src/autoTime/runnerCore.test.ts src/autoTime/runnerConfig.test.ts src/autoTime/healthReportCore.test.ts src/autoTime/fullLoopRunner.test.ts`.
+- [ ] Run `npm run test -- --run src/autoTime`.
+- [ ] Run `npm run build`.

--- a/docs/superpowers/specs/2026-04-24-auto-time-full-loop-design.md
+++ b/docs/superpowers/specs/2026-04-24-auto-time-full-loop-design.md
@@ -1,0 +1,468 @@
+# SA-TIME Auto Time Full Loop Design
+
+> Date: 2026-04-24
+> Status: design approved; implementation plan is next
+
+## Goal
+
+Build a full automatic closed loop for NAS-based auto timesheets:
+
+1. Detect new NAS project roots from `public.asset_version_log`.
+2. Automatically create active SA-TIME project master records when a valid NAS project has no matching project.
+3. Automatically insert `time_tracker.project_nas_roots`.
+4. Rebuild affected auto-time dates so missed timesheets are repaired without manual reruns.
+5. Persist a daily health report that explains what was created, rebuilt, skipped, rejected, or still broken.
+
+The user explicitly chose the full automation boundary: when a NAS path can be parsed into a project code/name, the system should create an active project, add the root mapping, and rerun affected auto-time generation.
+
+## Current Context
+
+The current worker already runs this sequence daily:
+
+```text
+nasRootAutoParser.ts -> runner.ts
+```
+
+`nasRootAutoParser.ts` can detect candidate roots and auto-insert roots only when an active project already exists. When the project master is missing, candidates are persisted with `candidate_status = missing_project_master`.
+
+Observed issue on `2026-04-23`:
+
+- `具志坚强` had NAS activity under `/daga-2025-project/CONCEPT/C20260413_友谊商店二期`.
+- `time_tracker.projects` had no active `C20260413` project.
+- `time_tracker.project_nas_roots` had no root for that NAS path.
+- The run diagnostic showed `raw_total_minutes = 513`, `unattributed_minutes = 513`, `distinct_project_count = 0`, `project_minutes = []`.
+- No `auto_time_run_items` or `tasks` were generated for that user/date.
+
+Other users on the same latest run also had full or partial misses:
+
+- Full zero-project users: `霍莹莹`, `公磊`, `具志坚强`.
+- High unattributed users included `阮漪婷`, `薛达`, `张龙潇`.
+
+This proves the missing link is not log ingestion. The missing link is the project-master and rebuild closure after candidate discovery.
+
+## Design Principles
+
+1. Full automation is allowed, but it must be rule-driven.
+2. The system may create active projects, but every automatic decision must be auditable.
+3. Rebuild is part of the feature, not an operator task.
+4. Existing manual tasks are never overwritten.
+5. Existing unrelated user changes or hand-filled timesheets have priority.
+6. Non-project paths must be rejected by machine rules to avoid polluting project master data.
+7. Project-code conflicts must not be guessed if they would merge costs into the wrong project.
+
+## Proposed Worker Flow
+
+The daily worker changes from:
+
+```text
+parse NAS roots
+-> generate auto time
+```
+
+to:
+
+```text
+parse NAS roots
+-> auto create missing projects
+-> auto insert project_nas_roots
+-> queue affected date rebuilds
+-> rebuild affected dates
+-> generate normal target-date auto time
+-> analyze zero-project and high-unattributed users
+-> write daily health report
+-> write Markdown/JSON report files
+```
+
+The normal daily target is still yesterday in `Asia/Shanghai`.
+
+## Project Creation Rules
+
+The system automatically creates a project when all of these are true:
+
+1. The candidate root has a parseable project code or project name.
+2. The root path is under an accepted project area:
+   - `/daga-YYYY-project/CONCEPT/<project-segment>`
+   - `/daga-YYYY-project/<project-segment>`
+3. The parsed code matches one of:
+   - `CYYYYMMDD`
+   - `D####`
+4. The parsed project name is non-empty after removing the code and separators.
+5. No active project exists with the same exact `source_project_code`.
+6. The candidate is not rejected by blacklist rules.
+
+When these rules pass, create:
+
+```text
+time_tracker.projects
+name = parsed_project_name
+source_project_code = parsed_project_code
+status = active
+contract_amount = 0
+human_cost_budget = 0
+human_cost_ratio = organization.default_human_cost_ratio
+manager_user_id = null
+```
+
+The project should be marked as auto-created through an audit/action table, not by overloading business fields.
+
+## Rejection Rules
+
+The system must not create active projects for paths whose project segment is clearly not a project. Reject when the parsed name or segment matches any of:
+
+```text
+新建文件夹
+新建文件夹 ->
+server-backup
+chat-images
+console.log
+项目梳理
+000000-项目梳理
+backup
+temp
+tmp
+test
+```
+
+Reject candidates where:
+
+- No project code is found and the name is a known infrastructure or temporary folder.
+- The path is a file-like root such as `console.log`.
+- The candidate code is a known placeholder such as `000000`.
+- The normalized root is already rejected for the same org.
+
+Rejected candidates remain in candidate history with `candidate_status = rejected_by_rule` and a machine-readable reason.
+
+## Conflict Rules
+
+If the candidate code matches multiple active projects, do not auto-pick one.
+
+Set:
+
+```text
+candidate_status = conflict_needs_manual_fix
+match_method = code_exact
+notes = source_project_code matched multiple active projects
+```
+
+This exception appears in the health report. The system should not create another duplicate project and should not attach a root to an arbitrary project.
+
+This is the only intentional break from complete automation, because assigning hours to the wrong active project corrupts cost accounting more severely than leaving a visible exception.
+
+## Database Changes
+
+### `time_tracker.auto_time_project_root_candidates`
+
+Extend `candidate_status` to support:
+
+```text
+auto_project_created
+auto_root_inserted
+rebuild_queued
+rebuild_completed
+rejected_by_rule
+conflict_needs_manual_fix
+failed
+```
+
+Existing statuses remain valid:
+
+```text
+auto_inserted
+pending_review
+missing_project_master
+rejected
+```
+
+### `time_tracker.auto_time_project_actions`
+
+Create an audit table for automatic project and root actions:
+
+```text
+id uuid primary key
+org_id uuid not null
+target_work_date date not null
+candidate_root_path text not null
+parsed_project_code text
+parsed_project_name text
+action_type text not null
+action_status text not null
+project_id uuid
+project_root_id uuid
+run_id uuid
+rebuild_target_work_date date
+reason text
+metadata jsonb not null default '{}'
+created_at timestamptz not null default now()
+```
+
+`action_type` values:
+
+```text
+auto_create_project
+auto_insert_root
+queue_rebuild
+complete_rebuild
+reject_candidate
+conflict_candidate
+fail_candidate
+```
+
+`action_status` values:
+
+```text
+completed
+skipped
+failed
+```
+
+### `time_tracker.auto_time_daily_health_reports`
+
+Create a permanent database report table:
+
+```text
+id uuid primary key
+org_id uuid not null
+target_work_date date not null
+run_id uuid
+parser_started_at timestamptz
+parser_finished_at timestamptz
+runner_started_at timestamptz
+runner_finished_at timestamptz
+status text not null
+total_logs_scanned integer not null default 0
+total_logs_accepted integer not null default 0
+total_projects_auto_created integer not null default 0
+total_roots_auto_inserted integer not null default 0
+total_rebuild_dates_queued integer not null default 0
+total_rebuild_dates_completed integer not null default 0
+total_tasks_written integer not null default 0
+total_zero_project_users integer not null default 0
+total_high_unattributed_users integer not null default 0
+total_conflict_candidates integer not null default 0
+total_rejected_candidates integer not null default 0
+summary jsonb not null default '{}'
+created_at timestamptz not null default now()
+```
+
+The report table is the source of truth for operational review. Worker log files are secondary output only.
+
+## Rebuild Design
+
+When a new project or root is created, calculate affected local work dates from the candidate's `first_seen_at` and `last_seen_at`.
+
+Example:
+
+```text
+first_seen_at = 2026-04-15T17:29:42+00:00
+last_seen_at = 2026-04-23T07:53:46+00:00
+timezone = Asia/Shanghai
+affected dates = 2026-04-16 ... 2026-04-23
+```
+
+Skip dates that are weekends or configured holidays using the same rules as the normal runner.
+
+For each affected date, run auto-time in rebuild mode:
+
+```text
+runner.ts --date=<date> --rebuild-nas-auto
+```
+
+Rebuild mode must:
+
+1. Preserve manual tasks.
+2. Remove or supersede existing `entry_source = nas_auto` tasks for the target date.
+3. Insert fresh `auto_time_run_items`.
+4. Insert fresh `tasks`.
+5. Link generated tasks back to run items.
+6. Record rebuild action rows.
+
+Preferred implementation is soft superseding old generated tasks. If the table change is too large for the first implementation, physical deletion of `entry_source = nas_auto` rows for the target date is acceptable only if the rebuild action table records the deleted task ids first.
+
+## Health Report Contents
+
+Each daily report must include:
+
+```text
+target_work_date
+status
+run_id
+projects_auto_created
+roots_auto_inserted
+rebuild_dates_queued
+rebuild_dates_completed
+zero_project_users
+high_unattributed_users
+conflict_candidates
+rejected_candidates
+tasks_written
+```
+
+### Zero-Project Users
+
+A zero-project user is:
+
+```text
+raw_total_minutes > 0
+distinct_project_count = 0
+```
+
+These users had NAS activity but no recognized project. They are the highest priority anomalies.
+
+### High-Unattributed Users
+
+A high-unattributed user is:
+
+```text
+raw_total_minutes > 0
+distinct_project_count > 0
+unattributed_minutes / raw_total_minutes >= 0.5
+```
+
+These users may still have generated tasks, but the project allocation is suspicious because most of the day was not tied to recognized projects.
+
+### Report Storage
+
+The worker writes reports to three places:
+
+1. Database truth:
+
+```text
+time_tracker.auto_time_daily_health_reports
+```
+
+2. Server export:
+
+```text
+/opt/sa-time/auto-time/reports/YYYY-MM-DD-health.md
+/opt/sa-time/auto-time/reports/YYYY-MM-DD-health.json
+```
+
+3. Future frontend page:
+
+```text
+Admin -> Auto Time Health
+```
+
+The first implementation may create the table and server export before building the frontend page.
+
+## Frontend Follow-Up
+
+Add an admin-only page after the backend loop is stable:
+
+```text
+管理后台 -> 自动工时健康
+```
+
+Default view: last 7 target work dates.
+
+Columns:
+
+```text
+日期
+状态
+自动建项目
+自动补 root
+重跑日期
+写入工时
+完全未归属人数
+高未归属人数
+冲突候选
+拒绝候选
+```
+
+Detail drawer:
+
+```text
+auto-created projects
+auto-inserted roots
+rebuild dates
+zero-project users
+high-unattributed users
+conflict candidates
+rejected candidates
+```
+
+## Expected Behavior For The Known Case
+
+For:
+
+```text
+/daga-2025-project/CONCEPT/C20260413_友谊商店二期
+```
+
+The system should:
+
+1. Parse `source_project_code = C20260413`.
+2. Parse `name = 友谊商店二期`.
+3. Create active project `友谊商店二期`.
+4. Insert root `/daga-2025-project/CONCEPT/C20260413_友谊商店二期`.
+5. Queue rebuild dates based on the candidate first/last seen range.
+6. Rebuild those dates.
+7. Generate tasks for users whose logs previously had `distinct_project_count = 0`, including `具志坚强` on `2026-04-23`.
+8. Write a health report showing the auto-created project, inserted root, rebuild dates, and repaired zero-project users.
+
+## Testing Strategy
+
+### Unit Tests
+
+Add focused Vitest coverage for:
+
+- Candidate path parsing.
+- Auto-create eligibility rules.
+- Rejection rules.
+- Conflict rules.
+- Affected date calculation from `first_seen_at` / `last_seen_at`.
+- Health report summary building.
+- Rebuild task selection.
+
+### Repository Tests
+
+Mock Supabase repository methods for:
+
+- Creating auto projects.
+- Inserting roots.
+- Writing action rows.
+- Writing health reports.
+- Rebuild mode deleting/superseding old `nas_auto` tasks.
+
+### Integration Dry Run
+
+Run:
+
+```bash
+npm run auto-time:parse-nas-roots -- --org-id=<org_id> --date=2026-04-23 --dry-run
+```
+
+Expected: `C20260413_友谊商店二期` appears as eligible for auto project creation, while `server-backup`, `chat-images`, and `console.log` are rejected.
+
+### Production Verification
+
+After deploying:
+
+1. Run the worker for `2026-04-23`.
+2. Confirm `time_tracker.projects` contains `C20260413 / 友谊商店二期`.
+3. Confirm `project_nas_roots` contains the matching NAS root.
+4. Confirm rebuild produced `nas_auto` tasks for affected users.
+5. Confirm health report exists in `time_tracker.auto_time_daily_health_reports`.
+
+## Rollback Strategy
+
+Every automatic project/root action has an audit row. If a project is wrongly created:
+
+1. Mark the project inactive or archived.
+2. Mark related `project_nas_roots.is_active = false`.
+3. Rebuild affected dates again.
+4. The health report records the corrected result.
+
+If rebuild creates wrong `nas_auto` tasks, rerun rebuild after fixing project/root data. Manual tasks remain untouched.
+
+## Implementation Defaults
+
+These defaults are selected for implementation:
+
+1. Auto-created projects are active immediately.
+2. Auto-created project budgets default to zero.
+3. Manager is null.
+4. Root conflicts do not auto-resolve.
+5. Backend tables and worker reports are implemented before the frontend health page.
+6. The first implementation may physically delete old `nas_auto` target-date rows during rebuild if it logs deleted ids in `auto_time_project_actions.metadata`.

--- a/scripts/asset-log-time-capture/README.md
+++ b/scripts/asset-log-time-capture/README.md
@@ -1,0 +1,141 @@
+# asset-log-time-capture
+
+SA-TIME 自动工时 runner 骨架。
+
+当前阶段只完成：
+
+- 配置解析
+- 目标工作日窗口计算
+- 周末 / 法定节假日跳过
+- 真实读取 `public.asset_version_log` 的分页加载器
+- 忽略账号加载与首轮日志过滤统计
+- `sa_ai_user_id / nas_user_aliases` 用户映射
+- `project_nas_roots` 根路径命中
+- `用户 + 日期 + 项目` 候选聚合去重
+- 阶段 A 后台原始时间分配链路（相邻区间归前一个项目）
+- `raw_last_activity_at / raw_total_minutes / unattributed_minutes`
+- `raw_project_minutes / normalized_project_minutes` 诊断字段
+- `allocation_mode = even_split | interval_to_previous_project` 正式分配开关（当前默认 `interval_to_previous_project`）
+- `allocation_meta` 与 summary 中的大间隔 / 保守模式标记
+- `allocation_sample_rows` 领导可读样表输出
+- `auto_time_run_items` 写入
+- 手填优先判断
+- 正式分钟分配写入
+- `time_tracker.tasks` 正式写入
+- `/timesheet` 月历格子已按 `tasks.entry_source = nas_auto` 显示条目级 `AUTO` 标记
+- `generated_task_id / source_run_id / source_item_id` 关联回填
+- `auto_time_runs` 生命周期骨架
+- NAS 新项目根路径候选解析与自动补全脚本
+- `auto_time_project_root_candidates` 候选落库草稿
+- dry-run 输出
+
+当前阶段还未完成：
+
+- `017_time_tracker_auto_time_project_root_candidates.sql` 执行到共享库
+- NAS 根路径解析器的服务器部署与每日定时挂载
+- 待确认 / 缺主数据候选的业务审核收口
+- 上线后持续观察与异常口径收口
+
+## 用法
+
+```bash
+npm run auto-time:dry-run -- --org-id=<org_uuid>
+```
+
+```bash
+npm run auto-time:run -- --org-id=<org_uuid> --date=2026-04-21
+```
+
+```bash
+npm run auto-time:parse-nas-roots -- --org-id=<org_uuid> --date=2026-04-22
+```
+
+```bash
+npm run auto-time:sample-report -- --org-id=<org_uuid> --days=7 --end-date=2026-04-21
+```
+
+```bash
+npm run auto-time:sample-report -- --org-id=<org_uuid> --days=7 --end-date=2026-04-21 --markdown-output=docs/trial-runs/2026-04-21-sample-report.md
+```
+
+## 必填环境变量
+
+正式运行：
+
+- `SA_TIME_SUPABASE_URL`
+- `SA_TIME_SUPABASE_SERVICE_ROLE_KEY`
+- `SA_TIME_ORG_ID` 或 `--org-id`
+
+可选：
+
+- `SA_TIME_TIMEZONE`，默认 `Asia/Shanghai`
+- `SA_TIME_IGNORE_WEEKENDS`，默认 `true`
+- `SA_TIME_ACTIONS`，默认 `create,write,rename,delete`
+- `SA_TIME_SOURCE_TABLE`，默认 `public.asset_version_log`
+- `SA_TIME_ALLOCATION_MODE`，默认 `even_split`
+- `SA_TIME_LARGE_GAP_THRESHOLD_MINUTES`，默认 `120`
+- `SA_TIME_SKIP_FORMAL_WRITE_ON_LARGE_GAP`，默认 `false`
+- `SA_TIME_NAS_ROOT_LOOKBACK_DAYS`，默认 `7`
+
+## Worker 部署骨架
+
+当前仓库已经补了独立 worker 部署骨架，目录在：
+
+- `deploy/auto-time/docker-compose.auto-time.yml`
+- `deploy/auto-time/.env.auto-time.prod.example`
+- `deploy/auto-time/run-auto-time.sh`
+- `deploy/auto-time/systemd/sa-time-auto-time.service`
+- `deploy/auto-time/systemd/sa-time-auto-time.timer`
+
+设计约束：
+
+- 自动工时是独立 worker，不是 HTTP 后端
+- worker 直接写共享 Supabase 的 `time_tracker.*`
+- 不暴露任何端口
+- 推荐由 `systemd timer` 触发 `docker compose run --rm`
+
+推荐服务器目录：
+
+- 代码目录：`/home/ubuntu/sa-time-auto-time`
+- deploy 目录：`/home/ubuntu/sa-time-auto-time/deploy/auto-time`
+- 环境文件：`/home/ubuntu/sa-time-auto-time/deploy/auto-time/.env.auto-time.prod`
+- 日志目录：`/opt/sa-time/auto-time/logs`
+
+推荐执行方式：
+
+```bash
+cd /home/ubuntu/sa-time-auto-time/deploy/auto-time
+cp .env.auto-time.prod.example .env.auto-time.prod
+docker compose --env-file .env.auto-time.prod -f docker-compose.auto-time.yml run --rm sa-time-auto-time-worker
+```
+
+注意：
+
+- `run-auto-time.sh` 当前会在容器内执行 `npm ci`，所以代码目录挂载必须可写，不能使用只读挂载。
+- 首次上线建议先手工跑一次 service，确认 `auto_time_runs / auto_time_run_items / tasks` 三层结果一致，再启用 timer。
+
+## 当前行为说明
+
+- 如果提供 `SA_TIME_SUPABASE_URL` 与 `SA_TIME_SUPABASE_SERVICE_ROLE_KEY`，`dry-run` 会真实读取 `public.asset_version_log` 并输出扫描/接受统计。
+- 如果同时存在 `nas_user_aliases` 与 `project_nas_roots` 数据，`dry-run` 会继续输出未映射用户数、未命中项目数、候选聚合数和阶段 A 原始分配诊断 summary。
+- summary 会同时区分诊断 `480` 映射分钟与当前正式写入分钟，并输出大间隔 / 多项目诊断标记。
+- summary 还会输出 `allocation_sample_rows`，方便直接拿最近样本给领导看。
+- `auto-time:sample-report` 会按最近 N 个工作日逐天执行 dry-run，并输出聚合统计与逐日样表；默认最近 `7` 个工作日。
+- 如提供 `--markdown-output=<path>`，会额外写出一份领导可读的 Markdown 试跑报告。
+- `auto-time:parse-nas-roots` 会扫描“目标工作日 + 前 7 天”内尚未命中 `project_nas_roots` 的 NAS 日志，自动提取候选根路径。
+- 对 `source_project_code` 唯一精确命中的候选，解析器会自动补入 `project_nas_roots`；名称命中或缺主数据的候选只写入 `auto_time_project_root_candidates`，不直接进入正式工时。
+- 如果只提供 `SA_TIME_ORG_ID`，`dry-run` 仍可作为纯 skeleton 模式运行，用于验证日期窗口和命令入口。
+- 非 dry-run 且具备数据库连接时，runner 已可写入 `auto_time_run_items`，并对已有手填工时的用户按 `manual_override_skipped` 落审计记录，同时保留阶段 A 诊断字段与 `allocation_meta`。
+- 非 dry-run 且具备数据库连接时，runner 已可继续写入 `time_tracker.tasks`，并把生成出的 task id 回填到 `auto_time_run_items.generated_task_id`；仓库默认正式写入口径现已切到 `allocation_mode=interval_to_previous_project`。
+- 当前默认口径下，`3+` 项目日也会按同一套“相邻区间归前一个项目 + 480 映射”规则正式拆分；`policy_guard_skipped` 仅保留给未来可能启用的大间隔拦截。
+- 非 dry-run 且具备数据库连接时，runner 会跳过法定节假日，并对同一 `work_date` 下已存在的 `nas_auto` 任务做重复写入保护。
+- 前端月历继续沿用现有“项目名称 + 小时数”胶囊样式，但若条目来自 `entry_source = nas_auto`，会在胶囊内追加 `AUTO` 标记，不展示额外诊断摘要。
+- 2026-04-21 已在共享库执行 `014 / 015`，并以最小 trial seed 对 `2026-04-20` 跑通首轮真实 trial-run，生成 5 条 `nas_auto` 自动工时。
+- 2026-04-22 已完成服务器 worker 部署：`sa-time-auto-time.timer` 已启用，`sa-time-auto-time.service` 可成功手工触发并按既有重复写入保护跳过已存在任务。
+- 2026-04-22 已在共享库执行 `016`，并完成最近 `7` 个工作日真实 sample-report；实际输出 `94` 条样本行，其中 `18` 个单项目日、`1` 个双项目日、`5` 个大间隔命中日。Markdown 报告已落在 [docs/trial-runs/2026-04-22-auto-time-sample-report.md](/mnt/f/SA-TIME/02_核心源码_Src/TimeTrackerPro/docs/trial-runs/2026-04-22-auto-time-sample-report.md)。
+- 2026-04-22 已修复“连续同项目日志压缩后误吃掉最后项目时段”的原始分配 bug：连续同项目区间现在保留首个事件作为区间起点，最后一个项目可正确延伸到 `raw_last_activity_at`。
+- 2026-04-22 已对 `2026-04-21` 按修复后的新规则完成真实重跑：`runId = 2d15265b-a9be-4550-8c4c-efeaf49975ac`，`auto_time_run_items` `5` 条，`tasks(entry_source=nas_auto)` `5` 条；其中胡芳婷由旧的 `480 + 0` 修正为 `342 + 138`。
+- 2026-04-22 已补 `5` 条 `project_nas_roots` 映射：`成都王府井 / 天津郁江新里城更文创园（公交二厂） / 办公室 / 青岛麦岛站 / 深圳罗山公园商业`，并对 `2026-04-22` 重新正式入账：`runId = 23655490-a3bd-4bc0-afc4-9324474bed1b`，当天 `tasks(entry_source=nas_auto)` 由 `4` 条增至 `9` 条。
+- 2026-04-22 已补 NAS 根路径自动解析代码：新增 `nasRootAutoParser.ts / nasRootAutoParserCore.ts / nasRootAutoParserConfig.ts`、`017_time_tracker_auto_time_project_root_candidates.sql`、`auto-time:parse-nas-roots` 命令与对应 Vitest 用例；当前处于“代码已落仓，待共享库执行 migration 与挂前置定时任务”状态。
+- 2026-04-22 已在共享 Supabase 执行 `017`，并对 `2026-04-22` 跑通一次真实 dry-run 与 non-dry-run：扫描 `1267068` 条日志、接受 `123666` 条、命中现有根路径 `17191` 条、生成候选 `32` 条，其中自动补入 `project_nas_roots` `14` 条、`pending_review` `1` 条、`missing_project_master` `17` 条。
+- 2026-04-22 已把 `deploy/auto-time/run-auto-time.sh` 调整为“先跑 `nasRootAutoParser.ts`，再跑正式 `runner.ts`”；当前代码侧已挂到 worker 前置阶段，服务器代码目录仍需同步本次改动后才会在线生效。

--- a/scripts/asset-log-time-capture/activity-span-diagnostic.sql
+++ b/scripts/asset-log-time-capture/activity-span-diagnostic.sql
@@ -1,0 +1,94 @@
+-- SA-TIME NAS 日志活动跨度诊断 SQL
+--
+-- 用途：
+-- 1. 先做“后台活动跨度”诊断，不直接改正式 8h 入账口径
+-- 2. 以 Asia/Shanghai 为业务日期
+-- 3. 以每天 10:00 作为后台跨度统计起点
+-- 4. 过滤明显噪音：thumbnailimage / crdownload / embedded_files / ViewCapture / .rhl / tmp-like
+--
+-- 注意：
+-- - 该 SQL 的输出是“活动信号”，不是正式工时事实
+-- - `span_from_10h` 仅表示 10:00 之后到最后有效活动的跨度
+-- - `project_candidates` 是候选项目，不应直接等同于正式入账项目
+
+WITH base AS (
+  SELECT
+    (detected_at AT TIME ZONE 'Asia/Shanghai')::date AS work_date,
+    detected_at,
+    created_at,
+    nas_username,
+    sa_ai_user_id,
+    action,
+    file_path,
+    commit_message,
+    preview_image_url,
+    snapshot_path,
+    is_recoverable
+  FROM public.asset_version_log
+  WHERE detected_at >= now() - interval '7 days'
+),
+classified AS (
+  SELECT
+    *,
+    CASE
+      WHEN file_path ILIKE '%/thumbnailimage/%' THEN 'thumbnailimage'
+      WHEN file_path ILIKE '%crdownload%' THEN 'crdownload'
+      WHEN file_path ILIKE '%embedded_files%' THEN 'embedded_files'
+      WHEN file_path ILIKE '%viewcapture%' THEN 'viewcapture'
+      WHEN file_path ILIKE '%.rhl%' THEN 'rhl'
+      WHEN file_path ~* '(^|/)(atmp|save[0-9a-f]{6,}|rhi[0-9a-f]{3,})' THEN 'temp_name'
+      WHEN file_path ~* '(^|/).+\.tmp( ->|$)' THEN 'tmp_ext'
+      WHEN lower(nas_username) = 'wenshunhe' THEN 'ignored_account'
+      ELSE 'kept'
+    END AS filter_reason,
+    substring(file_path FROM '/([A-Z]\d{4}_[^/]+|C\d{8}_[^/]+|D\d{4}_[^/]+)') AS project_token
+  FROM base
+),
+daily AS (
+  SELECT
+    work_date,
+    nas_username,
+    sa_ai_user_id,
+    min(detected_at) FILTER (WHERE filter_reason = 'kept') AS first_kept_at,
+    max(detected_at) FILTER (WHERE filter_reason = 'kept') AS last_kept_at,
+    count(*) FILTER (WHERE filter_reason = 'kept') AS kept_events,
+    count(*) AS raw_events,
+    count(*) FILTER (WHERE filter_reason <> 'kept') AS filtered_events,
+    count(DISTINCT project_token) FILTER (
+      WHERE filter_reason = 'kept'
+        AND project_token IS NOT NULL
+    ) AS distinct_projects,
+    string_agg(DISTINCT project_token, ' | ' ORDER BY project_token) FILTER (
+      WHERE filter_reason = 'kept'
+        AND project_token IS NOT NULL
+    ) AS project_candidates
+  FROM classified
+  GROUP BY work_date, nas_username, sa_ai_user_id
+)
+SELECT
+  work_date,
+  nas_username,
+  sa_ai_user_id,
+  first_kept_at,
+  last_kept_at,
+  GREATEST(
+    round(
+      extract(
+        epoch FROM (
+          last_kept_at
+          - GREATEST(first_kept_at, work_date::timestamp + interval '10 hour')
+        )
+      ) / 3600.0,
+      2
+    ),
+    0
+  ) AS span_from_10h,
+  kept_events,
+  raw_events,
+  filtered_events,
+  distinct_projects,
+  project_candidates
+FROM daily
+WHERE kept_events > 0
+  AND sa_ai_user_id IS NOT NULL
+ORDER BY work_date DESC, span_from_10h DESC, kept_events DESC;

--- a/scripts/asset-log-time-capture/config.ts
+++ b/scripts/asset-log-time-capture/config.ts
@@ -1,0 +1,147 @@
+import {
+	buildTargetDayWindow,
+	type AutoTimeAction,
+	type AutoTimeAllocationMode,
+	type AutoTimeRunnerConfig
+} from "./core.ts";
+
+const DEFAULT_ACTIONS: AutoTimeAction[] = ["create", "write", "rename", "delete"];
+const VALID_ACTIONS = new Set<AutoTimeAction>(DEFAULT_ACTIONS);
+const VALID_ALLOCATION_MODES = new Set<AutoTimeAllocationMode>(["even_split", "interval_to_previous_project"]);
+const DEFAULT_LARGE_GAP_THRESHOLD_MINUTES = 120;
+const DEFAULT_SKIP_FORMAL_WRITE_ON_LARGE_GAP = false;
+
+const readArgumentValue = (argv: string[], name: string): string | undefined => {
+	const exactIndex = argv.findIndex((entry) => entry === name);
+	if (exactIndex >= 0) {
+		return argv[exactIndex + 1];
+	}
+
+	const prefix = `${name}=`;
+	const matched = argv.find((entry) => entry.startsWith(prefix));
+	return matched ? matched.slice(prefix.length) : undefined;
+};
+
+const parseBoolean = (value: string | undefined, defaultValue: boolean): boolean => {
+	if (!value) {
+		return defaultValue;
+	}
+
+	if (value === "true") {
+		return true;
+	}
+
+	if (value === "false") {
+		return false;
+	}
+
+	throw new Error(`Invalid boolean value: ${value}`);
+};
+
+const parseActions = (value: string | undefined): AutoTimeAction[] => {
+	if (!value) {
+		return DEFAULT_ACTIONS;
+	}
+
+	const actions = value
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean) as AutoTimeAction[];
+
+	if (actions.length === 0 || actions.some((entry) => !VALID_ACTIONS.has(entry))) {
+		throw new Error(`Invalid action list: ${value}`);
+	}
+
+	return actions;
+};
+
+const parseAllocationMode = (value: string | undefined): AutoTimeAllocationMode => {
+	if (!value) {
+		return "interval_to_previous_project";
+	}
+
+	if (!VALID_ALLOCATION_MODES.has(value as AutoTimeAllocationMode)) {
+		throw new Error(`Invalid allocation mode: ${value}`);
+	}
+
+	return value as AutoTimeAllocationMode;
+};
+
+const parsePositiveInteger = (value: string | undefined, defaultValue: number): number => {
+	if (!value) {
+		return defaultValue;
+	}
+
+	const parsed = Number(value);
+	if (!Number.isInteger(parsed) || parsed <= 0) {
+		throw new Error(`Invalid positive integer: ${value}`);
+	}
+
+	return parsed;
+};
+
+export const createRunnerConfig = ({
+	env = process.env,
+	argv = process.argv.slice(2),
+	now = new Date()
+}: {
+	env?: NodeJS.ProcessEnv;
+	argv?: string[];
+	now?: Date;
+} = {}): AutoTimeRunnerConfig => {
+	const timezone = readArgumentValue(argv, "--timezone") ?? env.SA_TIME_TIMEZONE ?? "Asia/Shanghai";
+	const targetWorkDate = readArgumentValue(argv, "--date")
+		?? env.SA_TIME_TARGET_WORK_DATE
+		?? buildTargetDayWindow({
+			now,
+			timezone
+		}).targetWorkDate;
+	const dryRun = argv.includes("--dry-run") || env.SA_TIME_DRY_RUN === "true";
+	const ignoreWeekends = parseBoolean(
+		readArgumentValue(argv, "--ignore-weekends") ?? env.SA_TIME_IGNORE_WEEKENDS,
+		true
+	);
+
+	const config: AutoTimeRunnerConfig = {
+		orgId: readArgumentValue(argv, "--org-id") ?? env.SA_TIME_ORG_ID ?? "",
+		supabaseUrl: env.SA_TIME_SUPABASE_URL ?? "",
+		supabaseServiceRoleKey: env.SA_TIME_SUPABASE_SERVICE_ROLE_KEY ?? "",
+		targetWorkDate,
+		timezone,
+		dryRun,
+		ignoreWeekends,
+		actions: parseActions(readArgumentValue(argv, "--actions") ?? env.SA_TIME_ACTIONS),
+		sourceTable: env.SA_TIME_SOURCE_TABLE ?? "public.asset_version_log",
+		allocationMode: parseAllocationMode(
+			readArgumentValue(argv, "--allocation-mode") ?? env.SA_TIME_ALLOCATION_MODE
+		),
+		largeGapThresholdMinutes: parsePositiveInteger(
+			readArgumentValue(argv, "--large-gap-threshold-minutes")
+				?? env.SA_TIME_LARGE_GAP_THRESHOLD_MINUTES,
+			DEFAULT_LARGE_GAP_THRESHOLD_MINUTES
+		),
+		skipFormalWriteOnLargeGap: parseBoolean(
+			readArgumentValue(argv, "--skip-formal-write-on-large-gap")
+				?? env.SA_TIME_SKIP_FORMAL_WRITE_ON_LARGE_GAP,
+			DEFAULT_SKIP_FORMAL_WRITE_ON_LARGE_GAP
+		),
+		rebuildNasAuto: argv.includes("--rebuild-nas-auto")
+			|| parseBoolean(env.SA_TIME_REBUILD_NAS_AUTO, false)
+	};
+
+	if (!config.orgId) {
+		throw new Error("Missing SA_TIME_ORG_ID or --org-id");
+	}
+
+	if (!config.dryRun) {
+		if (!config.supabaseUrl) {
+			throw new Error("Missing SA_TIME_SUPABASE_URL");
+		}
+
+		if (!config.supabaseServiceRoleKey) {
+			throw new Error("Missing SA_TIME_SUPABASE_SERVICE_ROLE_KEY");
+		}
+	}
+
+	return config;
+};

--- a/scripts/asset-log-time-capture/core.ts
+++ b/scripts/asset-log-time-capture/core.ts
@@ -1,0 +1,1345 @@
+import { getHolidayEntry } from "../../src/config/holidays.ts";
+
+export type AutoTimeAction = "create" | "write" | "rename" | "delete";
+export type AutoTimeRunStatus = "completed" | "failed" | "skipped";
+export type AutoTimeAllocationMode = "even_split" | "interval_to_previous_project";
+
+export type AutoTimeRunnerConfig = {
+	orgId: string;
+	supabaseUrl: string;
+	supabaseServiceRoleKey: string;
+	targetWorkDate: string;
+	timezone: string;
+	dryRun: boolean;
+	ignoreWeekends: boolean;
+	actions: AutoTimeAction[];
+	sourceTable: string;
+	allocationMode: AutoTimeAllocationMode;
+	largeGapThresholdMinutes: number;
+	skipFormalWriteOnLargeGap: boolean;
+	rebuildNasAuto: boolean;
+};
+
+export type AutoTimeRunnerSummary = {
+	stage: string;
+	target_work_date: string;
+	timezone: string;
+	range_start: string;
+	range_end: string;
+	day_of_week: number;
+	actions: AutoTimeAction[];
+	total_logs_scanned: number;
+	total_logs_accepted: number;
+	total_tasks_written: number;
+	total_logs_ignored_accounts?: number;
+	total_logs_rejected_incomplete?: number;
+	total_logs_unmapped_users?: number;
+	total_logs_unmapped_projects?: number;
+	total_candidate_items?: number;
+	total_run_items_written?: number;
+	total_manual_override_items?: number;
+	total_existing_auto_tasks_skipped?: number;
+	total_existing_auto_tasks_deleted?: number;
+	total_users_with_allocation_diagnostics?: number;
+	total_policy_guard_items?: number;
+	formal_allocation_mode?: AutoTimeAllocationMode;
+	rebuild_nas_auto?: boolean;
+	allocation_diagnostics?: Array<Record<string, unknown>>;
+	allocation_sample_rows?: Array<Record<string, unknown>>;
+	skipReason?: string;
+};
+
+export type AutoTimeAssetLog = {
+	id: string;
+	file_path: string | null;
+	nas_username: string | null;
+	action: AutoTimeAction;
+	detected_at: string;
+	sa_ai_user_id: string | null;
+	created_at: string | null;
+};
+
+export type LoadAssetLogsParams = {
+	sourceTable: string;
+	rangeStartIso: string;
+	rangeEndIso: string;
+	actions: AutoTimeAction[];
+};
+
+export type AutoTimeNasUserAlias = {
+	nas_username: string;
+	user_id: string;
+};
+
+export type AutoTimeProjectRoot = {
+	id: string;
+	project_id: string;
+	root_path: string;
+};
+
+export type AutoTimeRunRow = {
+	org_id: string;
+	target_work_date: string;
+	source_kind: "asset_version_log";
+	status: "running";
+	started_at: string;
+	summary: Record<string, unknown>;
+};
+
+export type AutoTimeRunItemInsert = {
+	org_id: string;
+	target_work_date: string;
+	nas_username: string;
+	user_id: string | null;
+	project_id: string | null;
+	project_root_id: string | null;
+	source_event_count: number;
+	source_event_ids: string[];
+	source_paths: string[];
+	first_detected_at: string | null;
+	last_detected_at: string | null;
+	raw_first_activity_at: string | null;
+	raw_last_activity_at: string | null;
+	raw_total_minutes: number;
+	unattributed_minutes: number;
+	raw_project_minutes: number;
+	normalized_project_minutes: number;
+	allocation_method: string;
+	allocation_version: string;
+	allocation_meta: Record<string, unknown>;
+	resolution_status: "accepted" | "manual_override_skipped" | "policy_guard_skipped";
+	resolution_reason: string | null;
+	generated_duration_minutes: number | null;
+	metadata: Record<string, unknown>;
+};
+
+export type AutoTimePersistedRunItem = AutoTimeRunItemInsert & {
+	id: string;
+};
+
+export type AutoTimeTaskInsert = {
+	org_id: string;
+	user_id: string;
+	project_id: string;
+	task_name: string;
+	work_date: string;
+	duration_minutes: number;
+	notes: string | null;
+	entry_source: "nas_auto";
+	source_run_id: string;
+	source_item_id: string;
+};
+
+export type AutoTimeInsertedTask = {
+	id: string;
+	source_item_id: string;
+};
+
+export type AutoTimeGeneratedTaskLink = {
+	run_item_id: string;
+	generated_task_id: string;
+};
+
+export type AutoTimeRunnerRepository = {
+	createRun: (payload: AutoTimeRunRow) => Promise<{ id: string }>;
+	finalizeRun: (runId: string, status: AutoTimeRunStatus, summary: Record<string, unknown>, errorSummary?: string) => Promise<void>;
+	loadAssetLogs?: (params: LoadAssetLogsParams) => Promise<AutoTimeAssetLog[]>;
+	loadIgnoreAccounts?: (orgId: string) => Promise<string[]>;
+	loadNasUserAliases?: (orgId: string) => Promise<AutoTimeNasUserAlias[]>;
+	loadProjectRoots?: (orgId: string) => Promise<AutoTimeProjectRoot[]>;
+	loadManualTaskUserIds?: (orgId: string, targetWorkDate: string) => Promise<string[]>;
+	loadExistingAutoTaskKeys?: (orgId: string, targetWorkDate: string) => Promise<string[]>;
+	deleteExistingAutoTasks?: (orgId: string, targetWorkDate: string) => Promise<string[]>;
+	insertRunItems?: (runId: string, items: AutoTimeRunItemInsert[]) => Promise<AutoTimePersistedRunItem[]>;
+	insertTasks?: (runId: string, tasks: AutoTimeTaskInsert[]) => Promise<AutoTimeInsertedTask[]>;
+	linkGeneratedTasks?: (links: AutoTimeGeneratedTaskLink[]) => Promise<void>;
+};
+
+export type TargetDayWindow = {
+	targetWorkDate: string;
+	rangeStartIso: string;
+	rangeEndIso: string;
+	dayOfWeek: number;
+};
+
+const DATE_PARTS_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+	year: "numeric",
+	month: "2-digit",
+	day: "2-digit"
+});
+
+const makeDateKey = (year: number, month: number, day: number): string =>
+	`${year.toString().padStart(4, "0")}-${month.toString().padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
+
+const parseDateKey = (value: string) => {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+	if (!match) {
+		throw new Error(`Invalid work date: ${value}`);
+	}
+
+	return {
+		year: Number(match[1]),
+		month: Number(match[2]),
+		day: Number(match[3])
+	};
+};
+
+const shiftDateKey = (value: string, offsetDays: number): string => {
+	const { year, month, day } = parseDateKey(value);
+	const shifted = new Date(Date.UTC(year, month - 1, day));
+	shifted.setUTCDate(shifted.getUTCDate() + offsetDays);
+
+	return makeDateKey(shifted.getUTCFullYear(), shifted.getUTCMonth() + 1, shifted.getUTCDate());
+};
+
+const getLocalDateKey = (date: Date, timezone: string): string => {
+	const zoned = new Intl.DateTimeFormat("en-CA", {
+		timeZone: timezone,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit"
+	}).formatToParts(date).reduce<Record<string, string>>((acc, part) => {
+		if (part.type !== "literal") {
+			acc[part.type] = part.value;
+		}
+		return acc;
+	}, {});
+
+	return makeDateKey(Number(zoned.year), Number(zoned.month), Number(zoned.day));
+};
+
+const getTimeZoneOffsetMs = (date: Date, timezone: string): number => {
+	const parts = new Intl.DateTimeFormat("en-US", {
+		timeZone: timezone,
+		hour12: false,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit"
+	}).formatToParts(date).reduce<Record<string, string>>((acc, part) => {
+		if (part.type !== "literal") {
+			acc[part.type] = part.value;
+		}
+		return acc;
+	}, {});
+
+	const utcFromZone = Date.UTC(
+		Number(parts.year),
+		Number(parts.month) - 1,
+		Number(parts.day),
+		Number(parts.hour),
+		Number(parts.minute),
+		Number(parts.second)
+	);
+
+	return utcFromZone - date.getTime();
+};
+
+const zonedDateKeyToUtcIso = (dateKey: string, timezone: string): string => {
+	const { year, month, day } = parseDateKey(dateKey);
+	const utcGuess = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+	const offsetMs = getTimeZoneOffsetMs(utcGuess, timezone);
+
+	return new Date(utcGuess.getTime() - offsetMs).toISOString();
+};
+
+const buildWindowForDate = (targetWorkDate: string, timezone: string): TargetDayWindow => ({
+	targetWorkDate,
+	rangeStartIso: zonedDateKeyToUtcIso(targetWorkDate, timezone),
+	rangeEndIso: zonedDateKeyToUtcIso(shiftDateKey(targetWorkDate, 1), timezone),
+	dayOfWeek: new Date(`${targetWorkDate}T00:00:00.000Z`).getUTCDay()
+});
+
+const zonedDateTimeToUtcIso = (
+	dateKey: string,
+	timezone: string,
+	hour: number,
+	minute = 0,
+	second = 0
+): string => {
+	const { year, month, day } = parseDateKey(dateKey);
+	const utcGuess = new Date(Date.UTC(year, month - 1, day, hour, minute, second));
+	const offsetMs = getTimeZoneOffsetMs(utcGuess, timezone);
+
+	return new Date(utcGuess.getTime() - offsetMs).toISOString();
+};
+
+export const buildTargetDayWindow = ({
+	now,
+	timezone
+}: {
+	now: Date;
+	timezone: string;
+}): TargetDayWindow => {
+	const currentLocalDate = getLocalDateKey(now, timezone);
+	return buildWindowForDate(shiftDateKey(currentLocalDate, -1), timezone);
+};
+
+const isWeekend = (dayOfWeek: number): boolean => dayOfWeek === 0 || dayOfWeek === 6;
+
+const normalizeNasUsername = (value: string | null): string => value?.trim().toLowerCase() ?? "";
+const normalizePath = (value: string | null): string =>
+	value?.trim().replace(/[\\/]+$/, "").toLowerCase() ?? "";
+const diffMinutes = (startIso: string, endIso: string): number =>
+	Math.max(0, Math.floor((Date.parse(endIso) - Date.parse(startIso)) / 60000));
+
+const filterAcceptedLogs = ({
+	logs,
+	ignoreAccounts
+}: {
+	logs: AutoTimeAssetLog[];
+	ignoreAccounts: string[];
+}) => {
+	const ignoredAccountSet = new Set(ignoreAccounts.map((entry) => entry.trim().toLowerCase()).filter(Boolean));
+	let ignoredAccountCount = 0;
+	let incompleteCount = 0;
+
+	const acceptedLogs = logs.filter((log) => {
+		const normalizedUsername = normalizeNasUsername(log.nas_username);
+		const normalizedPath = log.file_path?.trim() ?? "";
+
+		if (!normalizedUsername || !normalizedPath) {
+			incompleteCount += 1;
+			return false;
+		}
+
+		if (ignoredAccountSet.has(normalizedUsername)) {
+			ignoredAccountCount += 1;
+			return false;
+		}
+
+		return true;
+	});
+
+	return {
+		acceptedLogs,
+		ignoredAccountCount,
+		incompleteCount
+	};
+};
+
+const buildAliasMap = (aliases: AutoTimeNasUserAlias[]): Map<string, string> =>
+	new Map(
+		aliases
+			.map((alias) => [normalizeNasUsername(alias.nas_username), alias.user_id] as const)
+			.filter(([nasUsername, userId]) => Boolean(nasUsername) && Boolean(userId))
+	);
+
+const buildSortedProjectRoots = (roots: AutoTimeProjectRoot[]): Array<AutoTimeProjectRoot & { normalized_root_path: string }> =>
+	roots
+		.map((root) => ({
+			...root,
+			normalized_root_path: normalizePath(root.root_path)
+		}))
+		.filter((root) => Boolean(root.normalized_root_path))
+		.sort((left, right) => right.normalized_root_path.length - left.normalized_root_path.length);
+
+const resolveUserId = (log: AutoTimeAssetLog, aliasMap: Map<string, string>): string | null => {
+	if (log.sa_ai_user_id) {
+		return log.sa_ai_user_id;
+	}
+
+	return aliasMap.get(normalizeNasUsername(log.nas_username)) ?? null;
+};
+
+const resolveProjectRoot = (
+	log: AutoTimeAssetLog,
+	projectRoots: Array<AutoTimeProjectRoot & { normalized_root_path: string }>
+) => {
+	const normalizedFilePath = normalizePath(log.file_path);
+
+	return projectRoots.find((root) =>
+		normalizedFilePath === root.normalized_root_path
+		|| normalizedFilePath.startsWith(`${root.normalized_root_path}/`)
+		|| normalizedFilePath.startsWith(`${root.normalized_root_path}\\`)
+	) ?? null;
+};
+
+const compressConsecutiveProjectEvents = (
+	projectEvents: AutoTimeProjectEvent[]
+): AutoTimeCompressedProjectEvent[] => {
+	const sortedEvents = [...projectEvents]
+		.sort((left, right) => Date.parse(left.detected_at) - Date.parse(right.detected_at));
+	const compressedEvents: AutoTimeCompressedProjectEvent[] = [];
+
+	for (const event of sortedEvents) {
+		const previousEvent = compressedEvents[compressedEvents.length - 1];
+		if (
+			previousEvent
+			&& previousEvent.project_id === event.project_id
+			&& previousEvent.project_root_id === event.project_root_id
+		) {
+			continue;
+		}
+
+		compressedEvents.push(event);
+	}
+
+	return compressedEvents;
+};
+
+type AutoTimeCandidateAggregation = {
+	org_id: string;
+	target_work_date: string;
+	nas_username: string;
+	user_id: string;
+	project_id: string;
+	project_root_id: string;
+	source_event_count: number;
+	source_event_ids: string[];
+	source_paths: string[];
+	first_detected_at: string | null;
+	last_detected_at: string | null;
+	raw_first_activity_at: string | null;
+	raw_last_activity_at: string | null;
+	raw_total_minutes: number;
+	unattributed_minutes: number;
+	raw_project_minutes: number;
+	normalized_project_minutes: number;
+	allocation_method: string;
+	allocation_version: string;
+	allocation_meta: Record<string, unknown>;
+	metadata: Record<string, unknown>;
+};
+
+export type AutoTimeProjectEvent = {
+	project_id: string;
+	project_root_id: string;
+	detected_at: string;
+};
+
+export type AutoTimeCompressedProjectEvent = AutoTimeProjectEvent;
+
+export type AutoTimeProjectInterval = {
+	project_id: string;
+	project_root_id: string;
+	start_at: string;
+	end_at: string;
+	interval_minutes: number;
+};
+
+export type AutoTimeProjectMinutes = {
+	project_id: string;
+	project_root_id: string;
+	raw_project_minutes: number;
+	normalized_project_minutes: number;
+	formal_generated_minutes?: number | null;
+};
+
+export type AutoTimeRawAllocationDiagnostics = {
+	raw_total_minutes: number;
+	unattributed_minutes: number;
+	attributed_total_minutes: number;
+	distinct_project_count: number;
+	compressed_project_events: AutoTimeCompressedProjectEvent[];
+	project_intervals: AutoTimeProjectInterval[];
+	largest_interval_minutes: number;
+	project_minutes: AutoTimeProjectMinutes[];
+};
+
+type AutoTimeUserAllocationDiagnostic = {
+	nas_username: string;
+	user_id: string;
+	raw_first_activity_at: string | null;
+	raw_last_activity_at: string | null;
+	raw_total_minutes: number;
+	unattributed_minutes: number;
+	attributed_total_minutes: number;
+	distinct_project_count: number;
+	allocation_method: string;
+	allocation_version: string;
+	large_gap_threshold_minutes: number;
+	large_gap_hit: boolean;
+	largest_interval_minutes: number;
+	conservative_mode_hit: boolean;
+	conservative_mode_reason: string | null;
+	formal_write_skipped: boolean;
+	formal_write_skip_reason: string | null;
+	formal_allocation_mode: AutoTimeAllocationMode;
+	project_minutes: AutoTimeProjectMinutes[];
+};
+
+const RAW_ALLOCATION_METHOD = "interval_to_previous_project";
+const RAW_ALLOCATION_VERSION = "stage_a_v1";
+const CONSERVATIVE_MODE_PROJECT_THRESHOLD = 3;
+
+export const normalizeProjectMinutesToFixedTotal = (
+	projectMinutes: Array<Pick<AutoTimeProjectMinutes, "project_id" | "project_root_id" | "raw_project_minutes">>,
+	totalMinutes: number
+): AutoTimeProjectMinutes[] => {
+	if (projectMinutes.length === 0) {
+		return [];
+	}
+
+	const attributedTotalMinutes = projectMinutes.reduce((sum, entry) => sum + entry.raw_project_minutes, 0);
+	if (attributedTotalMinutes <= 0 || totalMinutes <= 0) {
+		return projectMinutes.map((entry) => ({
+			...entry,
+			normalized_project_minutes: 0
+		}));
+	}
+
+	let assignedMinutes = 0;
+	return projectMinutes.map((entry, index) => {
+		const isLast = index === projectMinutes.length - 1;
+		const normalizedProjectMinutes = isLast
+			? totalMinutes - assignedMinutes
+			: Math.floor((entry.raw_project_minutes / attributedTotalMinutes) * totalMinutes);
+		assignedMinutes += normalizedProjectMinutes;
+
+		return {
+			...entry,
+			normalized_project_minutes: normalizedProjectMinutes
+		};
+	});
+};
+
+export const normalizeProjectMinutesTo480 = (
+	projectMinutes: Array<Pick<AutoTimeProjectMinutes, "project_id" | "project_root_id" | "raw_project_minutes">>
+): AutoTimeProjectMinutes[] => normalizeProjectMinutesToFixedTotal(projectMinutes, 480);
+
+export const buildProjectIntervalsFromEvents = ({
+	compressedProjectEvents,
+	rawLastActivityAt
+}: {
+	compressedProjectEvents: AutoTimeCompressedProjectEvent[];
+	rawLastActivityAt: string;
+}): AutoTimeProjectInterval[] =>
+	compressedProjectEvents.map((event, index) => {
+		const endAt = compressedProjectEvents[index + 1]?.detected_at ?? rawLastActivityAt;
+		return {
+			project_id: event.project_id,
+			project_root_id: event.project_root_id,
+			start_at: event.detected_at,
+			end_at: endAt,
+			interval_minutes: diffMinutes(event.detected_at, endAt)
+		};
+	});
+
+export const calculateRawProjectMinutes = (
+	projectIntervals: AutoTimeProjectInterval[]
+): AutoTimeProjectMinutes[] => {
+	const projectMinutesByKey = new Map<string, AutoTimeProjectMinutes>();
+
+	for (const interval of projectIntervals) {
+		const key = `${interval.project_id}|${interval.project_root_id}`;
+		const existing = projectMinutesByKey.get(key);
+
+		if (existing) {
+			existing.raw_project_minutes += interval.interval_minutes;
+			continue;
+		}
+
+		projectMinutesByKey.set(key, {
+			project_id: interval.project_id,
+			project_root_id: interval.project_root_id,
+			raw_project_minutes: interval.interval_minutes,
+			normalized_project_minutes: 0
+		});
+	}
+
+	return Array.from(projectMinutesByKey.values());
+};
+
+const buildFormalProjectMinutes = ({
+	projectMinutes,
+	formalAllocationMode,
+	formalWriteSkipped
+}: {
+	projectMinutes: AutoTimeProjectMinutes[];
+	formalAllocationMode: AutoTimeAllocationMode;
+	formalWriteSkipped: boolean;
+}): AutoTimeProjectMinutes[] => {
+	if (formalWriteSkipped) {
+		return projectMinutes.map((entry) => ({
+			...entry,
+			formal_generated_minutes: null
+		}));
+	}
+
+	if (formalAllocationMode === "interval_to_previous_project") {
+		return projectMinutes.map((entry) => ({
+			...entry,
+			formal_generated_minutes: entry.normalized_project_minutes
+		}));
+	}
+
+	const evenSplitMinutes = allocateDurations(projectMinutes.length);
+	return projectMinutes.map((entry, index) => ({
+		...entry,
+		formal_generated_minutes: evenSplitMinutes[index] ?? 0
+	}));
+};
+
+export const buildAllocationSummary = ({
+	nasUsername,
+	userId,
+	rawFirstActivityAt,
+	rawLastActivityAt,
+	rawAllocation,
+	formalAllocationMode,
+	largeGapThresholdMinutes,
+	skipFormalWriteOnLargeGap
+}: {
+	nasUsername: string;
+	userId: string;
+	rawFirstActivityAt: string | null;
+	rawLastActivityAt: string | null;
+	rawAllocation: AutoTimeRawAllocationDiagnostics;
+	formalAllocationMode: AutoTimeAllocationMode;
+	largeGapThresholdMinutes: number;
+	skipFormalWriteOnLargeGap: boolean;
+}): AutoTimeUserAllocationDiagnostic => {
+	const conservativeModeHit = rawAllocation.distinct_project_count >= CONSERVATIVE_MODE_PROJECT_THRESHOLD;
+	const largestIntervalMinutes = rawAllocation.largest_interval_minutes;
+	const largeGapHit = largestIntervalMinutes >= largeGapThresholdMinutes;
+	const formalWriteSkipReasons: string[] = [];
+
+	if (
+		formalAllocationMode === "interval_to_previous_project"
+		&& largeGapHit
+		&& skipFormalWriteOnLargeGap
+	) {
+		formalWriteSkipReasons.push(`largest_interval_minutes_gte_${largeGapThresholdMinutes}`);
+	}
+
+	const formalWriteSkipped = formalWriteSkipReasons.length > 0;
+	const projectMinutes = buildFormalProjectMinutes({
+		projectMinutes: normalizeProjectMinutesTo480(rawAllocation.project_minutes),
+		formalAllocationMode,
+		formalWriteSkipped
+	});
+
+	return {
+		nas_username: nasUsername,
+		user_id: userId,
+		raw_first_activity_at: rawFirstActivityAt,
+		raw_last_activity_at: rawLastActivityAt,
+		raw_total_minutes: rawAllocation.raw_total_minutes,
+		unattributed_minutes: rawAllocation.unattributed_minutes,
+		attributed_total_minutes: rawAllocation.attributed_total_minutes,
+		distinct_project_count: rawAllocation.distinct_project_count,
+		allocation_method: RAW_ALLOCATION_METHOD,
+		allocation_version: RAW_ALLOCATION_VERSION,
+		large_gap_threshold_minutes: largeGapThresholdMinutes,
+		large_gap_hit: largeGapHit,
+		largest_interval_minutes: largestIntervalMinutes,
+		conservative_mode_hit: conservativeModeHit,
+		conservative_mode_reason: conservativeModeHit ? "distinct_project_count_gte_3" : null,
+		formal_write_skipped: formalWriteSkipped,
+		formal_write_skip_reason: formalWriteSkipReasons.length > 0 ? formalWriteSkipReasons.join(",") : null,
+		formal_allocation_mode: formalAllocationMode,
+		project_minutes: projectMinutes
+	};
+};
+
+const buildAllocationSampleRows = ({
+	targetWorkDate,
+	allocationDiagnostics
+}: {
+	targetWorkDate: string;
+	allocationDiagnostics: AutoTimeUserAllocationDiagnostic[];
+}): Array<Record<string, unknown>> =>
+	allocationDiagnostics.map((entry) => ({
+		target_work_date: targetWorkDate,
+		nas_username: entry.nas_username,
+		user_id: entry.user_id,
+		raw_first_activity_at: entry.raw_first_activity_at,
+		raw_last_activity_at: entry.raw_last_activity_at,
+		raw_total_minutes: entry.raw_total_minutes,
+		unattributed_minutes: entry.unattributed_minutes,
+		attributed_total_minutes: entry.attributed_total_minutes,
+		distinct_project_count: entry.distinct_project_count,
+		large_gap_threshold_minutes: entry.large_gap_threshold_minutes,
+		large_gap_hit: entry.large_gap_hit,
+		largest_interval_minutes: entry.largest_interval_minutes,
+		conservative_mode_hit: entry.conservative_mode_hit,
+		conservative_mode_reason: entry.conservative_mode_reason,
+		formal_write_skipped: entry.formal_write_skipped,
+		formal_write_skip_reason: entry.formal_write_skip_reason,
+		formal_allocation_mode: entry.formal_allocation_mode,
+		projects: entry.project_minutes.map((projectEntry) => ({
+			project_id: projectEntry.project_id,
+			project_root_id: projectEntry.project_root_id,
+			raw_project_minutes: projectEntry.raw_project_minutes,
+			normalized_project_minutes: projectEntry.normalized_project_minutes,
+			formal_generated_minutes: projectEntry.formal_generated_minutes ?? null
+		}))
+	}));
+
+export const buildRawAllocationDiagnostics = ({
+	dayStartIso,
+	rawLastActivityAt,
+	projectEvents
+}: {
+	dayStartIso: string;
+	rawLastActivityAt: string | null;
+	projectEvents: AutoTimeProjectEvent[];
+}): AutoTimeRawAllocationDiagnostics => {
+	if (!rawLastActivityAt || Date.parse(rawLastActivityAt) <= Date.parse(dayStartIso)) {
+		return {
+			raw_total_minutes: 0,
+			unattributed_minutes: 0,
+			attributed_total_minutes: 0,
+			distinct_project_count: 0,
+			compressed_project_events: [],
+			project_intervals: [],
+			largest_interval_minutes: 0,
+			project_minutes: []
+		};
+	}
+
+	const rawTotalMinutes = diffMinutes(dayStartIso, rawLastActivityAt);
+	const inWindowProjectEvents = projectEvents.filter((event) => {
+		const eventTime = Date.parse(event.detected_at);
+		return eventTime >= Date.parse(dayStartIso) && eventTime <= Date.parse(rawLastActivityAt);
+	});
+	const compressedProjectEvents = compressConsecutiveProjectEvents(inWindowProjectEvents);
+
+	if (compressedProjectEvents.length === 0) {
+		return {
+			raw_total_minutes: rawTotalMinutes,
+			unattributed_minutes: rawTotalMinutes,
+			attributed_total_minutes: 0,
+			distinct_project_count: 0,
+			compressed_project_events: [],
+			project_intervals: [],
+			largest_interval_minutes: 0,
+			project_minutes: []
+		};
+	}
+
+	const unattributedMinutes = diffMinutes(dayStartIso, compressedProjectEvents[0].detected_at);
+	const projectIntervals = buildProjectIntervalsFromEvents({
+		compressedProjectEvents,
+		rawLastActivityAt
+	});
+	const rawProjectMinutes = calculateRawProjectMinutes(projectIntervals);
+	return {
+		raw_total_minutes: rawTotalMinutes,
+		unattributed_minutes: unattributedMinutes,
+		attributed_total_minutes: rawProjectMinutes.reduce((sum, entry) => sum + entry.raw_project_minutes, 0),
+		distinct_project_count: rawProjectMinutes.length,
+		compressed_project_events: compressedProjectEvents,
+		project_intervals: projectIntervals,
+		largest_interval_minutes: projectIntervals.reduce((maxMinutes, interval) => Math.max(maxMinutes, interval.interval_minutes), 0),
+		project_minutes: rawProjectMinutes
+	};
+};
+
+const aggregateCandidateItems = ({
+	orgId,
+	logs,
+	targetWorkDate,
+	timezone,
+	formalAllocationMode,
+	largeGapThresholdMinutes,
+	skipFormalWriteOnLargeGap,
+	aliases,
+	projectRoots
+}: {
+	orgId: string;
+	logs: AutoTimeAssetLog[];
+	targetWorkDate: string;
+	timezone: string;
+	formalAllocationMode: AutoTimeAllocationMode;
+	largeGapThresholdMinutes: number;
+	skipFormalWriteOnLargeGap: boolean;
+	aliases: AutoTimeNasUserAlias[];
+	projectRoots: AutoTimeProjectRoot[];
+}) => {
+	const aliasMap = buildAliasMap(aliases);
+	const sortedProjectRoots = buildSortedProjectRoots(projectRoots);
+	const dayStartIso = zonedDateTimeToUtcIso(targetWorkDate, timezone, 10);
+	let unmappedUserCount = 0;
+	let unmappedProjectCount = 0;
+	const candidateMap = new Map<string, AutoTimeCandidateAggregation>();
+	const userActivityMap = new Map<string, {
+		nas_username: string;
+		user_id: string;
+		raw_first_activity_at: string | null;
+		raw_last_activity_at: string | null;
+		project_events: AutoTimeProjectEvent[];
+	}>();
+
+	for (const log of logs) {
+		const userId = resolveUserId(log, aliasMap);
+		if (!userId) {
+			unmappedUserCount += 1;
+			continue;
+		}
+
+		const existingUserActivity = userActivityMap.get(userId);
+		if (existingUserActivity) {
+			existingUserActivity.raw_first_activity_at = existingUserActivity.raw_first_activity_at
+				&& existingUserActivity.raw_first_activity_at < log.detected_at
+				? existingUserActivity.raw_first_activity_at
+				: log.detected_at;
+			existingUserActivity.raw_last_activity_at = existingUserActivity.raw_last_activity_at
+				&& existingUserActivity.raw_last_activity_at > log.detected_at
+				? existingUserActivity.raw_last_activity_at
+				: log.detected_at;
+		} else {
+			userActivityMap.set(userId, {
+				nas_username: log.nas_username?.trim() ?? "",
+				user_id: userId,
+				raw_first_activity_at: log.detected_at,
+				raw_last_activity_at: log.detected_at,
+				project_events: []
+			});
+		}
+
+		const projectRoot = resolveProjectRoot(log, sortedProjectRoots);
+		if (!projectRoot) {
+			unmappedProjectCount += 1;
+			continue;
+		}
+
+		userActivityMap.get(userId)?.project_events.push({
+			project_id: projectRoot.project_id,
+			project_root_id: projectRoot.id,
+			detected_at: log.detected_at
+		});
+
+		const key = `${userId}|${targetWorkDate}|${projectRoot.project_id}`;
+		const normalizedPath = log.file_path?.trim() ?? "";
+		const existing = candidateMap.get(key);
+
+		if (existing) {
+			existing.source_event_count += 1;
+			existing.source_event_ids.push(log.id);
+			if (!existing.source_paths.includes(normalizedPath)) {
+				existing.source_paths.push(normalizedPath);
+			}
+			existing.first_detected_at = existing.first_detected_at && existing.first_detected_at < log.detected_at
+				? existing.first_detected_at
+				: log.detected_at;
+			existing.last_detected_at = existing.last_detected_at && existing.last_detected_at > log.detected_at
+				? existing.last_detected_at
+				: log.detected_at;
+			continue;
+		}
+
+		candidateMap.set(key, {
+			org_id: orgId,
+			target_work_date: targetWorkDate,
+			nas_username: log.nas_username?.trim() ?? "",
+			user_id: userId,
+			project_id: projectRoot.project_id,
+			project_root_id: projectRoot.id,
+			source_event_count: 1,
+			source_event_ids: [log.id],
+			source_paths: normalizedPath ? [normalizedPath] : [],
+			first_detected_at: log.detected_at,
+			last_detected_at: log.detected_at,
+			raw_first_activity_at: null,
+			raw_last_activity_at: null,
+			raw_total_minutes: 0,
+			unattributed_minutes: 0,
+			raw_project_minutes: 0,
+			normalized_project_minutes: 0,
+			allocation_method: RAW_ALLOCATION_METHOD,
+			allocation_version: RAW_ALLOCATION_VERSION,
+			allocation_meta: {},
+			metadata: {
+				source: "asset_version_log",
+				resolved_via: log.sa_ai_user_id ? "sa_ai_user_id" : "nas_user_aliases"
+			}
+		});
+	}
+
+	const allocationDiagnostics = Array.from(userActivityMap.values()).map((userActivity) => {
+		const rawAllocation = buildRawAllocationDiagnostics({
+			dayStartIso,
+			rawLastActivityAt: userActivity.raw_last_activity_at,
+			projectEvents: userActivity.project_events
+		});
+		return buildAllocationSummary({
+			nasUsername: userActivity.nas_username,
+			userId: userActivity.user_id,
+			rawFirstActivityAt: userActivity.raw_first_activity_at,
+			rawLastActivityAt: userActivity.raw_last_activity_at,
+			rawAllocation,
+			formalAllocationMode,
+			largeGapThresholdMinutes,
+			skipFormalWriteOnLargeGap
+		});
+	});
+	const allocationDiagnosticsByUserId = new Map(
+		allocationDiagnostics.map((entry) => [entry.user_id, entry] as const)
+	);
+	const candidateItems = Array.from(candidateMap.values()).map((candidateItem) => {
+		const userDiagnostic = allocationDiagnosticsByUserId.get(candidateItem.user_id);
+		const projectDiagnostic = userDiagnostic?.project_minutes.find((entry) =>
+			entry.project_id === candidateItem.project_id
+			&& entry.project_root_id === candidateItem.project_root_id
+		);
+
+		return {
+			...candidateItem,
+			raw_first_activity_at: userDiagnostic?.raw_first_activity_at ?? null,
+			raw_last_activity_at: userDiagnostic?.raw_last_activity_at ?? null,
+			raw_total_minutes: userDiagnostic?.raw_total_minutes ?? 0,
+			unattributed_minutes: userDiagnostic?.unattributed_minutes ?? 0,
+			raw_project_minutes: projectDiagnostic?.raw_project_minutes ?? 0,
+			normalized_project_minutes: projectDiagnostic?.normalized_project_minutes ?? 0,
+			allocation_method: userDiagnostic?.allocation_method ?? RAW_ALLOCATION_METHOD,
+			allocation_version: userDiagnostic?.allocation_version ?? RAW_ALLOCATION_VERSION,
+			allocation_meta: {
+				raw_first_activity_at: userDiagnostic?.raw_first_activity_at ?? null,
+				raw_last_activity_at: userDiagnostic?.raw_last_activity_at ?? null,
+				raw_total_minutes: userDiagnostic?.raw_total_minutes ?? 0,
+				unattributed_minutes: userDiagnostic?.unattributed_minutes ?? 0,
+				attributed_total_minutes: userDiagnostic?.attributed_total_minutes ?? 0,
+				distinct_project_count: userDiagnostic?.distinct_project_count ?? 0,
+				diagnostic_normalized_project_minutes: projectDiagnostic?.normalized_project_minutes ?? 0,
+				formal_generated_minutes: projectDiagnostic?.formal_generated_minutes ?? null,
+				formal_allocation_mode: userDiagnostic?.formal_allocation_mode ?? formalAllocationMode,
+				large_gap_threshold_minutes: userDiagnostic?.large_gap_threshold_minutes ?? largeGapThresholdMinutes,
+				large_gap_hit: userDiagnostic?.large_gap_hit ?? false,
+				largest_interval_minutes: userDiagnostic?.largest_interval_minutes ?? 0,
+				conservative_mode_hit: userDiagnostic?.conservative_mode_hit ?? false,
+				conservative_mode_reason: userDiagnostic?.conservative_mode_reason ?? null,
+				formal_write_skipped: userDiagnostic?.formal_write_skipped ?? false,
+				formal_write_skip_reason: userDiagnostic?.formal_write_skip_reason ?? null,
+				allocation_method: userDiagnostic?.allocation_method ?? RAW_ALLOCATION_METHOD,
+				allocation_version: userDiagnostic?.allocation_version ?? RAW_ALLOCATION_VERSION
+			},
+			metadata: {
+				...candidateItem.metadata,
+				allocation: {
+					raw_first_activity_at: userDiagnostic?.raw_first_activity_at ?? null,
+					raw_last_activity_at: userDiagnostic?.raw_last_activity_at ?? null,
+					raw_total_minutes: userDiagnostic?.raw_total_minutes ?? 0,
+					unattributed_minutes: userDiagnostic?.unattributed_minutes ?? 0,
+					attributed_total_minutes: userDiagnostic?.attributed_total_minutes ?? 0,
+					distinct_project_count: userDiagnostic?.distinct_project_count ?? 0,
+					raw_project_minutes: projectDiagnostic?.raw_project_minutes ?? 0,
+					normalized_project_minutes: projectDiagnostic?.normalized_project_minutes ?? 0,
+					formal_generated_minutes: projectDiagnostic?.formal_generated_minutes ?? null,
+					formal_allocation_mode: userDiagnostic?.formal_allocation_mode ?? formalAllocationMode,
+					large_gap_threshold_minutes: userDiagnostic?.large_gap_threshold_minutes ?? largeGapThresholdMinutes,
+					large_gap_hit: userDiagnostic?.large_gap_hit ?? false,
+					largest_interval_minutes: userDiagnostic?.largest_interval_minutes ?? 0,
+					conservative_mode_hit: userDiagnostic?.conservative_mode_hit ?? false,
+					conservative_mode_reason: userDiagnostic?.conservative_mode_reason ?? null,
+					formal_write_skipped: userDiagnostic?.formal_write_skipped ?? false,
+					formal_write_skip_reason: userDiagnostic?.formal_write_skip_reason ?? null,
+					allocation_method: userDiagnostic?.allocation_method ?? RAW_ALLOCATION_METHOD,
+					allocation_version: userDiagnostic?.allocation_version ?? RAW_ALLOCATION_VERSION
+				}
+			}
+		};
+	});
+
+	return {
+		unmappedUserCount,
+		unmappedProjectCount,
+		candidateItemCount: candidateMap.size,
+		allocationDiagnostics,
+		candidateItems
+	};
+};
+
+const allocateDurations = (count: number): number[] => {
+	if (count <= 0) {
+		return [];
+	}
+
+	const base = Math.floor(480 / count);
+	const remainder = 480 - (base * count);
+
+	return Array.from({
+		length: count
+	}, (_, index) => base + (index === count - 1 ? remainder : 0));
+};
+
+const buildRunItems = ({
+	candidateItems,
+	manualOverrideUserIds,
+	formalAllocationMode
+}: {
+	candidateItems: AutoTimeCandidateAggregation[];
+	manualOverrideUserIds: string[];
+	formalAllocationMode: AutoTimeAllocationMode;
+}): {
+	runItems: AutoTimeRunItemInsert[];
+	manualOverrideItems: number;
+	policyGuardItems: number;
+} => {
+	const manualOverrideSet = new Set(manualOverrideUserIds);
+	const candidateItemsByUser = new Map<string, AutoTimeCandidateAggregation[]>();
+
+	for (const candidateItem of candidateItems) {
+		const existing = candidateItemsByUser.get(candidateItem.user_id) ?? [];
+		existing.push(candidateItem);
+		candidateItemsByUser.set(candidateItem.user_id, existing);
+	}
+
+	const runItems: AutoTimeRunItemInsert[] = [];
+	let manualOverrideItems = 0;
+	let policyGuardItems = 0;
+
+	for (const userItems of candidateItemsByUser.values()) {
+		const sortedItems = [...userItems].sort((left, right) => left.project_id.localeCompare(right.project_id));
+		const isManualOverride = manualOverrideSet.has(sortedItems[0].user_id);
+		const evenSplitAllocations = isManualOverride || formalAllocationMode === "interval_to_previous_project"
+			? []
+			: allocateDurations(sortedItems.length);
+
+		for (const [index, item] of sortedItems.entries()) {
+			const policyGuardSkipped = Boolean(item.allocation_meta.formal_write_skipped);
+			const generatedDurationMinutes = isManualOverride || policyGuardSkipped
+				? null
+				: formalAllocationMode === "interval_to_previous_project"
+					? item.normalized_project_minutes
+					: evenSplitAllocations[index];
+			const resolutionStatus = isManualOverride
+				? "manual_override_skipped"
+				: policyGuardSkipped
+					? "policy_guard_skipped"
+					: "accepted";
+			const resolutionReason = isManualOverride
+				? "manual task already exists for target work date"
+				: policyGuardSkipped
+					? String(item.allocation_meta.formal_write_skip_reason ?? "formal write skipped by allocation policy guard")
+					: null;
+
+			if (isManualOverride) {
+				manualOverrideItems += 1;
+			} else if (policyGuardSkipped) {
+				policyGuardItems += 1;
+			}
+
+			runItems.push({
+				org_id: item.org_id,
+				target_work_date: item.target_work_date,
+				nas_username: item.nas_username,
+				user_id: item.user_id,
+				project_id: item.project_id,
+				project_root_id: item.project_root_id,
+				source_event_count: item.source_event_count,
+				source_event_ids: item.source_event_ids,
+				source_paths: item.source_paths,
+				first_detected_at: item.first_detected_at,
+				last_detected_at: item.last_detected_at,
+				raw_first_activity_at: item.raw_first_activity_at,
+				raw_last_activity_at: item.raw_last_activity_at,
+				raw_total_minutes: item.raw_total_minutes,
+				unattributed_minutes: item.unattributed_minutes,
+				raw_project_minutes: item.raw_project_minutes,
+				normalized_project_minutes: item.normalized_project_minutes,
+				allocation_method: item.allocation_method,
+				allocation_version: item.allocation_version,
+				allocation_meta: {
+					...item.allocation_meta,
+					formal_generated_minutes: generatedDurationMinutes,
+					formal_allocation_mode: formalAllocationMode
+				},
+				resolution_status: resolutionStatus,
+				resolution_reason: resolutionReason,
+				generated_duration_minutes: generatedDurationMinutes,
+				metadata: item.metadata
+			});
+		}
+	}
+
+	return {
+		runItems,
+		manualOverrideItems,
+		policyGuardItems
+	};
+};
+
+const buildTaskInserts = ({
+	runId,
+	runItems,
+	existingAutoTaskKeys = []
+}: {
+	runId: string;
+	runItems: AutoTimePersistedRunItem[];
+	existingAutoTaskKeys?: string[];
+}): AutoTimeTaskInsert[] =>
+	runItems
+		.filter((item) =>
+			item.resolution_status === "accepted"
+			&& Boolean(item.user_id)
+			&& Boolean(item.project_id)
+			&& item.generated_duration_minutes !== null
+			&& item.generated_duration_minutes > 0
+			&& !existingAutoTaskKeys.includes(`${item.user_id}|${item.project_id}|${item.target_work_date}`)
+		)
+		.map((item) => ({
+			org_id: item.org_id,
+			user_id: item.user_id as string,
+			project_id: item.project_id as string,
+			task_name: "NAS自动工时",
+			work_date: item.target_work_date,
+			duration_minutes: item.generated_duration_minutes as number,
+			notes: "基于 asset_version_log 自动生成",
+			entry_source: "nas_auto",
+			source_run_id: runId,
+			source_item_id: item.id
+		}));
+
+export const runAutoTimeCapture = async ({
+	config,
+	repository,
+	now = new Date()
+}: {
+	config: AutoTimeRunnerConfig;
+	repository: AutoTimeRunnerRepository;
+	now?: Date;
+}): Promise<{
+	runId?: string;
+	status: AutoTimeRunStatus | "dry-run";
+	summary: AutoTimeRunnerSummary;
+}> => {
+	const window = buildWindowForDate(config.targetWorkDate, config.timezone);
+	let summary: AutoTimeRunnerSummary = {
+		stage: "skeleton_pending_implementation",
+		target_work_date: window.targetWorkDate,
+		timezone: config.timezone,
+		range_start: window.rangeStartIso,
+		range_end: window.rangeEndIso,
+		day_of_week: window.dayOfWeek,
+		actions: config.actions,
+		total_logs_scanned: 0,
+		total_logs_accepted: 0,
+		total_tasks_written: 0,
+		formal_allocation_mode: config.allocationMode,
+		rebuild_nas_auto: config.rebuildNasAuto
+	};
+	let runId: string | undefined;
+
+	if (config.ignoreWeekends && isWeekend(window.dayOfWeek)) {
+		return {
+			status: "skipped",
+			summary: {
+				...summary,
+				skipReason: "weekend"
+			}
+		};
+	}
+
+	const holidayEntry = getHolidayEntry(config.targetWorkDate);
+	if (holidayEntry?.isOffDay) {
+		return {
+			status: "skipped",
+			summary: {
+				...summary,
+				skipReason: "holiday"
+			}
+		};
+	}
+
+	try {
+		if (repository.loadAssetLogs) {
+			const ignoreAccounts = repository.loadIgnoreAccounts
+				? await repository.loadIgnoreAccounts(config.orgId)
+				: [];
+			const loadedLogs = await repository.loadAssetLogs({
+				sourceTable: config.sourceTable,
+				rangeStartIso: window.rangeStartIso,
+				rangeEndIso: window.rangeEndIso,
+				actions: config.actions
+			});
+			const filteredLogs = filterAcceptedLogs({
+				logs: loadedLogs,
+				ignoreAccounts
+			});
+
+			summary = {
+				...summary,
+				stage: "logs_loaded",
+				total_logs_scanned: loadedLogs.length,
+				total_logs_accepted: filteredLogs.acceptedLogs.length,
+				total_logs_ignored_accounts: filteredLogs.ignoredAccountCount,
+				total_logs_rejected_incomplete: filteredLogs.incompleteCount
+			};
+
+			if (repository.loadNasUserAliases && repository.loadProjectRoots) {
+				const aliases = await repository.loadNasUserAliases(config.orgId);
+				const projectRoots = await repository.loadProjectRoots(config.orgId);
+				const candidates = aggregateCandidateItems({
+					orgId: config.orgId,
+					logs: filteredLogs.acceptedLogs,
+					targetWorkDate: config.targetWorkDate,
+					timezone: config.timezone,
+					formalAllocationMode: config.allocationMode,
+					largeGapThresholdMinutes: config.largeGapThresholdMinutes,
+					skipFormalWriteOnLargeGap: config.skipFormalWriteOnLargeGap,
+					aliases,
+					projectRoots
+				});
+
+				summary = {
+					...summary,
+					stage: "candidates_aggregated",
+					total_logs_unmapped_users: candidates.unmappedUserCount,
+					total_logs_unmapped_projects: candidates.unmappedProjectCount,
+					total_candidate_items: candidates.candidateItemCount,
+					total_users_with_allocation_diagnostics: candidates.allocationDiagnostics.length,
+					allocation_sample_rows: buildAllocationSampleRows({
+						targetWorkDate: config.targetWorkDate,
+						allocationDiagnostics: candidates.allocationDiagnostics
+					}),
+					allocation_diagnostics: candidates.allocationDiagnostics.map((entry) => ({
+						nas_username: entry.nas_username,
+						user_id: entry.user_id,
+						raw_first_activity_at: entry.raw_first_activity_at,
+						raw_last_activity_at: entry.raw_last_activity_at,
+						raw_total_minutes: entry.raw_total_minutes,
+						unattributed_minutes: entry.unattributed_minutes,
+						attributed_total_minutes: entry.attributed_total_minutes,
+						distinct_project_count: entry.distinct_project_count,
+						large_gap_threshold_minutes: entry.large_gap_threshold_minutes,
+						large_gap_hit: entry.large_gap_hit,
+						largest_interval_minutes: entry.largest_interval_minutes,
+						conservative_mode_hit: entry.conservative_mode_hit,
+						conservative_mode_reason: entry.conservative_mode_reason,
+						formal_write_skipped: entry.formal_write_skipped,
+						formal_write_skip_reason: entry.formal_write_skip_reason,
+						formal_allocation_mode: entry.formal_allocation_mode,
+						allocation_method: entry.allocation_method,
+						allocation_version: entry.allocation_version,
+						project_minutes: entry.project_minutes.map((projectEntry) => ({
+							project_id: projectEntry.project_id,
+							project_root_id: projectEntry.project_root_id,
+							raw_project_minutes: projectEntry.raw_project_minutes,
+							normalized_project_minutes: projectEntry.normalized_project_minutes,
+							formal_generated_minutes: projectEntry.formal_generated_minutes ?? null
+						}))
+					}))
+				};
+
+				if (!config.dryRun && repository.loadManualTaskUserIds && repository.insertRunItems) {
+					const manualTaskUserIds = await repository.loadManualTaskUserIds(config.orgId, config.targetWorkDate);
+					const runItemsResult = buildRunItems({
+						candidateItems: candidates.candidateItems,
+						manualOverrideUserIds: manualTaskUserIds,
+						formalAllocationMode: config.allocationMode
+					});
+					const createdRun = await repository.createRun({
+						org_id: config.orgId,
+						target_work_date: config.targetWorkDate,
+						source_kind: "asset_version_log",
+						status: "running",
+						started_at: now.toISOString(),
+						summary: {
+							stage: summary.stage,
+							range_start: summary.range_start,
+							range_end: summary.range_end,
+							actions: summary.actions,
+							source_table: config.sourceTable,
+							total_logs_scanned: summary.total_logs_scanned,
+							total_logs_accepted: summary.total_logs_accepted
+						}
+					});
+					runId = createdRun.id;
+
+					const insertedRunItems = await repository.insertRunItems(runId, runItemsResult.runItems);
+					let totalTasksWritten = 0;
+					let existingAutoTaskKeys: string[] = [];
+					let deletedExistingAutoTaskIds: string[] = [];
+
+					if (repository.insertTasks && repository.linkGeneratedTasks) {
+						if (config.rebuildNasAuto && repository.deleteExistingAutoTasks) {
+							deletedExistingAutoTaskIds = await repository.deleteExistingAutoTasks(
+								config.orgId,
+								config.targetWorkDate
+							);
+						}
+						existingAutoTaskKeys = config.rebuildNasAuto
+							? []
+							: repository.loadExistingAutoTaskKeys
+								? await repository.loadExistingAutoTaskKeys(config.orgId, config.targetWorkDate)
+								: [];
+						const taskInserts = buildTaskInserts({
+							runId,
+							runItems: insertedRunItems,
+							existingAutoTaskKeys
+						});
+
+						if (taskInserts.length > 0) {
+							const insertedTasks = await repository.insertTasks(runId, taskInserts);
+							totalTasksWritten = insertedTasks.length;
+
+							await repository.linkGeneratedTasks(
+								insertedTasks.map((task) => ({
+									run_item_id: task.source_item_id,
+									generated_task_id: task.id
+								}))
+							);
+						}
+					}
+
+					summary = {
+						...summary,
+						stage: totalTasksWritten > 0 ? "tasks_written" : "run_items_written",
+						total_run_items_written: insertedRunItems.length,
+						total_manual_override_items: runItemsResult.manualOverrideItems,
+						total_policy_guard_items: runItemsResult.policyGuardItems,
+						total_existing_auto_tasks_skipped: existingAutoTaskKeys.length,
+						total_existing_auto_tasks_deleted: deletedExistingAutoTaskIds.length,
+						total_tasks_written: totalTasksWritten
+					};
+
+					await repository.finalizeRun(runId, "completed", summary);
+
+					return {
+						runId,
+						status: "completed",
+						summary
+					};
+				}
+			}
+		}
+
+		if (config.dryRun) {
+			return {
+				status: "dry-run",
+				summary
+			};
+		}
+
+		const createdRun = await repository.createRun({
+			org_id: config.orgId,
+			target_work_date: config.targetWorkDate,
+			source_kind: "asset_version_log",
+			status: "running",
+			started_at: now.toISOString(),
+			summary: {
+				stage: summary.stage,
+				range_start: summary.range_start,
+				range_end: summary.range_end,
+				actions: summary.actions,
+				source_table: config.sourceTable,
+				total_logs_scanned: summary.total_logs_scanned,
+				total_logs_accepted: summary.total_logs_accepted
+			}
+		});
+		runId = createdRun.id;
+
+		await repository.finalizeRun(runId, "skipped", summary);
+
+		return {
+			runId,
+			status: "skipped",
+			summary
+		};
+	} catch (error) {
+		if (runId) {
+			await repository.finalizeRun(
+				runId,
+				"failed",
+				summary,
+				error instanceof Error ? error.message : String(error)
+			);
+		}
+
+		throw error;
+	}
+};

--- a/scripts/asset-log-time-capture/fullLoopRunner.ts
+++ b/scripts/asset-log-time-capture/fullLoopRunner.ts
@@ -1,0 +1,224 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { getHolidayEntry } from "../../src/config/holidays.ts";
+import { createRunnerConfig } from "./config.ts";
+import {
+	runAutoTimeCapture,
+	type AutoTimeRunnerConfig,
+	type AutoTimeRunnerRepository
+} from "./core.ts";
+import {
+	buildAutoTimeDailyHealthReport,
+	buildAutoTimeHealthMarkdown,
+	type AutoTimeDailyHealthReport
+} from "./healthReportCore.ts";
+import { createNasRootAutoParserConfig } from "./nasRootAutoParserConfig.ts";
+import {
+	runNasRootAutoParser,
+	type NasRootAutoParserConfig,
+	type NasRootAutoParserRepository,
+	type NasRootAutoParserSummary
+} from "./nasRootAutoParserCore.ts";
+import { createRepository } from "./repository.ts";
+
+export type AutoTimeFullLoopRepository =
+	& AutoTimeRunnerRepository
+	& NasRootAutoParserRepository
+	& {
+		insertDailyHealthReport?: (report: AutoTimeDailyHealthReport) => Promise<void>;
+	};
+
+type ParserResult = Awaited<ReturnType<typeof runNasRootAutoParser>>;
+type CaptureResult = Awaited<ReturnType<typeof runAutoTimeCapture>>;
+
+const makeDateKey = (date: Date): string =>
+	`${date.getUTCFullYear().toString().padStart(4, "0")}-${(date.getUTCMonth() + 1).toString().padStart(2, "0")}-${date.getUTCDate().toString().padStart(2, "0")}`;
+
+const getLocalDateKey = (iso: string, timezone: string): string => {
+	const parts = new Intl.DateTimeFormat("en-CA", {
+		timeZone: timezone,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit"
+	}).formatToParts(new Date(iso)).reduce<Record<string, string>>((acc, part) => {
+		if (part.type !== "literal") {
+			acc[part.type] = part.value;
+		}
+		return acc;
+	}, {});
+
+	return `${parts.year}-${parts.month}-${parts.day}`;
+};
+
+const enumerateDateKeys = (startDate: string, endDate: string): string[] => {
+	const start = new Date(`${startDate}T00:00:00.000Z`);
+	const end = new Date(`${endDate}T00:00:00.000Z`);
+	const dates: string[] = [];
+
+	for (const cursor = new Date(start); cursor <= end; cursor.setUTCDate(cursor.getUTCDate() + 1)) {
+		dates.push(makeDateKey(cursor));
+	}
+
+	return dates;
+};
+
+const isWeekend = (dateKey: string): boolean => {
+	const day = new Date(`${dateKey}T00:00:00.000Z`).getUTCDay();
+	return day === 0 || day === 6;
+};
+
+export const buildRebuildDatesFromParserSummary = ({
+	parserSummary,
+	timezone
+}: {
+	parserSummary: Pick<NasRootAutoParserSummary, "candidate_samples">;
+	timezone: string;
+}): string[] => {
+	const dateSet = new Set<string>();
+
+	for (const candidate of parserSummary.candidate_samples ?? []) {
+		const status = candidate.candidate_status;
+		if (status !== "auto_project_created" && status !== "auto_inserted") {
+			continue;
+		}
+
+		const firstSeenAt = typeof candidate.first_seen_at === "string" ? candidate.first_seen_at : null;
+		const lastSeenAt = typeof candidate.last_seen_at === "string" ? candidate.last_seen_at : null;
+		if (!firstSeenAt || !lastSeenAt) {
+			continue;
+		}
+
+		for (const dateKey of enumerateDateKeys(
+			getLocalDateKey(firstSeenAt, timezone),
+			getLocalDateKey(lastSeenAt, timezone)
+		)) {
+			if (!isWeekend(dateKey) && !getHolidayEntry(dateKey)?.isOffDay) {
+				dateSet.add(dateKey);
+			}
+		}
+	}
+
+	return Array.from(dateSet).sort();
+};
+
+export const runAutoTimeFullLoop = async ({
+	parserConfig,
+	runnerConfig,
+	repository,
+	runParser = async (config, repo) => runNasRootAutoParser({
+		config,
+		repository: repo
+	}),
+	runCapture = async (config, repo) => runAutoTimeCapture({
+		config,
+		repository: repo
+	}),
+	reportsDir
+}: {
+	parserConfig: NasRootAutoParserConfig;
+	runnerConfig: AutoTimeRunnerConfig;
+	repository: AutoTimeFullLoopRepository;
+	runParser?: (config: NasRootAutoParserConfig, repository: AutoTimeFullLoopRepository) => Promise<ParserResult>;
+	runCapture?: (config: AutoTimeRunnerConfig, repository: AutoTimeFullLoopRepository) => Promise<CaptureResult>;
+	reportsDir?: string;
+}) => {
+	const parserResult = await runParser(parserConfig, repository);
+	const rebuildDates = buildRebuildDatesFromParserSummary({
+		parserSummary: parserResult.summary,
+		timezone: parserConfig.timezone
+	});
+	const rebuildResults: CaptureResult[] = [];
+
+	for (const rebuildDate of rebuildDates) {
+		rebuildResults.push(await runCapture({
+			...runnerConfig,
+			targetWorkDate: rebuildDate,
+			rebuildNasAuto: true
+		}, repository));
+	}
+
+	const normalResult = await runCapture({
+		...runnerConfig,
+		targetWorkDate: runnerConfig.targetWorkDate,
+		rebuildNasAuto: false
+	}, repository);
+	const totalRebuildTasksWritten = rebuildResults.reduce(
+		(total, result) => total + (result.summary.total_tasks_written ?? 0),
+		0
+	);
+	const healthReport = buildAutoTimeDailyHealthReport({
+		orgId: runnerConfig.orgId,
+		targetWorkDate: runnerConfig.targetWorkDate,
+		runId: normalResult.runId ?? null,
+		parserSummary: {
+			total_auto_created_projects: parserResult.summary.total_auto_created_projects,
+			total_auto_inserted_roots: parserResult.summary.total_auto_inserted_roots,
+			total_conflict_roots: parserResult.summary.total_conflict_roots,
+			total_rejected_roots: parserResult.summary.total_rejected_roots
+		},
+		runnerSummary: {
+			...normalResult.summary,
+			total_tasks_written: (normalResult.summary.total_tasks_written ?? 0) + totalRebuildTasksWritten,
+			total_existing_auto_tasks_deleted: rebuildResults.length
+		}
+	});
+	healthReport.total_rebuild_dates_queued = rebuildDates.length;
+	healthReport.total_rebuild_dates_completed = rebuildResults.length;
+
+	if (repository.insertDailyHealthReport) {
+		await repository.insertDailyHealthReport(healthReport);
+	}
+
+	if (reportsDir) {
+		await fs.mkdir(reportsDir, {
+			recursive: true
+		});
+		await fs.writeFile(
+			path.join(reportsDir, `${runnerConfig.targetWorkDate}-health.json`),
+			`${JSON.stringify(healthReport, null, 2)}\n`
+		);
+		await fs.writeFile(
+			path.join(reportsDir, `${runnerConfig.targetWorkDate}-health.md`),
+			`${buildAutoTimeHealthMarkdown(healthReport)}\n`
+		);
+	}
+
+	return {
+		parserResult,
+		rebuildDates,
+		rebuildResults,
+		normalResult,
+		healthReport
+	};
+};
+
+const main = async () => {
+	const parserConfig = createNasRootAutoParserConfig();
+	const runnerConfig = createRunnerConfig();
+	const repository = createRepository(
+		runnerConfig.supabaseUrl,
+		runnerConfig.supabaseServiceRoleKey
+	);
+	const reportsDir = process.env.SA_TIME_HEALTH_REPORT_DIR ?? "/logs/reports";
+	const result = await runAutoTimeFullLoop({
+		parserConfig,
+		runnerConfig,
+		repository,
+		reportsDir
+	});
+
+	console.log(JSON.stringify({
+		status: result.normalResult.status,
+		runId: result.normalResult.runId ?? null,
+		rebuildDates: result.rebuildDates,
+		healthReport: result.healthReport
+	}, null, 2));
+};
+
+if (process.argv[1]?.endsWith("fullLoopRunner.ts")) {
+	main().catch((error) => {
+		console.error("[asset-log-time-capture] full loop runner failed");
+		console.error(error);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/asset-log-time-capture/healthReportCore.ts
+++ b/scripts/asset-log-time-capture/healthReportCore.ts
@@ -1,0 +1,160 @@
+type ParserSummaryInput = {
+	total_auto_created_projects?: number;
+	total_auto_inserted_roots?: number;
+	total_conflict_roots?: number;
+	total_rejected_roots?: number;
+};
+
+type RunnerSummaryInput = {
+	total_logs_scanned?: number;
+	total_logs_accepted?: number;
+	total_tasks_written?: number;
+	total_existing_auto_tasks_deleted?: number;
+	allocation_diagnostics?: Array<Record<string, unknown>>;
+};
+
+type HealthUser = {
+	nas_username: string | null;
+	user_id: string | null;
+	raw_total_minutes: number;
+	unattributed_minutes: number;
+	distinct_project_count: number;
+	unattributed_ratio: number;
+};
+
+export type AutoTimeDailyHealthReport = {
+	org_id: string;
+	target_work_date: string;
+	run_id: string | null;
+	status: "completed" | "completed_with_anomalies";
+	total_logs_scanned: number;
+	total_logs_accepted: number;
+	total_projects_auto_created: number;
+	total_roots_auto_inserted: number;
+	total_rebuild_dates_queued: number;
+	total_rebuild_dates_completed: number;
+	total_tasks_written: number;
+	total_zero_project_users: number;
+	total_high_unattributed_users: number;
+	total_conflict_candidates: number;
+	total_rejected_candidates: number;
+	summary: {
+		zero_project_users: HealthUser[];
+		high_unattributed_users: HealthUser[];
+		[key: string]: unknown;
+	};
+};
+
+const toNumber = (value: unknown): number =>
+	typeof value === "number" && Number.isFinite(value) ? value : 0;
+
+const toStringOrNull = (value: unknown): string | null =>
+	typeof value === "string" && value ? value : null;
+
+const buildHealthUser = (entry: Record<string, unknown>): HealthUser => {
+	const rawTotalMinutes = toNumber(entry.raw_total_minutes);
+	const unattributedMinutes = toNumber(entry.unattributed_minutes);
+
+	return {
+		nas_username: toStringOrNull(entry.nas_username),
+		user_id: toStringOrNull(entry.user_id),
+		raw_total_minutes: rawTotalMinutes,
+		unattributed_minutes: unattributedMinutes,
+		distinct_project_count: toNumber(entry.distinct_project_count),
+		unattributed_ratio: rawTotalMinutes > 0 ? unattributedMinutes / rawTotalMinutes : 0
+	};
+};
+
+export const buildAutoTimeDailyHealthReport = ({
+	orgId,
+	targetWorkDate,
+	runId = null,
+	parserSummary = {},
+	runnerSummary = {}
+}: {
+	orgId: string;
+	targetWorkDate: string;
+	runId?: string | null;
+	parserSummary?: ParserSummaryInput;
+	runnerSummary?: RunnerSummaryInput;
+}): AutoTimeDailyHealthReport => {
+	const diagnostics = runnerSummary.allocation_diagnostics ?? [];
+	const healthUsers = diagnostics.map(buildHealthUser);
+	const zeroProjectUsers = healthUsers.filter((entry) =>
+		entry.raw_total_minutes > 0
+		&& entry.distinct_project_count === 0
+	);
+	const highUnattributedUsers = healthUsers.filter((entry) =>
+		entry.raw_total_minutes > 0
+		&& entry.distinct_project_count > 0
+		&& entry.unattributed_ratio >= 0.5
+	);
+	const hasAnomalies = zeroProjectUsers.length > 0
+		|| highUnattributedUsers.length > 0
+		|| toNumber(parserSummary.total_conflict_roots) > 0;
+
+	return {
+		org_id: orgId,
+		target_work_date: targetWorkDate,
+		run_id: runId,
+		status: hasAnomalies ? "completed_with_anomalies" : "completed",
+		total_logs_scanned: toNumber(runnerSummary.total_logs_scanned),
+		total_logs_accepted: toNumber(runnerSummary.total_logs_accepted),
+		total_projects_auto_created: toNumber(parserSummary.total_auto_created_projects),
+		total_roots_auto_inserted: toNumber(parserSummary.total_auto_inserted_roots),
+		total_rebuild_dates_queued: toNumber(runnerSummary.total_existing_auto_tasks_deleted) > 0 ? 1 : 0,
+		total_rebuild_dates_completed: toNumber(runnerSummary.total_existing_auto_tasks_deleted) > 0 ? 1 : 0,
+		total_tasks_written: toNumber(runnerSummary.total_tasks_written),
+		total_zero_project_users: zeroProjectUsers.length,
+		total_high_unattributed_users: highUnattributedUsers.length,
+		total_conflict_candidates: toNumber(parserSummary.total_conflict_roots),
+		total_rejected_candidates: toNumber(parserSummary.total_rejected_roots),
+		summary: {
+			zero_project_users: zeroProjectUsers,
+			high_unattributed_users: highUnattributedUsers
+		}
+	};
+};
+
+const renderUserRows = (users: HealthUser[]): string => {
+	if (users.length === 0) {
+		return "_None_";
+	}
+
+	return [
+		"| NAS Username | User ID | Raw Total Minutes | Unattributed Minutes |",
+		"| --- | --- | ---: | ---: |",
+		...users.map((user) =>
+			`| ${user.nas_username ?? ""} | ${user.user_id ?? ""} | ${user.raw_total_minutes} | ${user.unattributed_minutes} |`
+		)
+	].join("\n");
+};
+
+export const buildAutoTimeHealthMarkdown = (report: AutoTimeDailyHealthReport): string => [
+	"# SA-TIME Auto Time Health Report",
+	"",
+	"| Field | Value |",
+	"| --- | ---: |",
+	`| Target Work Date | ${report.target_work_date} |`,
+	`| Status | ${report.status} |`,
+	`| Run ID | ${report.run_id ?? ""} |`,
+	`| Logs Scanned | ${report.total_logs_scanned} |`,
+	`| Logs Accepted | ${report.total_logs_accepted} |`,
+	`| Auto Created Projects | ${report.total_projects_auto_created} |`,
+	`| Auto Inserted Roots | ${report.total_roots_auto_inserted} |`,
+	`| Rebuild Dates Queued | ${report.total_rebuild_dates_queued} |`,
+	`| Rebuild Dates Completed | ${report.total_rebuild_dates_completed} |`,
+	`| Tasks Written | ${report.total_tasks_written} |`,
+	`| Zero Project Users | ${report.total_zero_project_users} |`,
+	`| High Unattributed Users | ${report.total_high_unattributed_users} |`,
+	`| Conflict Candidates | ${report.total_conflict_candidates} |`,
+	`| Rejected Candidates | ${report.total_rejected_candidates} |`,
+	"",
+	"## Zero Project Users",
+	"",
+	renderUserRows(report.summary.zero_project_users),
+	"",
+	"## High Unattributed Users",
+	"",
+	renderUserRows(report.summary.high_unattributed_users)
+].join("\n");

--- a/scripts/asset-log-time-capture/loadAssetLogs.ts
+++ b/scripts/asset-log-time-capture/loadAssetLogs.ts
@@ -1,0 +1,58 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type {
+	AutoTimeAction,
+	AutoTimeAssetLog,
+	LoadAssetLogsParams
+} from "./core.ts";
+
+const PAGE_SIZE = 1000;
+
+const resolveSourceTableName = (sourceTable: string): string => {
+	if (sourceTable === "public.asset_version_log" || sourceTable === "asset_version_log") {
+		return "asset_version_log";
+	}
+
+	throw new Error(`Unsupported source table: ${sourceTable}`);
+};
+
+export const createLoadAssetLogs = (client: SupabaseClient) =>
+	async ({
+		sourceTable,
+		rangeStartIso,
+		rangeEndIso,
+		actions
+	}: LoadAssetLogsParams): Promise<AutoTimeAssetLog[]> => {
+		const tableName = resolveSourceTableName(sourceTable);
+		const rows: AutoTimeAssetLog[] = [];
+		let page = 0;
+
+		while (true) {
+			const from = page * PAGE_SIZE;
+			const to = from + PAGE_SIZE - 1;
+			const { data, error } = await client
+				.from(tableName)
+				.select("id,file_path,nas_username,action,detected_at,sa_ai_user_id,created_at")
+				.gte("detected_at", rangeStartIso)
+				.lt("detected_at", rangeEndIso)
+				.in("action", actions as AutoTimeAction[])
+				.order("detected_at", {
+					ascending: true
+				})
+				.range(from, to);
+
+			if (error) {
+				throw new Error(`Failed to load asset_version_log rows: ${error.message}`);
+			}
+
+			const batch = (data ?? []) as AutoTimeAssetLog[];
+			rows.push(...batch);
+
+			if (batch.length < PAGE_SIZE) {
+				break;
+			}
+
+			page += 1;
+		}
+
+		return rows;
+	};

--- a/scripts/asset-log-time-capture/nasRootAutoParser.ts
+++ b/scripts/asset-log-time-capture/nasRootAutoParser.ts
@@ -1,0 +1,26 @@
+import { createNasRootAutoParserConfig } from "./nasRootAutoParserConfig.ts";
+import { runNasRootAutoParser } from "./nasRootAutoParserCore.ts";
+import { createRepository } from "./repository.ts";
+
+const main = async () => {
+	const config = createNasRootAutoParserConfig();
+	const repository = createRepository(
+		config.supabaseUrl,
+		config.supabaseServiceRoleKey
+	);
+	const result = await runNasRootAutoParser({
+		config,
+		repository
+	});
+
+	console.log(JSON.stringify({
+		status: result.status,
+		summary: result.summary
+	}, null, 2));
+};
+
+main().catch((error) => {
+	console.error("[asset-log-time-capture] nas root auto parser failed");
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/scripts/asset-log-time-capture/nasRootAutoParserConfig.ts
+++ b/scripts/asset-log-time-capture/nasRootAutoParserConfig.ts
@@ -1,0 +1,98 @@
+import {
+	buildTargetDayWindow,
+	type AutoTimeAction
+} from "./core.ts";
+import type { NasRootAutoParserConfig } from "./nasRootAutoParserCore.ts";
+
+const DEFAULT_ACTIONS: AutoTimeAction[] = ["create", "write", "rename", "delete"];
+const VALID_ACTIONS = new Set<AutoTimeAction>(DEFAULT_ACTIONS);
+const DEFAULT_LOOKBACK_DAYS = 7;
+
+const readArgumentValue = (argv: string[], name: string): string | undefined => {
+	const exactIndex = argv.findIndex((entry) => entry === name);
+	if (exactIndex >= 0) {
+		return argv[exactIndex + 1];
+	}
+
+	const prefix = `${name}=`;
+	const matched = argv.find((entry) => entry.startsWith(prefix));
+	return matched ? matched.slice(prefix.length) : undefined;
+};
+
+const parseActions = (value: string | undefined): AutoTimeAction[] => {
+	if (!value) {
+		return DEFAULT_ACTIONS;
+	}
+
+	const actions = value
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean) as AutoTimeAction[];
+
+	if (actions.length === 0 || actions.some((entry) => !VALID_ACTIONS.has(entry))) {
+		throw new Error(`Invalid action list: ${value}`);
+	}
+
+	return actions;
+};
+
+const parsePositiveInteger = (value: string | undefined, defaultValue: number): number => {
+	if (!value) {
+		return defaultValue;
+	}
+
+	const parsed = Number(value);
+	if (!Number.isInteger(parsed) || parsed < 0) {
+		throw new Error(`Invalid non-negative integer: ${value}`);
+	}
+
+	return parsed;
+};
+
+export const createNasRootAutoParserConfig = ({
+	env = process.env,
+	argv = process.argv.slice(2),
+	now = new Date()
+}: {
+	env?: NodeJS.ProcessEnv;
+	argv?: string[];
+	now?: Date;
+} = {}): NasRootAutoParserConfig => {
+	const timezone = readArgumentValue(argv, "--timezone") ?? env.SA_TIME_TIMEZONE ?? "Asia/Shanghai";
+	const targetWorkDate = readArgumentValue(argv, "--date")
+		?? env.SA_TIME_TARGET_WORK_DATE
+		?? buildTargetDayWindow({
+			now,
+			timezone
+		}).targetWorkDate;
+	const dryRun = argv.includes("--dry-run") || env.SA_TIME_DRY_RUN === "true";
+
+	const config: NasRootAutoParserConfig = {
+		orgId: readArgumentValue(argv, "--org-id") ?? env.SA_TIME_ORG_ID ?? "",
+		supabaseUrl: env.SA_TIME_SUPABASE_URL ?? "",
+		supabaseServiceRoleKey: env.SA_TIME_SUPABASE_SERVICE_ROLE_KEY ?? "",
+		sourceTable: env.SA_TIME_SOURCE_TABLE ?? "public.asset_version_log",
+		targetWorkDate,
+		timezone,
+		dryRun,
+		actions: parseActions(readArgumentValue(argv, "--actions") ?? env.SA_TIME_ACTIONS),
+		lookbackDays: parsePositiveInteger(
+			readArgumentValue(argv, "--lookback-days") ?? env.SA_TIME_NAS_ROOT_LOOKBACK_DAYS,
+			DEFAULT_LOOKBACK_DAYS
+		)
+	};
+
+	if (!config.orgId) {
+		throw new Error("Missing SA_TIME_ORG_ID or --org-id");
+	}
+
+	if (!config.supabaseUrl) {
+		throw new Error("Missing SA_TIME_SUPABASE_URL");
+	}
+
+	if (!config.supabaseServiceRoleKey) {
+		throw new Error("Missing SA_TIME_SUPABASE_SERVICE_ROLE_KEY");
+	}
+
+	return config;
+};

--- a/scripts/asset-log-time-capture/nasRootAutoParserCore.ts
+++ b/scripts/asset-log-time-capture/nasRootAutoParserCore.ts
@@ -1,0 +1,916 @@
+import type {
+	AutoTimeAction,
+	AutoTimeAssetLog,
+	AutoTimeProjectRoot,
+	LoadAssetLogsParams
+} from "./core.ts";
+
+export type NasRootAutoParserStatus = "completed" | "dry-run";
+export type NasRootCandidateMatchMethod = "code_exact" | "name_exact" | "none";
+export type NasRootCandidateStatus =
+	| "auto_inserted"
+	| "auto_project_created"
+	| "auto_root_inserted"
+	| "rebuild_queued"
+	| "rebuild_completed"
+	| "pending_review"
+	| "missing_project_master"
+	| "rejected"
+	| "rejected_by_rule"
+	| "conflict_needs_manual_fix"
+	| "failed";
+
+export type NasRootAutoParserConfig = {
+	orgId: string;
+	supabaseUrl: string;
+	supabaseServiceRoleKey: string;
+	sourceTable: string;
+	targetWorkDate: string;
+	timezone: string;
+	dryRun: boolean;
+	actions: AutoTimeAction[];
+	lookbackDays: number;
+};
+
+export type NasRootProjectRecord = {
+	id: string;
+	name: string | null;
+	source_project_code: string | null;
+	status: string | null;
+};
+
+export type NasRootProjectInsert = {
+	org_id: string;
+	name: string;
+	source_project_code: string | null;
+	status: "active";
+};
+
+export type NasRootProjectRootInsert = {
+	org_id: string;
+	project_id: string;
+	root_path: string;
+	notes: string | null;
+};
+
+export type NasRootProjectActionInsert = {
+	org_id: string;
+	target_work_date: string;
+	candidate_root_path: string;
+	parsed_project_code: string | null;
+	parsed_project_name: string | null;
+	action_type:
+		| "auto_create_project"
+		| "auto_insert_root"
+		| "queue_rebuild"
+		| "complete_rebuild"
+		| "reject_candidate"
+		| "conflict_candidate"
+		| "fail_candidate";
+	action_status: "completed" | "skipped" | "failed";
+	project_id: string | null;
+	project_root_id: string | null;
+	run_id: string | null;
+	rebuild_target_work_date: string | null;
+	reason: string | null;
+	metadata: Record<string, unknown>;
+};
+
+export type NasRootProjectRootCandidateUpsert = {
+	org_id: string;
+	candidate_root_path: string;
+	normalized_root_path: string;
+	parsed_project_code: string | null;
+	parsed_project_name: string | null;
+	matched_project_id: string | null;
+	match_method: NasRootCandidateMatchMethod;
+	confidence_score: number;
+	candidate_status: NasRootCandidateStatus;
+	sample_log_count: number;
+	first_seen_at: string | null;
+	last_seen_at: string | null;
+	sample_paths: string[];
+	promoted_root_id: string | null;
+	notes: string | null;
+};
+
+export type NasRootAutoParserSummary = {
+	stage: string;
+	target_work_date: string;
+	timezone: string;
+	range_start: string;
+	range_end: string;
+	actions: AutoTimeAction[];
+	total_logs_scanned: number;
+	total_logs_accepted: number;
+	total_logs_ignored_accounts: number;
+	total_logs_rejected_incomplete: number;
+	total_existing_project_hits: number;
+	total_candidate_roots: number;
+	total_auto_created_projects: number;
+	total_auto_inserted_roots: number;
+	total_pending_review_roots: number;
+	total_missing_project_master_roots: number;
+	total_conflict_roots: number;
+	total_rejected_roots: number;
+	candidate_samples: Array<Record<string, unknown>>;
+};
+
+export type NasRootAutoParserRepository = {
+	loadAssetLogs: (params: LoadAssetLogsParams) => Promise<AutoTimeAssetLog[]>;
+	loadIgnoreAccounts?: (orgId: string) => Promise<string[]>;
+	loadProjectRoots: (orgId: string) => Promise<AutoTimeProjectRoot[]>;
+	loadProjects: (orgId: string) => Promise<NasRootProjectRecord[]>;
+	createProjects?: (items: NasRootProjectInsert[]) => Promise<NasRootProjectRecord[]>;
+	insertProjectRoots?: (items: NasRootProjectRootInsert[]) => Promise<AutoTimeProjectRoot[]>;
+	insertProjectActions?: (items: NasRootProjectActionInsert[]) => Promise<void>;
+	upsertProjectRootCandidates?: (items: NasRootProjectRootCandidateUpsert[]) => Promise<void>;
+};
+
+type NasRootCandidateAggregation = {
+	candidate_root_path: string;
+	normalized_root_path: string;
+	parsed_project_code: string | null;
+	parsed_project_name: string | null;
+	sample_log_count: number;
+	first_seen_at: string | null;
+	last_seen_at: string | null;
+	sample_paths: string[];
+};
+
+type NasRootMatchDecision = {
+	matched_project_id: string | null;
+	match_method: NasRootCandidateMatchMethod;
+	confidence_score: number;
+	candidate_status: NasRootCandidateStatus;
+	notes: string | null;
+};
+
+const makeDateKey = (year: number, month: number, day: number): string =>
+	`${year.toString().padStart(4, "0")}-${month.toString().padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
+
+const parseDateKey = (value: string) => {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+	if (!match) {
+		throw new Error(`Invalid work date: ${value}`);
+	}
+
+	return {
+		year: Number(match[1]),
+		month: Number(match[2]),
+		day: Number(match[3])
+	};
+};
+
+const shiftDateKey = (value: string, offsetDays: number): string => {
+	const { year, month, day } = parseDateKey(value);
+	const shifted = new Date(Date.UTC(year, month - 1, day));
+	shifted.setUTCDate(shifted.getUTCDate() + offsetDays);
+
+	return makeDateKey(shifted.getUTCFullYear(), shifted.getUTCMonth() + 1, shifted.getUTCDate());
+};
+
+const getTimeZoneOffsetMs = (date: Date, timezone: string): number => {
+	const parts = new Intl.DateTimeFormat("en-US", {
+		timeZone: timezone,
+		hour12: false,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit"
+	}).formatToParts(date).reduce<Record<string, string>>((acc, part) => {
+		if (part.type !== "literal") {
+			acc[part.type] = part.value;
+		}
+		return acc;
+	}, {});
+
+	const utcFromZone = Date.UTC(
+		Number(parts.year),
+		Number(parts.month) - 1,
+		Number(parts.day),
+		Number(parts.hour),
+		Number(parts.minute),
+		Number(parts.second)
+	);
+
+	return utcFromZone - date.getTime();
+};
+
+const zonedDateKeyToUtcIso = (dateKey: string, timezone: string): string => {
+	const { year, month, day } = parseDateKey(dateKey);
+	const utcGuess = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+	const offsetMs = getTimeZoneOffsetMs(utcGuess, timezone);
+
+	return new Date(utcGuess.getTime() - offsetMs).toISOString();
+};
+
+const sanitizePath = (value: string | null | undefined): string =>
+	(value ?? "")
+		.trim()
+		.replace(/\\/g, "/")
+		.replace(/\/{2,}/g, "/")
+		.replace(/\/+$/, "");
+
+const normalizePath = (value: string | null | undefined): string =>
+	sanitizePath(value).toLowerCase();
+
+const normalizeNasUsername = (value: string | null | undefined): string =>
+	value?.trim().toLowerCase() ?? "";
+
+const normalizeProjectCode = (value: string | null | undefined): string | null => {
+	const normalized = value?.trim().toUpperCase() ?? "";
+	return normalized || null;
+};
+
+const normalizeProjectName = (value: string | null | undefined): string => {
+	const normalized = value
+		?.trim()
+		.normalize("NFKC")
+		.replace(/[\s_\-()（）[\]【】]+/g, "")
+		.toLowerCase() ?? "";
+
+	return normalized;
+};
+
+const REJECTED_PROJECT_NAMES = new Set([
+	"新建文件夹",
+	"新建文件夹->",
+	"serverbackup",
+	"chatimages",
+	"consolelog",
+	"项目梳理",
+	"000000项目梳理",
+	"backup",
+	"temp",
+	"tmp",
+	"test"
+]);
+
+const buildDateRange = (targetWorkDate: string, timezone: string, lookbackDays: number) => ({
+	rangeStartIso: zonedDateKeyToUtcIso(shiftDateKey(targetWorkDate, -lookbackDays), timezone),
+	rangeEndIso: zonedDateKeyToUtcIso(shiftDateKey(targetWorkDate, 1), timezone)
+});
+
+const filterAcceptedLogs = ({
+	logs,
+	ignoreAccounts
+}: {
+	logs: AutoTimeAssetLog[];
+	ignoreAccounts: string[];
+}) => {
+	const ignoredAccountSet = new Set(ignoreAccounts.map((entry) => entry.trim().toLowerCase()).filter(Boolean));
+	let ignoredAccountCount = 0;
+	let incompleteCount = 0;
+
+	const acceptedLogs = logs.filter((log) => {
+		const normalizedUsername = normalizeNasUsername(log.nas_username);
+		const normalizedPath = sanitizePath(log.file_path);
+
+		if (!normalizedUsername || !normalizedPath) {
+			incompleteCount += 1;
+			return false;
+		}
+
+		if (ignoredAccountSet.has(normalizedUsername)) {
+			ignoredAccountCount += 1;
+			return false;
+		}
+
+		return true;
+	});
+
+	return {
+		acceptedLogs,
+		ignoredAccountCount,
+		incompleteCount
+	};
+};
+
+const buildSortedProjectRoots = (roots: AutoTimeProjectRoot[]): Array<AutoTimeProjectRoot & { normalized_root_path: string }> =>
+	roots
+		.map((root) => ({
+			...root,
+			normalized_root_path: normalizePath(root.root_path)
+		}))
+		.filter((root) => Boolean(root.normalized_root_path))
+		.sort((left, right) => right.normalized_root_path.length - left.normalized_root_path.length);
+
+const resolveProjectRoot = (
+	log: AutoTimeAssetLog,
+	projectRoots: Array<AutoTimeProjectRoot & { normalized_root_path: string }>
+) => {
+	const normalizedFilePath = normalizePath(log.file_path);
+
+	return projectRoots.find((root) =>
+		normalizedFilePath === root.normalized_root_path
+		|| normalizedFilePath.startsWith(`${root.normalized_root_path}/`)
+	) ?? null;
+};
+
+const extractCandidateRootPath = (filePath: string | null | undefined): string | null => {
+	const sanitized = sanitizePath(filePath);
+	if (!sanitized) {
+		return null;
+	}
+
+	const segments = sanitized.split("/").filter(Boolean);
+	const baseIndex = segments.findIndex((segment) => /^daga-\d{4}-project$/i.test(segment));
+	if (baseIndex < 0 || baseIndex >= segments.length - 1) {
+		return null;
+	}
+
+	const baseSegment = segments[baseIndex];
+	const firstProjectSegment = segments[baseIndex + 1];
+	if (!firstProjectSegment) {
+		return null;
+	}
+
+	if (/^concept$/i.test(firstProjectSegment)) {
+		const secondProjectSegment = segments[baseIndex + 2];
+		if (!secondProjectSegment) {
+			return null;
+		}
+
+		return `/${baseSegment}/${firstProjectSegment}/${secondProjectSegment}`;
+	}
+
+	return `/${baseSegment}/${firstProjectSegment}`;
+};
+
+const extractProjectCode = (candidateRootPath: string): string | null => {
+	const match = /(C\d{8}|D\d{4})/i.exec(candidateRootPath);
+	return match ? match[1].toUpperCase() : null;
+};
+
+const extractProjectName = (candidateRootPath: string, projectCode: string | null): string | null => {
+	const segments = sanitizePath(candidateRootPath).split("/").filter(Boolean);
+	const projectSegment = segments[segments.length - 1] ?? "";
+	const withoutCode = projectCode
+		? projectSegment.replace(new RegExp(projectCode, "i"), "")
+		: projectSegment;
+	const normalized = withoutCode.replace(/^[-_\s]+/, "").trim();
+
+	return normalized || null;
+};
+
+const buildProjectIndexes = (projects: NasRootProjectRecord[]) => {
+	const activeProjects = projects.filter((project) => project.status === "active");
+	const projectCodes = new Map<string, NasRootProjectRecord[]>();
+	const projectNames = new Map<string, NasRootProjectRecord[]>();
+
+	for (const project of activeProjects) {
+		const projectCode = normalizeProjectCode(project.source_project_code);
+		if (projectCode) {
+			const entries = projectCodes.get(projectCode) ?? [];
+			entries.push(project);
+			projectCodes.set(projectCode, entries);
+		}
+
+		const projectName = normalizeProjectName(project.name);
+		if (projectName) {
+			const entries = projectNames.get(projectName) ?? [];
+			entries.push(project);
+			projectNames.set(projectName, entries);
+		}
+	}
+
+	return {
+		projectCodes,
+		projectNames
+	};
+};
+
+const shouldRejectCandidateByRule = ({
+	parsedProjectCode,
+	parsedProjectName,
+	candidateRootPath
+}: {
+	parsedProjectCode: string | null;
+	parsedProjectName: string | null;
+	candidateRootPath: string;
+}): boolean => {
+	if (parsedProjectCode === "000000") {
+		return true;
+	}
+
+	const normalizedName = normalizeProjectName(parsedProjectName);
+	const normalizedPathSegment = normalizeProjectName(sanitizePath(candidateRootPath).split("/").filter(Boolean).at(-1));
+	const normalizedPath = normalizeProjectName(candidateRootPath);
+
+	return REJECTED_PROJECT_NAMES.has(normalizedName)
+		|| REJECTED_PROJECT_NAMES.has(normalizedPathSegment)
+		|| normalizedPath.endsWith("consolelog")
+		|| normalizedPath.includes("serverbackup")
+		|| normalizedPath.includes("chatimages")
+		|| normalizedName.startsWith("000000");
+};
+
+const decideCandidateMatch = ({
+	candidateRootPath,
+	parsedProjectCode,
+	parsedProjectName,
+	projectIndexes
+}: {
+	candidateRootPath: string;
+	parsedProjectCode: string | null;
+	parsedProjectName: string | null;
+	projectIndexes: ReturnType<typeof buildProjectIndexes>;
+}): NasRootMatchDecision => {
+	if (shouldRejectCandidateByRule({
+		parsedProjectCode,
+		parsedProjectName,
+		candidateRootPath
+	})) {
+		return {
+			matched_project_id: null,
+			match_method: "none",
+			confidence_score: 0,
+			candidate_status: "rejected_by_rule",
+			notes: "candidate root rejected by auto-create guard"
+		};
+	}
+
+	if (parsedProjectCode) {
+		const matchedByCode = projectIndexes.projectCodes.get(parsedProjectCode) ?? [];
+		if (matchedByCode.length === 1) {
+			return {
+				matched_project_id: matchedByCode[0].id,
+				match_method: "code_exact",
+				confidence_score: 1,
+				candidate_status: "auto_inserted",
+				notes: `source_project_code ${parsedProjectCode} matched exactly once`
+			};
+		}
+
+		if (matchedByCode.length > 1) {
+			return {
+				matched_project_id: null,
+				match_method: "code_exact",
+				confidence_score: 0.4,
+				candidate_status: "conflict_needs_manual_fix",
+				notes: `source_project_code ${parsedProjectCode} matched multiple active projects`
+			};
+		}
+	}
+
+	if (parsedProjectName) {
+		const normalizedProjectName = normalizeProjectName(parsedProjectName);
+		const matchedByName = projectIndexes.projectNames.get(normalizedProjectName) ?? [];
+		if (matchedByName.length === 1) {
+			return {
+				matched_project_id: matchedByName[0].id,
+				match_method: "name_exact",
+				confidence_score: 0.6,
+				candidate_status: "pending_review",
+				notes: `project name ${parsedProjectName} matched exactly once`
+			};
+		}
+
+		if (matchedByName.length > 1) {
+			return {
+				matched_project_id: null,
+				match_method: "name_exact",
+				confidence_score: 0.3,
+				candidate_status: "pending_review",
+				notes: `project name ${parsedProjectName} matched multiple active projects`
+			};
+		}
+	}
+
+	if (parsedProjectCode || parsedProjectName) {
+		return {
+			matched_project_id: null,
+			match_method: "none",
+			confidence_score: 0,
+			candidate_status: "missing_project_master",
+			notes: "parsed project code or name did not match active project master data"
+		};
+	}
+
+	return {
+		matched_project_id: null,
+		match_method: "none",
+		confidence_score: 0,
+		candidate_status: "rejected",
+		notes: "could not extract project code or project name from candidate path"
+	};
+};
+
+const buildCandidateRows = ({
+	orgId,
+	logs,
+	projectRoots,
+	projects
+}: {
+	orgId: string;
+	logs: AutoTimeAssetLog[];
+	projectRoots: AutoTimeProjectRoot[];
+	projects: NasRootProjectRecord[];
+}) => {
+	const sortedProjectRoots = buildSortedProjectRoots(projectRoots);
+	const projectIndexes = buildProjectIndexes(projects);
+	const candidateMap = new Map<string, NasRootCandidateAggregation>();
+	let existingProjectHitCount = 0;
+	let rejectedRootCount = 0;
+
+	for (const log of logs) {
+		const resolvedProjectRoot = resolveProjectRoot(log, sortedProjectRoots);
+		if (resolvedProjectRoot) {
+			existingProjectHitCount += 1;
+			continue;
+		}
+
+		const candidateRootPath = extractCandidateRootPath(log.file_path);
+		if (!candidateRootPath) {
+			rejectedRootCount += 1;
+			continue;
+		}
+
+		const normalizedRootPath = normalizePath(candidateRootPath);
+		const parsedProjectCode = extractProjectCode(candidateRootPath);
+		const parsedProjectName = extractProjectName(candidateRootPath, parsedProjectCode);
+		const existing = candidateMap.get(normalizedRootPath);
+
+		if (existing) {
+			existing.sample_log_count += 1;
+			existing.first_seen_at = existing.first_seen_at && existing.first_seen_at < log.detected_at
+				? existing.first_seen_at
+				: log.detected_at;
+			existing.last_seen_at = existing.last_seen_at && existing.last_seen_at > log.detected_at
+				? existing.last_seen_at
+				: log.detected_at;
+			const sanitizedFilePath = sanitizePath(log.file_path);
+			if (sanitizedFilePath && !existing.sample_paths.includes(sanitizedFilePath)) {
+				existing.sample_paths.push(sanitizedFilePath);
+			}
+			continue;
+		}
+
+		candidateMap.set(normalizedRootPath, {
+			candidate_root_path: candidateRootPath,
+			normalized_root_path: normalizedRootPath,
+			parsed_project_code: parsedProjectCode,
+			parsed_project_name: parsedProjectName,
+			sample_log_count: 1,
+			first_seen_at: log.detected_at,
+			last_seen_at: log.detected_at,
+			sample_paths: sanitizePath(log.file_path) ? [sanitizePath(log.file_path)] : []
+		});
+	}
+
+	const candidateRows = Array.from(candidateMap.values())
+		.sort((left, right) => left.candidate_root_path.localeCompare(right.candidate_root_path))
+		.map((candidate) => {
+			const matchDecision = decideCandidateMatch({
+				candidateRootPath: candidate.candidate_root_path,
+				parsedProjectCode: candidate.parsed_project_code,
+				parsedProjectName: candidate.parsed_project_name,
+				projectIndexes
+			});
+
+			return {
+				org_id: orgId,
+				candidate_root_path: candidate.candidate_root_path,
+				normalized_root_path: candidate.normalized_root_path,
+				parsed_project_code: candidate.parsed_project_code,
+				parsed_project_name: candidate.parsed_project_name,
+				matched_project_id: matchDecision.matched_project_id,
+				match_method: matchDecision.match_method,
+				confidence_score: matchDecision.confidence_score,
+				candidate_status: matchDecision.candidate_status,
+				sample_log_count: candidate.sample_log_count,
+				first_seen_at: candidate.first_seen_at,
+				last_seen_at: candidate.last_seen_at,
+				sample_paths: candidate.sample_paths,
+				promoted_root_id: null,
+				notes: matchDecision.notes
+			} satisfies NasRootProjectRootCandidateUpsert;
+		});
+
+	return {
+		candidateRows,
+		existingProjectHitCount,
+		rejectedRootCount
+	};
+};
+
+const attachPromotedRootIds = ({
+	candidateRows,
+	insertedRoots
+}: {
+	candidateRows: NasRootProjectRootCandidateUpsert[];
+	insertedRoots: AutoTimeProjectRoot[];
+}) => {
+	const insertedRootIdByPath = new Map(
+		insertedRoots.map((root) => [normalizePath(root.root_path), root.id] as const)
+	);
+
+	return candidateRows.map((candidate) =>
+		(candidate.candidate_status === "auto_inserted" || candidate.candidate_status === "auto_project_created")
+			? {
+				...candidate,
+				promoted_root_id: insertedRootIdByPath.get(candidate.normalized_root_path) ?? null
+			}
+			: candidate
+	);
+};
+
+const buildProjectKey = (candidate: Pick<NasRootProjectRootCandidateUpsert, "parsed_project_code" | "normalized_root_path">): string =>
+	candidate.parsed_project_code ?? candidate.normalized_root_path;
+
+const buildProjectAction = ({
+	orgId,
+	targetWorkDate,
+	candidate,
+	actionType,
+	actionStatus,
+	projectId = null,
+	projectRootId = null,
+	reason = null,
+	metadata = {}
+}: {
+	orgId: string;
+	targetWorkDate: string;
+	candidate: NasRootProjectRootCandidateUpsert;
+	actionType: NasRootProjectActionInsert["action_type"];
+	actionStatus: NasRootProjectActionInsert["action_status"];
+	projectId?: string | null;
+	projectRootId?: string | null;
+	reason?: string | null;
+	metadata?: Record<string, unknown>;
+}): NasRootProjectActionInsert => ({
+	org_id: orgId,
+	target_work_date: targetWorkDate,
+	candidate_root_path: candidate.candidate_root_path,
+	parsed_project_code: candidate.parsed_project_code,
+	parsed_project_name: candidate.parsed_project_name,
+	action_type: actionType,
+	action_status: actionStatus,
+	project_id: projectId,
+	project_root_id: projectRootId,
+	run_id: null,
+	rebuild_target_work_date: null,
+	reason,
+	metadata
+});
+
+const markDuplicateNewProjectCodesAsConflicts = (
+	candidateRows: NasRootProjectRootCandidateUpsert[]
+): NasRootProjectRootCandidateUpsert[] => {
+	const candidatesByCode = new Map<string, NasRootProjectRootCandidateUpsert[]>();
+
+	for (const candidate of candidateRows) {
+		if (candidate.candidate_status !== "missing_project_master" || !candidate.parsed_project_code) {
+			continue;
+		}
+
+		const existing = candidatesByCode.get(candidate.parsed_project_code) ?? [];
+		existing.push(candidate);
+		candidatesByCode.set(candidate.parsed_project_code, existing);
+	}
+
+	const duplicateCodes = new Set(
+		Array.from(candidatesByCode.entries())
+			.filter(([, candidates]) => candidates.length > 1)
+			.map(([projectCode]) => projectCode)
+	);
+
+	if (duplicateCodes.size === 0) {
+		return candidateRows;
+	}
+
+	return candidateRows.map((candidate) =>
+		candidate.parsed_project_code && duplicateCodes.has(candidate.parsed_project_code)
+			? {
+				...candidate,
+				candidate_status: "conflict_needs_manual_fix",
+				match_method: "code_exact",
+				confidence_score: 0.4,
+				matched_project_id: null,
+				notes: `source_project_code ${candidate.parsed_project_code} appears in multiple new NAS candidates`
+			}
+			: candidate
+	);
+};
+
+export const runNasRootAutoParser = async ({
+	config,
+	repository
+}: {
+	config: NasRootAutoParserConfig;
+	repository: NasRootAutoParserRepository;
+}): Promise<{
+	status: NasRootAutoParserStatus;
+	summary: NasRootAutoParserSummary;
+}> => {
+	const window = buildDateRange(config.targetWorkDate, config.timezone, config.lookbackDays);
+	const ignoreAccounts = repository.loadIgnoreAccounts
+		? await repository.loadIgnoreAccounts(config.orgId)
+		: [];
+	const loadedLogs = await repository.loadAssetLogs({
+		sourceTable: config.sourceTable,
+		rangeStartIso: window.rangeStartIso,
+		rangeEndIso: window.rangeEndIso,
+		actions: config.actions
+	});
+	const filteredLogs = filterAcceptedLogs({
+		logs: loadedLogs,
+		ignoreAccounts
+	});
+	const [projectRoots, projects] = await Promise.all([
+		repository.loadProjectRoots(config.orgId),
+		repository.loadProjects(config.orgId)
+	]);
+	const builtCandidates = buildCandidateRows({
+		orgId: config.orgId,
+		logs: filteredLogs.acceptedLogs,
+		projectRoots,
+		projects
+	});
+	const candidateRows = markDuplicateNewProjectCodesAsConflicts(builtCandidates.candidateRows);
+	const autoInsertCandidates: NasRootProjectRootCandidateUpsert[] = candidateRows.filter((candidate) =>
+		candidate.candidate_status === "auto_inserted"
+		&& Boolean(candidate.matched_project_id)
+	);
+	const autoProjectCandidates: NasRootProjectRootCandidateUpsert[] = candidateRows.filter((candidate) =>
+		candidate.candidate_status === "missing_project_master"
+		&& Boolean(candidate.parsed_project_code)
+		&& Boolean(candidate.parsed_project_name)
+	);
+	let persistedCandidates: NasRootProjectRootCandidateUpsert[] = candidateRows;
+	let autoCreatedProjectCount = 0;
+	const actionRows: NasRootProjectActionInsert[] = [];
+
+	if (!config.dryRun && autoProjectCandidates.length > 0 && repository.createProjects) {
+		const createdProjects = await repository.createProjects(
+			autoProjectCandidates.map((candidate) => ({
+				org_id: config.orgId,
+				name: candidate.parsed_project_name as string,
+				source_project_code: candidate.parsed_project_code,
+				status: "active"
+			}))
+		);
+		autoCreatedProjectCount = createdProjects.length;
+		const createdProjectByKey = new Map(
+			createdProjects.map((project, index) => [
+				buildProjectKey(autoProjectCandidates[index]),
+				project
+			] as const)
+		);
+
+		persistedCandidates = persistedCandidates.map((candidate) => {
+			if (!autoProjectCandidates.includes(candidate)) {
+				return candidate;
+			}
+
+			const createdProject = createdProjectByKey.get(buildProjectKey(candidate));
+			if (!createdProject) {
+				return {
+					...candidate,
+					candidate_status: "failed" as const,
+					notes: "auto project creation did not return a matching project"
+				};
+			}
+
+			actionRows.push(buildProjectAction({
+				orgId: config.orgId,
+				targetWorkDate: config.targetWorkDate,
+				candidate,
+				actionType: "auto_create_project",
+				actionStatus: "completed",
+				projectId: createdProject.id,
+				reason: `auto created active project ${createdProject.source_project_code ?? createdProject.name}`
+			}));
+
+			return {
+				...candidate,
+				matched_project_id: createdProject.id,
+				match_method: "code_exact" as const,
+				confidence_score: 1,
+				candidate_status: "auto_project_created" as const,
+				notes: `auto created active project ${createdProject.source_project_code ?? createdProject.name}`
+			};
+		});
+	}
+
+	const projectRootInsertCandidates = persistedCandidates.filter((candidate) =>
+		(candidate.candidate_status === "auto_inserted" || candidate.candidate_status === "auto_project_created")
+		&& Boolean(candidate.matched_project_id)
+	);
+
+	if (!config.dryRun && projectRootInsertCandidates.length > 0 && repository.insertProjectRoots) {
+		const insertedRoots = await repository.insertProjectRoots(
+			projectRootInsertCandidates.map((candidate) => ({
+				org_id: config.orgId,
+				project_id: candidate.matched_project_id as string,
+				root_path: candidate.candidate_root_path,
+				notes: `Auto inserted from NAS root parser for ${config.targetWorkDate}`
+			}))
+		);
+		persistedCandidates = attachPromotedRootIds({
+			candidateRows: persistedCandidates,
+			insertedRoots
+		});
+
+		const insertedRootByPath = new Map(
+			insertedRoots.map((root) => [normalizePath(root.root_path), root] as const)
+		);
+		for (const candidate of projectRootInsertCandidates) {
+			const insertedRoot = insertedRootByPath.get(candidate.normalized_root_path);
+			if (insertedRoot) {
+				actionRows.push(buildProjectAction({
+					orgId: config.orgId,
+					targetWorkDate: config.targetWorkDate,
+					candidate,
+					actionType: "auto_insert_root",
+					actionStatus: "completed",
+					projectId: candidate.matched_project_id,
+					projectRootId: insertedRoot.id,
+					reason: `auto inserted project NAS root for ${candidate.candidate_root_path}`
+				}));
+			}
+		}
+	}
+
+	if (!config.dryRun) {
+		for (const candidate of persistedCandidates) {
+			if (candidate.candidate_status === "rejected_by_rule") {
+				actionRows.push(buildProjectAction({
+					orgId: config.orgId,
+					targetWorkDate: config.targetWorkDate,
+					candidate,
+					actionType: "reject_candidate",
+					actionStatus: "skipped",
+					reason: candidate.notes
+				}));
+			}
+			if (candidate.candidate_status === "conflict_needs_manual_fix") {
+				actionRows.push(buildProjectAction({
+					orgId: config.orgId,
+					targetWorkDate: config.targetWorkDate,
+					candidate,
+					actionType: "conflict_candidate",
+					actionStatus: "skipped",
+					reason: candidate.notes
+				}));
+			}
+		}
+	}
+
+	if (!config.dryRun && actionRows.length > 0 && repository.insertProjectActions) {
+		await repository.insertProjectActions(actionRows);
+	}
+
+	if (!config.dryRun && repository.upsertProjectRootCandidates) {
+		await repository.upsertProjectRootCandidates(persistedCandidates);
+	}
+
+	const summary: NasRootAutoParserSummary = {
+		stage: config.dryRun
+			? "candidates_built"
+			: projectRootInsertCandidates.length > 0
+				? "project_roots_updated"
+				: "candidates_persisted",
+		target_work_date: config.targetWorkDate,
+		timezone: config.timezone,
+		range_start: window.rangeStartIso,
+		range_end: window.rangeEndIso,
+		actions: config.actions,
+		total_logs_scanned: loadedLogs.length,
+		total_logs_accepted: filteredLogs.acceptedLogs.length,
+		total_logs_ignored_accounts: filteredLogs.ignoredAccountCount,
+		total_logs_rejected_incomplete: filteredLogs.incompleteCount,
+		total_existing_project_hits: builtCandidates.existingProjectHitCount,
+		total_candidate_roots: persistedCandidates.length,
+		total_auto_created_projects: autoCreatedProjectCount,
+		total_auto_inserted_roots: persistedCandidates.filter((candidate) =>
+			(candidate.candidate_status === "auto_inserted" || candidate.candidate_status === "auto_project_created")
+			&& Boolean(candidate.promoted_root_id)
+		).length,
+		total_pending_review_roots: persistedCandidates.filter((candidate) => candidate.candidate_status === "pending_review").length,
+		total_missing_project_master_roots: persistedCandidates.filter((candidate) => candidate.candidate_status === "missing_project_master").length,
+		total_conflict_roots: persistedCandidates.filter((candidate) => candidate.candidate_status === "conflict_needs_manual_fix").length,
+		total_rejected_roots: builtCandidates.rejectedRootCount
+			+ persistedCandidates.filter((candidate) => candidate.candidate_status === "rejected_by_rule").length,
+		candidate_samples: persistedCandidates.map((candidate) => ({
+			candidate_root_path: candidate.candidate_root_path,
+			parsed_project_code: candidate.parsed_project_code,
+			parsed_project_name: candidate.parsed_project_name,
+			matched_project_id: candidate.matched_project_id,
+			match_method: candidate.match_method,
+			candidate_status: candidate.candidate_status,
+			promoted_root_id: candidate.promoted_root_id,
+			sample_log_count: candidate.sample_log_count,
+			first_seen_at: candidate.first_seen_at,
+			last_seen_at: candidate.last_seen_at
+		}))
+	};
+
+	return {
+		status: config.dryRun ? "dry-run" : "completed",
+		summary
+	};
+};

--- a/scripts/asset-log-time-capture/repository.ts
+++ b/scripts/asset-log-time-capture/repository.ts
@@ -1,0 +1,378 @@
+import { createClient } from "@supabase/supabase-js";
+import type {
+	AutoTimeGeneratedTaskLink,
+	AutoTimeInsertedTask,
+	AutoTimeNasUserAlias,
+	AutoTimePersistedRunItem,
+	AutoTimeProjectRoot,
+	AutoTimeRunItemInsert,
+	AutoTimeRunnerRepository,
+	AutoTimeTaskInsert,
+	AutoTimeRunRow,
+	AutoTimeRunStatus
+} from "./core.ts";
+import type { AutoTimeDailyHealthReport } from "./healthReportCore.ts";
+import type {
+	NasRootProjectActionInsert,
+	NasRootAutoParserRepository,
+	NasRootProjectInsert,
+	NasRootProjectRecord,
+	NasRootProjectRootCandidateUpsert,
+	NasRootProjectRootInsert
+} from "./nasRootAutoParserCore.ts";
+import { createLoadAssetLogs } from "./loadAssetLogs.ts";
+
+export const createRepository = (
+	supabaseUrl: string,
+	supabaseServiceRoleKey: string
+): AutoTimeRunnerRepository & NasRootAutoParserRepository & {
+	insertDailyHealthReport: (report: AutoTimeDailyHealthReport) => Promise<void>;
+} => {
+	const client = createClient(supabaseUrl, supabaseServiceRoleKey);
+	const timeTracker = client.schema("time_tracker");
+	const loadAssetLogs = createLoadAssetLogs(client);
+
+	return {
+		loadAssetLogs,
+		loadIgnoreAccounts: async (orgId: string) => {
+			const { data, error } = await timeTracker
+				.from("auto_time_ignore_accounts")
+				.select("nas_username")
+				.eq("is_active", true)
+				.or(`org_id.eq.${orgId},org_id.is.null`);
+
+			if (error) {
+				throw new Error(`Failed to load auto_time_ignore_accounts: ${error.message}`);
+			}
+
+			return (data ?? [])
+				.map((row) => row.nas_username as string)
+				.filter(Boolean);
+		},
+		loadNasUserAliases: async (orgId: string): Promise<AutoTimeNasUserAlias[]> => {
+			const { data, error } = await timeTracker
+				.from("nas_user_aliases")
+				.select("nas_username,user_id")
+				.eq("org_id", orgId)
+				.eq("is_active", true);
+
+			if (error) {
+				throw new Error(`Failed to load nas_user_aliases: ${error.message}`);
+			}
+
+			return (data ?? []) as AutoTimeNasUserAlias[];
+		},
+		loadProjectRoots: async (orgId: string): Promise<AutoTimeProjectRoot[]> => {
+			const { data, error } = await timeTracker
+				.from("project_nas_roots")
+				.select("id,project_id,root_path")
+				.eq("org_id", orgId)
+				.eq("is_active", true);
+
+			if (error) {
+				throw new Error(`Failed to load project_nas_roots: ${error.message}`);
+			}
+
+			return (data ?? []) as AutoTimeProjectRoot[];
+		},
+		loadProjects: async (orgId: string): Promise<NasRootProjectRecord[]> => {
+			const { data, error } = await timeTracker
+				.from("projects")
+				.select("id,name,source_project_code,status")
+				.eq("org_id", orgId)
+				.eq("status", "active");
+
+			if (error) {
+				throw new Error(`Failed to load projects: ${error.message}`);
+			}
+
+			return (data ?? []) as NasRootProjectRecord[];
+		},
+		createProjects: async (items: NasRootProjectInsert[]): Promise<NasRootProjectRecord[]> => {
+			if (items.length === 0) {
+				return [];
+			}
+
+			const payload = items.map((item) => ({
+				org_id: item.org_id,
+				name: item.name,
+				source_project_code: item.source_project_code,
+				status: item.status,
+				contract_amount: 0,
+				human_cost_budget: 0
+			}));
+			const { data, error } = await timeTracker
+				.from("projects")
+				.insert(payload)
+				.select("id,name,source_project_code,status");
+
+			if (error) {
+				throw new Error(`Failed to auto create projects: ${error.message}`);
+			}
+
+			return (data ?? []) as NasRootProjectRecord[];
+		},
+		insertProjectRoots: async (items: NasRootProjectRootInsert[]): Promise<AutoTimeProjectRoot[]> => {
+			if (items.length === 0) {
+				return [];
+			}
+
+			const payload = items.map((item) => ({
+				org_id: item.org_id,
+				project_id: item.project_id,
+				root_path: item.root_path,
+				notes: item.notes,
+				is_active: true
+			}));
+			const { data, error } = await timeTracker
+				.from("project_nas_roots")
+				.insert(payload)
+				.select("id,project_id,root_path");
+
+			if (error) {
+				throw new Error(`Failed to insert project_nas_roots: ${error.message}`);
+			}
+
+			return (data ?? []) as AutoTimeProjectRoot[];
+		},
+		upsertProjectRootCandidates: async (items: NasRootProjectRootCandidateUpsert[]) => {
+			if (items.length === 0) {
+				return;
+			}
+
+			const payload = items.map((item) => ({
+				org_id: item.org_id,
+				candidate_root_path: item.candidate_root_path,
+				normalized_root_path: item.normalized_root_path,
+				parsed_project_code: item.parsed_project_code,
+				parsed_project_name: item.parsed_project_name,
+				matched_project_id: item.matched_project_id,
+				match_method: item.match_method,
+				confidence_score: item.confidence_score,
+				candidate_status: item.candidate_status,
+				sample_log_count: item.sample_log_count,
+				first_seen_at: item.first_seen_at,
+				last_seen_at: item.last_seen_at,
+				sample_paths: item.sample_paths,
+				promoted_root_id: item.promoted_root_id,
+				notes: item.notes
+			}));
+			const { error } = await timeTracker
+				.from("auto_time_project_root_candidates")
+				.upsert(payload, {
+					onConflict: "org_id,normalized_root_path"
+				});
+
+			if (error) {
+				throw new Error(`Failed to upsert auto_time_project_root_candidates: ${error.message}`);
+			}
+		},
+		insertProjectActions: async (items: NasRootProjectActionInsert[]) => {
+			if (items.length === 0) {
+				return;
+			}
+
+			const payload = items.map((item) => ({
+				org_id: item.org_id,
+				target_work_date: item.target_work_date,
+				candidate_root_path: item.candidate_root_path,
+				parsed_project_code: item.parsed_project_code,
+				parsed_project_name: item.parsed_project_name,
+				action_type: item.action_type,
+				action_status: item.action_status,
+				project_id: item.project_id,
+				project_root_id: item.project_root_id,
+				run_id: item.run_id,
+				rebuild_target_work_date: item.rebuild_target_work_date,
+				reason: item.reason,
+				metadata: item.metadata
+			}));
+			const { error } = await timeTracker
+				.from("auto_time_project_actions")
+				.insert(payload);
+
+			if (error) {
+				throw new Error(`Failed to insert auto_time_project_actions: ${error.message}`);
+			}
+		},
+		loadManualTaskUserIds: async (orgId: string, targetWorkDate: string): Promise<string[]> => {
+			const { data, error } = await timeTracker
+				.from("tasks")
+				.select("user_id")
+				.eq("org_id", orgId)
+				.eq("work_date", targetWorkDate)
+				.eq("entry_source", "manual");
+
+			if (error) {
+				throw new Error(`Failed to load manual tasks: ${error.message}`);
+			}
+
+			return Array.from(new Set((data ?? []).map((row) => row.user_id as string).filter(Boolean)));
+		},
+		loadExistingAutoTaskKeys: async (orgId: string, targetWorkDate: string): Promise<string[]> => {
+			const { data, error } = await timeTracker
+				.from("tasks")
+				.select("user_id,project_id,work_date")
+				.eq("org_id", orgId)
+				.eq("work_date", targetWorkDate)
+				.eq("entry_source", "nas_auto");
+
+			if (error) {
+				throw new Error(`Failed to load existing auto tasks: ${error.message}`);
+			}
+
+			return Array.from(new Set(
+				(data ?? [])
+					.map((row) => {
+						const userId = row.user_id as string | null;
+						const projectId = row.project_id as string | null;
+						const workDate = row.work_date as string | null;
+						return userId && projectId && workDate ? `${userId}|${projectId}|${workDate}` : null;
+					})
+					.filter(Boolean) as string[]
+			));
+		},
+		deleteExistingAutoTasks: async (orgId: string, targetWorkDate: string): Promise<string[]> => {
+			const { data: existingRows, error: selectError } = await timeTracker
+				.from("tasks")
+				.select("id")
+				.eq("org_id", orgId)
+				.eq("work_date", targetWorkDate)
+				.eq("entry_source", "nas_auto");
+
+			if (selectError) {
+				throw new Error(`Failed to load existing nas_auto tasks for rebuild: ${selectError.message}`);
+			}
+
+			const taskIds = (existingRows ?? [])
+				.map((row) => row.id as string | null)
+				.filter(Boolean) as string[];
+
+			if (taskIds.length === 0) {
+				return [];
+			}
+
+			const { error: deleteError } = await timeTracker
+				.from("tasks")
+				.delete()
+				.in("id", taskIds);
+
+			if (deleteError) {
+				throw new Error(`Failed to delete existing nas_auto tasks for rebuild: ${deleteError.message}`);
+			}
+
+			return taskIds;
+		},
+		insertRunItems: async (runId: string, items: AutoTimeRunItemInsert[]): Promise<AutoTimePersistedRunItem[]> => {
+			if (items.length === 0) {
+				return [];
+			}
+
+			const payload = items.map((item) => ({
+				run_id: runId,
+				...item
+			}));
+			const { data, error } = await timeTracker
+				.from("auto_time_run_items")
+				.insert(payload)
+				.select("id,org_id,target_work_date,nas_username,user_id,project_id,project_root_id,source_event_count,source_event_ids,source_paths,first_detected_at,last_detected_at,raw_first_activity_at,raw_last_activity_at,raw_total_minutes,unattributed_minutes,raw_project_minutes,normalized_project_minutes,allocation_method,allocation_version,allocation_meta,resolution_status,resolution_reason,generated_duration_minutes,metadata");
+
+			if (error) {
+				throw new Error(`Failed to insert auto_time_run_items: ${error.message}`);
+			}
+
+			return (data ?? []) as AutoTimePersistedRunItem[];
+		},
+		insertTasks: async (_runId: string, tasks: AutoTimeTaskInsert[]): Promise<AutoTimeInsertedTask[]> => {
+			if (tasks.length === 0) {
+				return [];
+			}
+
+			const { data, error } = await timeTracker
+				.from("tasks")
+				.insert(tasks)
+				.select("id,source_item_id");
+
+			if (error) {
+				throw new Error(`Failed to insert tasks: ${error.message}`);
+			}
+
+			return (data ?? []) as AutoTimeInsertedTask[];
+		},
+		linkGeneratedTasks: async (links: AutoTimeGeneratedTaskLink[]) => {
+			for (const link of links) {
+				const { error } = await timeTracker
+					.from("auto_time_run_items")
+					.update({
+						generated_task_id: link.generated_task_id
+					})
+					.eq("id", link.run_item_id);
+
+				if (error) {
+					throw new Error(`Failed to link generated task ${link.generated_task_id} to run item ${link.run_item_id}: ${error.message}`);
+				}
+			}
+		},
+		createRun: async (payload: AutoTimeRunRow) => {
+			const { data, error } = await timeTracker
+				.from("auto_time_runs")
+				.insert(payload)
+				.select("id")
+				.single();
+
+			if (error) {
+				throw new Error(`Failed to create auto_time_runs record: ${error.message}`);
+			}
+
+			return {
+				id: data.id as string
+			};
+		},
+		finalizeRun: async (
+			runId: string,
+			status: AutoTimeRunStatus,
+			summary: Record<string, unknown>,
+			errorSummary?: string
+		) => {
+			const { error } = await timeTracker
+				.from("auto_time_runs")
+				.update({
+					status,
+					finished_at: new Date().toISOString(),
+					summary,
+					error_summary: errorSummary ?? null
+				})
+				.eq("id", runId);
+
+			if (error) {
+				throw new Error(`Failed to finalize auto_time_runs record ${runId}: ${error.message}`);
+			}
+		},
+		insertDailyHealthReport: async (report: AutoTimeDailyHealthReport) => {
+			const { error } = await timeTracker
+				.from("auto_time_daily_health_reports")
+				.insert({
+					org_id: report.org_id,
+					target_work_date: report.target_work_date,
+					run_id: report.run_id,
+					status: report.status,
+					total_logs_scanned: report.total_logs_scanned,
+					total_logs_accepted: report.total_logs_accepted,
+					total_projects_auto_created: report.total_projects_auto_created,
+					total_roots_auto_inserted: report.total_roots_auto_inserted,
+					total_rebuild_dates_queued: report.total_rebuild_dates_queued,
+					total_rebuild_dates_completed: report.total_rebuild_dates_completed,
+					total_tasks_written: report.total_tasks_written,
+					total_zero_project_users: report.total_zero_project_users,
+					total_high_unattributed_users: report.total_high_unattributed_users,
+					total_conflict_candidates: report.total_conflict_candidates,
+					total_rejected_candidates: report.total_rejected_candidates,
+					summary: report.summary
+				});
+
+			if (error) {
+				throw new Error(`Failed to insert auto_time_daily_health_reports: ${error.message}`);
+			}
+		}
+	};
+};

--- a/scripts/asset-log-time-capture/runner.ts
+++ b/scripts/asset-log-time-capture/runner.ts
@@ -1,0 +1,33 @@
+import { createRunnerConfig } from "./config.ts";
+import {
+	runAutoTimeCapture,
+} from "./core.ts";
+import { createRepository } from "./repository.ts";
+
+const main = async () => {
+	const config = createRunnerConfig();
+	const repository = (config.supabaseUrl && config.supabaseServiceRoleKey)
+		? createRepository(config.supabaseUrl, config.supabaseServiceRoleKey)
+		: {
+			createRun: async () => {
+				throw new Error("Dry-run repository should not create run records");
+			},
+			finalizeRun: async () => undefined
+		};
+	const result = await runAutoTimeCapture({
+		config,
+		repository
+	});
+
+	console.log(JSON.stringify({
+		status: result.status,
+		runId: result.runId ?? null,
+		summary: result.summary
+	}, null, 2));
+};
+
+main().catch((error) => {
+	console.error("[asset-log-time-capture] runner failed");
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/scripts/asset-log-time-capture/sampleReport.ts
+++ b/scripts/asset-log-time-capture/sampleReport.ts
@@ -1,0 +1,100 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { createRunnerConfig } from "./config.ts";
+import { runAutoTimeCapture } from "./core.ts";
+import { createRepository } from "./repository.ts";
+import { buildRecentWorkDates, buildSampleReportMarkdown, buildSampleReportSummary } from "./sampleReportCore.ts";
+
+const readArgumentValue = (argv: string[], name: string): string | undefined => {
+	const exactIndex = argv.findIndex((entry) => entry === name);
+	if (exactIndex >= 0) {
+		return argv[exactIndex + 1];
+	}
+
+	const prefix = `${name}=`;
+	const matched = argv.find((entry) => entry.startsWith(prefix));
+	return matched ? matched.slice(prefix.length) : undefined;
+};
+
+const parsePositiveInteger = (value: string | undefined, defaultValue: number): number => {
+	if (!value) {
+		return defaultValue;
+	}
+
+	const parsed = Number(value);
+	if (!Number.isInteger(parsed) || parsed <= 0) {
+		throw new Error(`Invalid positive integer: ${value}`);
+	}
+
+	return parsed;
+};
+
+const main = async () => {
+	const argv = process.argv.slice(2);
+	const baseConfig = createRunnerConfig({
+		argv
+	});
+
+	if (!baseConfig.supabaseUrl || !baseConfig.supabaseServiceRoleKey) {
+		throw new Error("sample-report requires SA_TIME_SUPABASE_URL and SA_TIME_SUPABASE_SERVICE_ROLE_KEY");
+	}
+
+	const days = parsePositiveInteger(readArgumentValue(argv, "--days"), 7);
+	const endDate = readArgumentValue(argv, "--end-date") ?? baseConfig.targetWorkDate;
+	const markdownOutputPath = readArgumentValue(argv, "--markdown-output");
+	const targetDates = buildRecentWorkDates({
+		endDate,
+		days
+	});
+	const repository = createRepository(baseConfig.supabaseUrl, baseConfig.supabaseServiceRoleKey);
+	const results = [];
+
+	for (const targetWorkDate of targetDates) {
+		const result = await runAutoTimeCapture({
+			config: {
+				...baseConfig,
+				targetWorkDate,
+				dryRun: true
+			},
+			repository
+		});
+
+		results.push({
+			status: result.status,
+			target_work_date: targetWorkDate,
+			allocation_sample_rows: result.summary.allocation_sample_rows ?? [],
+			allocation_diagnostics: result.summary.allocation_diagnostics ?? []
+		});
+	}
+
+	const report = buildSampleReportSummary({
+		targetDates,
+		results
+	});
+
+	if (markdownOutputPath) {
+		const resolvedPath = path.resolve(markdownOutputPath);
+		await mkdir(path.dirname(resolvedPath), {
+			recursive: true
+		});
+		await writeFile(
+			resolvedPath,
+			buildSampleReportMarkdown({
+				report
+			}),
+			"utf8"
+		);
+	}
+
+	console.log(JSON.stringify({
+		report,
+		results,
+		markdown_output_path: markdownOutputPath ? path.resolve(markdownOutputPath) : null
+	}, null, 2));
+};
+
+main().catch((error) => {
+	console.error("[asset-log-time-capture] sample report failed");
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/scripts/asset-log-time-capture/sampleReportCore.ts
+++ b/scripts/asset-log-time-capture/sampleReportCore.ts
@@ -1,0 +1,130 @@
+type AllocationSampleRow = Record<string, unknown>;
+type SampleReportSummary = ReturnType<typeof buildSampleReportSummary>;
+
+const parseDateKey = (value: string) => {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+	if (!match) {
+		throw new Error(`Invalid work date: ${value}`);
+	}
+
+	return {
+		year: Number(match[1]),
+		month: Number(match[2]),
+		day: Number(match[3])
+	};
+};
+
+const makeDateKey = (year: number, month: number, day: number): string =>
+	`${year.toString().padStart(4, "0")}-${month.toString().padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
+
+const shiftDateKey = (value: string, offsetDays: number): string => {
+	const { year, month, day } = parseDateKey(value);
+	const shifted = new Date(Date.UTC(year, month - 1, day));
+	shifted.setUTCDate(shifted.getUTCDate() + offsetDays);
+
+	return makeDateKey(shifted.getUTCFullYear(), shifted.getUTCMonth() + 1, shifted.getUTCDate());
+};
+
+const getDayOfWeek = (dateKey: string): number => new Date(`${dateKey}T00:00:00.000Z`).getUTCDay();
+
+const isWeekend = (dayOfWeek: number): boolean => dayOfWeek === 0 || dayOfWeek === 6;
+
+export const buildRecentWorkDates = ({
+	endDate,
+	days
+}: {
+	endDate: string;
+	days: number;
+}): string[] => {
+	if (days <= 0) {
+		return [];
+	}
+
+	const collectedDates: string[] = [];
+	let cursor = endDate;
+
+	while (collectedDates.length < days) {
+		if (!isWeekend(getDayOfWeek(cursor))) {
+			collectedDates.push(cursor);
+		}
+		cursor = shiftDateKey(cursor, -1);
+	}
+
+	return collectedDates.reverse();
+};
+
+export const buildSampleReportSummary = ({
+	targetDates,
+	results
+}: {
+	targetDates: string[];
+	results: Array<{
+		target_work_date: string;
+		allocation_sample_rows?: AllocationSampleRow[];
+	}>;
+}) => {
+	const sampleRows = results.flatMap((result) => result.allocation_sample_rows ?? []);
+
+	return {
+		target_dates: targetDates,
+		total_dates: targetDates.length,
+		total_sample_rows: sampleRows.length,
+		single_project_days: sampleRows.filter((row) => Number(row.distinct_project_count ?? 0) === 1).length,
+		two_project_days: sampleRows.filter((row) => Number(row.distinct_project_count ?? 0) === 2).length,
+		three_plus_project_days: sampleRows.filter((row) => Number(row.distinct_project_count ?? 0) >= 3).length,
+		large_gap_hit_days: sampleRows.filter((row) => Boolean(row.large_gap_hit)).length,
+		conservative_mode_hit_days: sampleRows.filter((row) => Boolean(row.conservative_mode_hit)).length,
+		sample_rows: sampleRows
+	};
+};
+
+const formatProjectList = (projects: unknown): string => {
+	if (!Array.isArray(projects) || projects.length === 0) {
+		return "-";
+	}
+
+	return projects
+		.map((project) => {
+			const entry = project as Record<string, unknown>;
+			return `${entry.project_id ?? "unknown"}: raw ${entry.raw_project_minutes ?? 0}m, normalized ${entry.normalized_project_minutes ?? 0}m, formal ${entry.formal_generated_minutes ?? 0}m`;
+		})
+		.join("<br />");
+};
+
+export const buildSampleReportMarkdown = ({
+	report
+}: {
+	report: SampleReportSummary;
+}): string => {
+	const startDate = String(report.target_dates[0] ?? "");
+	const endDate = String(report.target_dates[report.target_dates.length - 1] ?? "");
+	const sampleRows = Array.isArray(report.sample_rows) ? report.sample_rows : [];
+
+	return [
+		"# SA-TIME Allocation Sample Report",
+		"",
+		`Report Window: ${startDate} -> ${endDate}`,
+		"",
+		"## Summary",
+		"",
+		"| Metric | Value |",
+		"| --- | --- |",
+		`| Total Dates | ${report.total_dates} |`,
+		`| Total Sample Rows | ${report.total_sample_rows} |`,
+		`| Single Project Days | ${report.single_project_days} |`,
+		`| Two Project Days | ${report.two_project_days} |`,
+		`| Three+ Project Days | ${report.three_plus_project_days} |`,
+		`| Large Gap Hit Days | ${report.large_gap_hit_days} |`,
+		`| Conservative Mode Hit Days | ${report.conservative_mode_hit_days} |`,
+		"",
+		"## Sample Rows",
+		"",
+		"| User | User ID | Date | Last Activity | Raw Total | Unattributed | Large Gap | Conservative | Projects |",
+		"| --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+		...sampleRows.map((row) => {
+			const entry = row as Record<string, unknown>;
+			return `| ${entry.nas_username ?? "-"} | ${entry.user_id ?? "-"} | ${entry.target_work_date ?? "-"} | ${entry.raw_last_activity_at ?? "-"} | ${entry.raw_total_minutes ?? 0} | ${entry.unattributed_minutes ?? 0} | ${Boolean(entry.large_gap_hit) ? "yes" : "no"} | ${Boolean(entry.conservative_mode_hit) ? "yes" : "no"} | ${formatProjectList(entry.projects)} |`;
+		}),
+		""
+	].join("\n");
+};

--- a/src/autoTime/fullLoopRunner.test.ts
+++ b/src/autoTime/fullLoopRunner.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	runAutoTimeFullLoop,
+	type AutoTimeFullLoopRepository
+} from "../../scripts/asset-log-time-capture/fullLoopRunner";
+import type { AutoTimeRunnerConfig } from "../../scripts/asset-log-time-capture/core";
+import type { NasRootAutoParserConfig } from "../../scripts/asset-log-time-capture/nasRootAutoParserCore";
+
+const parserConfig: NasRootAutoParserConfig = {
+	orgId: "org-001",
+	supabaseUrl: "https://example.supabase.co",
+	supabaseServiceRoleKey: "service-role-key",
+	sourceTable: "public.asset_version_log",
+	targetWorkDate: "2026-04-23",
+	timezone: "Asia/Shanghai",
+	dryRun: false,
+	actions: ["create", "write", "rename", "delete"],
+	lookbackDays: 7
+};
+
+const runnerConfig: AutoTimeRunnerConfig = {
+	orgId: "org-001",
+	supabaseUrl: "https://example.supabase.co",
+	supabaseServiceRoleKey: "service-role-key",
+	targetWorkDate: "2026-04-23",
+	timezone: "Asia/Shanghai",
+	dryRun: false,
+	ignoreWeekends: true,
+	actions: ["create", "write", "rename", "delete"],
+	sourceTable: "public.asset_version_log",
+	allocationMode: "interval_to_previous_project",
+	largeGapThresholdMinutes: 120,
+	skipFormalWriteOnLargeGap: false,
+	rebuildNasAuto: false
+};
+
+describe("auto time full loop runner", () => {
+	it("runs parser, rebuilds affected work dates, runs normal capture, and writes health report", async () => {
+		const repository = {
+			insertDailyHealthReport: vi.fn().mockResolvedValue(undefined)
+		} as unknown as AutoTimeFullLoopRepository;
+		const runParser = vi.fn().mockResolvedValue({
+			status: "completed",
+			summary: {
+				total_auto_created_projects: 1,
+				total_auto_inserted_roots: 1,
+				total_conflict_roots: 0,
+				total_rejected_roots: 0,
+				candidate_samples: [
+					{
+						candidate_root_path: "/daga-2025-project/CONCEPT/C20260413_友谊商店二期",
+						candidate_status: "auto_project_created",
+						first_seen_at: "2026-04-20T02:00:00.000Z",
+						last_seen_at: "2026-04-23T07:00:00.000Z"
+					}
+				]
+			}
+		});
+		const runCapture = vi.fn()
+			.mockResolvedValueOnce({
+				status: "completed",
+				runId: "rebuild-2026-04-20",
+				summary: {
+					total_logs_scanned: 10,
+					total_logs_accepted: 8,
+					total_existing_auto_tasks_deleted: 1,
+					total_tasks_written: 3,
+					allocation_diagnostics: []
+				}
+			})
+			.mockResolvedValueOnce({
+				status: "completed",
+				runId: "rebuild-2026-04-21",
+				summary: {
+					total_logs_scanned: 11,
+					total_logs_accepted: 9,
+					total_existing_auto_tasks_deleted: 1,
+					total_tasks_written: 4,
+					allocation_diagnostics: []
+				}
+			})
+			.mockResolvedValueOnce({
+				status: "completed",
+				runId: "rebuild-2026-04-22",
+				summary: {
+					total_logs_scanned: 12,
+					total_logs_accepted: 10,
+					total_existing_auto_tasks_deleted: 1,
+					total_tasks_written: 5,
+					allocation_diagnostics: []
+				}
+			})
+			.mockResolvedValueOnce({
+				status: "completed",
+				runId: "rebuild-2026-04-23",
+				summary: {
+					total_logs_scanned: 13,
+					total_logs_accepted: 11,
+					total_existing_auto_tasks_deleted: 1,
+					total_tasks_written: 6,
+					allocation_diagnostics: []
+				}
+			})
+			.mockResolvedValueOnce({
+				status: "completed",
+				runId: "normal-2026-04-23",
+				summary: {
+					total_logs_scanned: 13,
+					total_logs_accepted: 11,
+					total_tasks_written: 0,
+					allocation_diagnostics: [
+						{
+							nas_username: "具志坚强",
+							user_id: "user-001",
+							raw_total_minutes: 513,
+							unattributed_minutes: 0,
+							distinct_project_count: 1
+						}
+					]
+				}
+			});
+
+		const result = await runAutoTimeFullLoop({
+			parserConfig,
+			runnerConfig,
+			repository,
+			runParser,
+			runCapture
+		});
+
+		expect(runParser).toHaveBeenCalledWith(parserConfig, repository);
+		expect(runCapture).toHaveBeenNthCalledWith(1, expect.objectContaining({
+			targetWorkDate: "2026-04-20",
+			rebuildNasAuto: true
+		}), repository);
+		expect(runCapture).toHaveBeenNthCalledWith(4, expect.objectContaining({
+			targetWorkDate: "2026-04-23",
+			rebuildNasAuto: true
+		}), repository);
+		expect(runCapture).toHaveBeenNthCalledWith(5, expect.objectContaining({
+			targetWorkDate: "2026-04-23",
+			rebuildNasAuto: false
+		}), repository);
+		expect(repository.insertDailyHealthReport).toHaveBeenCalledWith(expect.objectContaining({
+			target_work_date: "2026-04-23",
+			run_id: "normal-2026-04-23",
+			total_projects_auto_created: 1,
+			total_roots_auto_inserted: 1,
+			total_rebuild_dates_queued: 4,
+			total_rebuild_dates_completed: 4,
+			total_tasks_written: 18
+		}));
+		expect(result.rebuildDates).toEqual([
+			"2026-04-20",
+			"2026-04-21",
+			"2026-04-22",
+			"2026-04-23"
+		]);
+	});
+});

--- a/src/autoTime/healthReportCore.test.ts
+++ b/src/autoTime/healthReportCore.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildAutoTimeDailyHealthReport,
+	buildAutoTimeHealthMarkdown
+} from "../../scripts/asset-log-time-capture/healthReportCore";
+
+describe("auto time health report core", () => {
+	it("detects zero-project and high-unattributed users from allocation diagnostics", () => {
+		const report = buildAutoTimeDailyHealthReport({
+			orgId: "org-001",
+			targetWorkDate: "2026-04-23",
+			runId: "run-001",
+			parserSummary: {
+				total_auto_created_projects: 1,
+				total_auto_inserted_roots: 1,
+				total_conflict_roots: 1,
+				total_rejected_roots: 2
+			},
+			runnerSummary: {
+				total_logs_scanned: 100,
+				total_logs_accepted: 20,
+				total_tasks_written: 5,
+				total_existing_auto_tasks_deleted: 3,
+				allocation_diagnostics: [
+					{
+						nas_username: "具志坚强",
+						user_id: "user-001",
+						raw_total_minutes: 513,
+						unattributed_minutes: 513,
+						distinct_project_count: 0
+					},
+					{
+						nas_username: "张龙潇",
+						user_id: "user-002",
+						raw_total_minutes: 512,
+						unattributed_minutes: 479,
+						distinct_project_count: 2
+					},
+					{
+						nas_username: "蒋仕豪",
+						user_id: "user-003",
+						raw_total_minutes: 782,
+						unattributed_minutes: 19,
+						distinct_project_count: 2
+					}
+				]
+			}
+		});
+
+		expect(report).toEqual(expect.objectContaining({
+			org_id: "org-001",
+			target_work_date: "2026-04-23",
+			run_id: "run-001",
+			status: "completed_with_anomalies",
+			total_logs_scanned: 100,
+			total_logs_accepted: 20,
+			total_projects_auto_created: 1,
+			total_roots_auto_inserted: 1,
+			total_rebuild_dates_completed: 1,
+			total_tasks_written: 5,
+			total_zero_project_users: 1,
+			total_high_unattributed_users: 1,
+			total_conflict_candidates: 1,
+			total_rejected_candidates: 2
+		}));
+		expect(report.summary.zero_project_users).toEqual([
+			expect.objectContaining({
+				nas_username: "具志坚强",
+				user_id: "user-001"
+			})
+		]);
+		expect(report.summary.high_unattributed_users).toEqual([
+			expect.objectContaining({
+				nas_username: "张龙潇",
+				unattributed_ratio: expect.closeTo(0.9355, 4)
+			})
+		]);
+	});
+
+	it("renders markdown with project automation and anomaly totals", () => {
+		const markdown = buildAutoTimeHealthMarkdown({
+			org_id: "org-001",
+			target_work_date: "2026-04-23",
+			run_id: "run-001",
+			status: "completed_with_anomalies",
+			total_logs_scanned: 100,
+			total_logs_accepted: 20,
+			total_projects_auto_created: 1,
+			total_roots_auto_inserted: 1,
+			total_rebuild_dates_queued: 1,
+			total_rebuild_dates_completed: 1,
+			total_tasks_written: 5,
+			total_zero_project_users: 1,
+			total_high_unattributed_users: 1,
+			total_conflict_candidates: 1,
+			total_rejected_candidates: 2,
+			summary: {
+				zero_project_users: [
+					{
+						nas_username: "具志坚强",
+						user_id: "user-001",
+						raw_total_minutes: 513,
+						unattributed_minutes: 513,
+						distinct_project_count: 0,
+						unattributed_ratio: 1
+					}
+				],
+				high_unattributed_users: []
+			}
+		});
+
+		expect(markdown).toContain("# SA-TIME Auto Time Health Report");
+		expect(markdown).toContain("| Target Work Date | 2026-04-23 |");
+		expect(markdown).toContain("| Auto Created Projects | 1 |");
+		expect(markdown).toContain("| Zero Project Users | 1 |");
+		expect(markdown).toContain("| 具志坚强 | user-001 | 513 | 513 |");
+	});
+});

--- a/src/autoTime/nasRootAutoParserCore.test.ts
+++ b/src/autoTime/nasRootAutoParserCore.test.ts
@@ -1,0 +1,471 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	runNasRootAutoParser,
+	type NasRootAutoParserConfig,
+	type NasRootAutoParserRepository
+} from "../../scripts/asset-log-time-capture/nasRootAutoParserCore";
+
+const createConfig = (overrides: Partial<NasRootAutoParserConfig> = {}): NasRootAutoParserConfig => ({
+	orgId: "00000000-0000-0000-0000-000000000001",
+	supabaseUrl: "https://example.supabase.co",
+	supabaseServiceRoleKey: "service-role-key",
+	sourceTable: "public.asset_version_log",
+	targetWorkDate: "2026-04-22",
+	timezone: "Asia/Shanghai",
+	dryRun: false,
+	actions: ["create", "write", "rename", "delete"],
+	lookbackDays: 7,
+	...overrides
+});
+
+describe("nas root auto parser core", () => {
+	it("auto creates a missing active project, inserts its root, and records audit actions", async () => {
+		const repository: NasRootAutoParserRepository = {
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-auto-project-001",
+					file_path: "/daga-2025-project/CONCEPT/C20260413_友谊商店二期/02-2D/file-1.psd",
+					nas_username: "juzhijianqiang",
+					action: "write",
+					detected_at: "2026-04-23T07:52:57.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-23T07:53:00.000Z"
+				},
+				{
+					id: "log-auto-project-002",
+					file_path: "/daga-2025-project/CONCEPT/C20260413_友谊商店二期/04-PRESENTATION/file-2.indd",
+					nas_username: "juzhijianqiang",
+					action: "write",
+					detected_at: "2026-04-23T10:33:04.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-23T10:33:06.000Z"
+				}
+			]),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadProjectRoots: vi.fn().mockResolvedValue([]),
+			loadProjects: vi.fn().mockResolvedValue([]),
+			createProjects: vi.fn().mockResolvedValue([
+				{
+					id: "project-auto-001",
+					name: "友谊商店二期",
+					source_project_code: "C20260413",
+					status: "active"
+				}
+			]),
+			insertProjectRoots: vi.fn().mockResolvedValue([
+				{
+					id: "root-auto-001",
+					project_id: "project-auto-001",
+					root_path: "/daga-2025-project/CONCEPT/C20260413_友谊商店二期"
+				}
+			]),
+			insertProjectActions: vi.fn().mockResolvedValue(undefined),
+			upsertProjectRootCandidates: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runNasRootAutoParser({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.createProjects).toHaveBeenCalledWith([
+			expect.objectContaining({
+				org_id: "00000000-0000-0000-0000-000000000001",
+				name: "友谊商店二期",
+				source_project_code: "C20260413",
+				status: "active"
+			})
+		]);
+		expect(repository.insertProjectRoots).toHaveBeenCalledWith([
+			expect.objectContaining({
+				project_id: "project-auto-001",
+				root_path: "/daga-2025-project/CONCEPT/C20260413_友谊商店二期"
+			})
+		]);
+		expect(repository.insertProjectActions).toHaveBeenCalledWith(expect.arrayContaining([
+			expect.objectContaining({
+				action_type: "auto_create_project",
+				action_status: "completed",
+				project_id: "project-auto-001",
+				candidate_root_path: "/daga-2025-project/CONCEPT/C20260413_友谊商店二期"
+			}),
+			expect.objectContaining({
+				action_type: "auto_insert_root",
+				action_status: "completed",
+				project_id: "project-auto-001",
+				project_root_id: "root-auto-001"
+			})
+		]));
+		expect(repository.upsertProjectRootCandidates).toHaveBeenCalledWith([
+			expect.objectContaining({
+				candidate_root_path: "/daga-2025-project/CONCEPT/C20260413_友谊商店二期",
+				parsed_project_code: "C20260413",
+				parsed_project_name: "友谊商店二期",
+				candidate_status: "auto_project_created",
+				matched_project_id: "project-auto-001",
+				promoted_root_id: "root-auto-001",
+				sample_log_count: 2
+			})
+		]);
+		expect(result.summary).toEqual(expect.objectContaining({
+			stage: "project_roots_updated",
+			total_auto_created_projects: 1,
+			total_auto_inserted_roots: 1,
+			total_missing_project_master_roots: 0
+		}));
+	});
+
+	it("rejects non-project roots by rule instead of auto creating active projects", async () => {
+		const repository: NasRootAutoParserRepository = {
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-reject-001",
+					file_path: "/daga-2025-project/server-backup/dump.sql",
+					nas_username: "ops",
+					action: "write",
+					detected_at: "2026-04-22T02:00:00.000Z",
+					sa_ai_user_id: "user-ops",
+					created_at: "2026-04-22T02:00:05.000Z"
+				},
+				{
+					id: "log-reject-002",
+					file_path: "/daga-2025-project/CONCEPT/000000-项目梳理/file.md",
+					nas_username: "ops",
+					action: "write",
+					detected_at: "2026-04-22T03:00:00.000Z",
+					sa_ai_user_id: "user-ops",
+					created_at: "2026-04-22T03:00:05.000Z"
+				}
+			]),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadProjectRoots: vi.fn().mockResolvedValue([]),
+			loadProjects: vi.fn().mockResolvedValue([]),
+			createProjects: vi.fn().mockResolvedValue([]),
+			insertProjectRoots: vi.fn().mockResolvedValue([]),
+			insertProjectActions: vi.fn().mockResolvedValue(undefined),
+			upsertProjectRootCandidates: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runNasRootAutoParser({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.createProjects).not.toHaveBeenCalled();
+		expect(repository.insertProjectRoots).not.toHaveBeenCalled();
+		expect(repository.upsertProjectRootCandidates).toHaveBeenCalledWith(expect.arrayContaining([
+			expect.objectContaining({
+				candidate_root_path: "/daga-2025-project/server-backup",
+				candidate_status: "rejected_by_rule",
+				notes: "candidate root rejected by auto-create guard"
+			}),
+			expect.objectContaining({
+				candidate_root_path: "/daga-2025-project/CONCEPT/000000-项目梳理",
+				candidate_status: "rejected_by_rule",
+				notes: "candidate root rejected by auto-create guard"
+			})
+		]));
+		expect(result.summary).toEqual(expect.objectContaining({
+			total_rejected_roots: 2,
+			total_auto_created_projects: 0
+		}));
+	});
+
+	it("marks duplicate source project codes as conflicts without creating projects or roots", async () => {
+		const repository: NasRootAutoParserRepository = {
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-conflict-001",
+					file_path: "/daga-2025-project/D0489_北京鲲熙汇PARK书店/file.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-22T02:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-22T02:00:05.000Z"
+				}
+			]),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadProjectRoots: vi.fn().mockResolvedValue([]),
+			loadProjects: vi.fn().mockResolvedValue([
+				{
+					id: "project-001",
+					name: "北京鲲熙汇PARK书店 A",
+					source_project_code: "D0489",
+					status: "active"
+				},
+				{
+					id: "project-002",
+					name: "北京鲲熙汇PARK书店 B",
+					source_project_code: "D0489",
+					status: "active"
+				}
+			]),
+			createProjects: vi.fn().mockResolvedValue([]),
+			insertProjectRoots: vi.fn().mockResolvedValue([]),
+			insertProjectActions: vi.fn().mockResolvedValue(undefined),
+			upsertProjectRootCandidates: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runNasRootAutoParser({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.createProjects).not.toHaveBeenCalled();
+		expect(repository.insertProjectRoots).not.toHaveBeenCalled();
+		expect(repository.upsertProjectRootCandidates).toHaveBeenCalledWith([
+			expect.objectContaining({
+				candidate_root_path: "/daga-2025-project/D0489_北京鲲熙汇PARK书店",
+				candidate_status: "conflict_needs_manual_fix",
+				match_method: "code_exact",
+				matched_project_id: null,
+				notes: "source_project_code D0489 matched multiple active projects"
+			})
+		]);
+		expect(result.summary).toEqual(expect.objectContaining({
+			total_conflict_roots: 1,
+			total_auto_created_projects: 0,
+			total_auto_inserted_roots: 0
+		}));
+	});
+
+	it("marks duplicate missing-project candidates in the same batch as conflicts", async () => {
+		const repository: NasRootAutoParserRepository = {
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-batch-conflict-001",
+					file_path: "/daga-2025-project/CONCEPT/C20260415_西单商场/file.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-22T02:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-22T02:00:05.000Z"
+				},
+				{
+					id: "log-batch-conflict-002",
+					file_path: "/daga-2025-project/CONCEPT/C20260415_泰达金二地块/file.psd",
+					nas_username: "bob",
+					action: "write",
+					detected_at: "2026-04-22T03:00:00.000Z",
+					sa_ai_user_id: "user-002",
+					created_at: "2026-04-22T03:00:05.000Z"
+				}
+			]),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadProjectRoots: vi.fn().mockResolvedValue([]),
+			loadProjects: vi.fn().mockResolvedValue([]),
+			createProjects: vi.fn().mockResolvedValue([]),
+			insertProjectRoots: vi.fn().mockResolvedValue([]),
+			insertProjectActions: vi.fn().mockResolvedValue(undefined),
+			upsertProjectRootCandidates: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runNasRootAutoParser({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.createProjects).not.toHaveBeenCalled();
+		expect(repository.insertProjectRoots).not.toHaveBeenCalled();
+		expect(repository.upsertProjectRootCandidates).toHaveBeenCalledWith(expect.arrayContaining([
+			expect.objectContaining({
+				parsed_project_code: "C20260415",
+				candidate_status: "conflict_needs_manual_fix",
+				notes: "source_project_code C20260415 appears in multiple new NAS candidates"
+			})
+		]));
+		expect(result.summary).toEqual(expect.objectContaining({
+			total_conflict_roots: 2,
+			total_auto_created_projects: 0
+		}));
+	});
+
+	it("auto inserts candidate roots when source_project_code matches exactly once", async () => {
+		const repository: NasRootAutoParserRepository = {
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-001",
+					file_path: "/daga-2025-project/CONCEPT/C20260104-成都王府井/方案/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-22T01:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-22T01:00:05.000Z"
+				},
+				{
+					id: "log-002",
+					file_path: "/daga-2025-project/CONCEPT/C20260104-成都王府井/模型/file-2.psd",
+					nas_username: "alice",
+					action: "rename",
+					detected_at: "2026-04-22T02:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-22T02:00:05.000Z"
+				},
+				{
+					id: "log-003",
+					file_path: "/daga-2025-project/D0490_青岛麦岛站/效果图/file-3.psd",
+					nas_username: "bob",
+					action: "write",
+					detected_at: "2026-04-21T08:00:00.000Z",
+					sa_ai_user_id: null,
+					created_at: "2026-04-21T08:00:05.000Z"
+				}
+			]),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue(["wenshunhe"]),
+			loadProjectRoots: vi.fn().mockResolvedValue([
+				{
+					id: "root-existing",
+					project_id: "project-existing",
+					root_path: "/daga-2025-project/D0473_办公室"
+				}
+			]),
+			loadProjects: vi.fn().mockResolvedValue([
+				{
+					id: "project-001",
+					name: "成都王府井",
+					source_project_code: "C20260104",
+					status: "active"
+				},
+				{
+					id: "project-002",
+					name: "青岛麦岛站",
+					source_project_code: "D0490",
+					status: "active"
+				}
+			]),
+			insertProjectRoots: vi.fn().mockImplementation(async (items: any[]) =>
+				items.map((item, index) => ({
+					id: `root-new-${index + 1}`,
+					project_id: item.project_id,
+					root_path: item.root_path
+				}))
+			),
+			upsertProjectRootCandidates: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runNasRootAutoParser({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.loadAssetLogs).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sourceTable: "public.asset_version_log",
+				rangeStartIso: "2026-04-14T16:00:00.000Z",
+				rangeEndIso: "2026-04-22T16:00:00.000Z",
+				actions: ["create", "write", "rename", "delete"]
+			})
+		);
+		expect(repository.insertProjectRoots).toHaveBeenCalledWith([
+			expect.objectContaining({
+				project_id: "project-001",
+				root_path: "/daga-2025-project/CONCEPT/C20260104-成都王府井"
+			}),
+			expect.objectContaining({
+				project_id: "project-002",
+				root_path: "/daga-2025-project/D0490_青岛麦岛站"
+			})
+		]);
+		expect(repository.upsertProjectRootCandidates).toHaveBeenCalledWith([
+			expect.objectContaining({
+				candidate_root_path: "/daga-2025-project/CONCEPT/C20260104-成都王府井",
+				parsed_project_code: "C20260104",
+				candidate_status: "auto_inserted",
+				match_method: "code_exact",
+				matched_project_id: "project-001",
+				promoted_root_id: "root-new-1",
+				sample_log_count: 2
+			}),
+			expect.objectContaining({
+				candidate_root_path: "/daga-2025-project/D0490_青岛麦岛站",
+				parsed_project_code: "D0490",
+				candidate_status: "auto_inserted",
+				match_method: "code_exact",
+				matched_project_id: "project-002",
+				promoted_root_id: "root-new-2",
+				sample_log_count: 1
+			})
+		]);
+		expect(result.summary).toEqual(expect.objectContaining({
+			stage: "project_roots_updated",
+			total_logs_scanned: 3,
+			total_logs_accepted: 3,
+			total_existing_project_hits: 0,
+			total_candidate_roots: 2,
+			total_auto_inserted_roots: 2,
+			total_pending_review_roots: 0,
+			total_missing_project_master_roots: 0
+		}));
+	});
+
+	it("keeps name-only matches and missing project master rows in candidates without inserting roots", async () => {
+		const repository: NasRootAutoParserRepository = {
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-101",
+					file_path: "/daga-2025-project/上德中心/方案/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-22T01:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-22T01:00:05.000Z"
+				},
+				{
+					id: "log-102",
+					file_path: "/daga-2025-project/C20260413_友谊商店二期/效果图/file-2.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-22T02:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-22T02:00:05.000Z"
+				}
+			]),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadProjectRoots: vi.fn().mockResolvedValue([]),
+			loadProjects: vi.fn().mockResolvedValue([
+				{
+					id: "project-301",
+					name: "上德中心",
+					source_project_code: null,
+					status: "active"
+				}
+			]),
+			insertProjectRoots: vi.fn().mockResolvedValue([]),
+			upsertProjectRootCandidates: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runNasRootAutoParser({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.insertProjectRoots).not.toHaveBeenCalled();
+		expect(repository.upsertProjectRootCandidates).toHaveBeenCalledWith(expect.arrayContaining([
+			expect.objectContaining({
+				candidate_root_path: "/daga-2025-project/上德中心",
+				parsed_project_code: null,
+				parsed_project_name: "上德中心",
+				candidate_status: "pending_review",
+				match_method: "name_exact",
+				matched_project_id: "project-301",
+				promoted_root_id: null
+			}),
+			expect.objectContaining({
+				candidate_root_path: "/daga-2025-project/C20260413_友谊商店二期",
+				parsed_project_code: "C20260413",
+				parsed_project_name: "友谊商店二期",
+				candidate_status: "missing_project_master",
+				match_method: "none",
+				matched_project_id: null,
+				promoted_root_id: null
+			})
+		]));
+		expect(result.summary).toEqual(expect.objectContaining({
+			stage: "candidates_persisted",
+			total_candidate_roots: 2,
+			total_auto_inserted_roots: 0,
+			total_pending_review_roots: 1,
+			total_missing_project_master_roots: 1
+		}));
+	});
+});

--- a/src/autoTime/runnerConfig.test.ts
+++ b/src/autoTime/runnerConfig.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { createRunnerConfig } from "../../scripts/asset-log-time-capture/config";
+
+describe("asset-log-time-capture config", () => {
+	it("defaults formal allocation mode to interval_to_previous_project", () => {
+		const config = createRunnerConfig({
+			env: {
+				SA_TIME_ORG_ID: "org-001",
+				SA_TIME_DRY_RUN: "true"
+			},
+			argv: []
+		});
+
+		expect(config.allocationMode).toBe("interval_to_previous_project");
+		expect(config.largeGapThresholdMinutes).toBe(120);
+		expect(config.skipFormalWriteOnLargeGap).toBe(false);
+	});
+
+	it("parses interval_to_previous_project allocation mode from env or argv", () => {
+		const envConfig = createRunnerConfig({
+			env: {
+				SA_TIME_ORG_ID: "org-001",
+				SA_TIME_DRY_RUN: "true",
+				SA_TIME_ALLOCATION_MODE: "interval_to_previous_project"
+			},
+			argv: []
+		});
+		const argvConfig = createRunnerConfig({
+			env: {
+				SA_TIME_ORG_ID: "org-001",
+				SA_TIME_DRY_RUN: "true"
+			},
+			argv: ["--allocation-mode=interval_to_previous_project"]
+		});
+
+		expect(envConfig.allocationMode).toBe("interval_to_previous_project");
+		expect(argvConfig.allocationMode).toBe("interval_to_previous_project");
+	});
+
+	it("parses large-gap policy guard options from env or argv", () => {
+		const envConfig = createRunnerConfig({
+			env: {
+				SA_TIME_ORG_ID: "org-001",
+				SA_TIME_DRY_RUN: "true",
+				SA_TIME_LARGE_GAP_THRESHOLD_MINUTES: "90",
+				SA_TIME_SKIP_FORMAL_WRITE_ON_LARGE_GAP: "true"
+			},
+			argv: []
+		});
+		const argvConfig = createRunnerConfig({
+			env: {
+				SA_TIME_ORG_ID: "org-001",
+				SA_TIME_DRY_RUN: "true"
+			},
+			argv: [
+				"--large-gap-threshold-minutes=150",
+				"--skip-formal-write-on-large-gap=true"
+			]
+		});
+
+		expect(envConfig.largeGapThresholdMinutes).toBe(90);
+		expect(envConfig.skipFormalWriteOnLargeGap).toBe(true);
+		expect(argvConfig.largeGapThresholdMinutes).toBe(150);
+		expect(argvConfig.skipFormalWriteOnLargeGap).toBe(true);
+	});
+
+	it("parses rebuild nas auto mode from env or argv", () => {
+		const envConfig = createRunnerConfig({
+			env: {
+				SA_TIME_ORG_ID: "org-001",
+				SA_TIME_DRY_RUN: "true",
+				SA_TIME_REBUILD_NAS_AUTO: "true"
+			},
+			argv: []
+		});
+		const argvConfig = createRunnerConfig({
+			env: {
+				SA_TIME_ORG_ID: "org-001",
+				SA_TIME_DRY_RUN: "true"
+			},
+			argv: ["--rebuild-nas-auto"]
+		});
+
+		expect(envConfig.rebuildNasAuto).toBe(true);
+		expect(argvConfig.rebuildNasAuto).toBe(true);
+	});
+});

--- a/src/autoTime/runnerCore.test.ts
+++ b/src/autoTime/runnerCore.test.ts
@@ -1,0 +1,1348 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildTargetDayWindow,
+	buildRawAllocationDiagnostics,
+	normalizeProjectMinutesToFixedTotal,
+	runAutoTimeCapture,
+	type AutoTimeRunnerRepository,
+	type AutoTimeRunnerConfig
+} from "../../scripts/asset-log-time-capture/core";
+
+const createConfig = (overrides: Partial<AutoTimeRunnerConfig> = {}): AutoTimeRunnerConfig => ({
+	orgId: "00000000-0000-0000-0000-000000000001",
+	supabaseUrl: "https://example.supabase.co",
+	supabaseServiceRoleKey: "service-role-key",
+	targetWorkDate: "2026-04-21",
+	timezone: "Asia/Shanghai",
+	dryRun: false,
+	ignoreWeekends: true,
+	actions: ["create", "write", "rename", "delete"],
+	sourceTable: "public.asset_version_log",
+	allocationMode: "even_split",
+	largeGapThresholdMinutes: 120,
+	skipFormalWriteOnLargeGap: false,
+	rebuildNasAuto: false,
+	...overrides
+});
+
+describe("asset-log-time-capture core", () => {
+	it("compresses consecutive project events and attributes adjacent intervals to the previous project", () => {
+		const allocation = buildRawAllocationDiagnostics({
+			dayStartIso: "2026-04-21T02:00:00.000Z",
+			rawLastActivityAt: "2026-04-21T08:00:00.000Z",
+			projectEvents: [
+				{
+					project_id: "project-001",
+					project_root_id: "root-001",
+					detected_at: "2026-04-21T03:00:00.000Z"
+				},
+				{
+					project_id: "project-001",
+					project_root_id: "root-001",
+					detected_at: "2026-04-21T04:00:00.000Z"
+				},
+				{
+					project_id: "project-002",
+					project_root_id: "root-002",
+					detected_at: "2026-04-21T05:00:00.000Z"
+				},
+				{
+					project_id: "project-001",
+					project_root_id: "root-001",
+					detected_at: "2026-04-21T06:00:00.000Z"
+				}
+			]
+		});
+
+		expect(allocation.raw_total_minutes).toBe(360);
+		expect(allocation.unattributed_minutes).toBe(60);
+		expect(allocation.attributed_total_minutes).toBe(300);
+		expect(allocation.distinct_project_count).toBe(2);
+		expect(allocation.compressed_project_events).toEqual([
+			expect.objectContaining({
+				project_id: "project-001",
+				detected_at: "2026-04-21T03:00:00.000Z"
+			}),
+			expect.objectContaining({
+				project_id: "project-002",
+				detected_at: "2026-04-21T05:00:00.000Z"
+			}),
+			expect.objectContaining({
+				project_id: "project-001",
+				detected_at: "2026-04-21T06:00:00.000Z"
+			})
+		]);
+		expect(allocation.project_minutes).toEqual([
+			expect.objectContaining({
+				project_id: "project-001",
+				raw_project_minutes: 240
+			}),
+			expect.objectContaining({
+				project_id: "project-002",
+				raw_project_minutes: 60
+			})
+		]);
+		expect(normalizeProjectMinutesToFixedTotal(allocation.project_minutes, 480)).toEqual([
+			expect.objectContaining({
+				project_id: "project-001",
+				normalized_project_minutes: 384
+			}),
+			expect.objectContaining({
+				project_id: "project-002",
+				normalized_project_minutes: 96
+			})
+		]);
+	});
+
+	it("keeps the last project's first event so its interval extends to rawLastActivityAt", () => {
+		const allocation = buildRawAllocationDiagnostics({
+			dayStartIso: "2026-04-21T02:00:00.000Z",
+			rawLastActivityAt: "2026-04-21T08:00:00.000Z",
+			projectEvents: [
+				{
+					project_id: "project-001",
+					project_root_id: "root-001",
+					detected_at: "2026-04-21T03:00:00.000Z"
+				},
+				{
+					project_id: "project-002",
+					project_root_id: "root-002",
+					detected_at: "2026-04-21T05:00:00.000Z"
+				},
+				{
+					project_id: "project-002",
+					project_root_id: "root-002",
+					detected_at: "2026-04-21T08:00:00.000Z"
+				}
+			]
+		});
+
+		expect(allocation.compressed_project_events).toEqual([
+			expect.objectContaining({
+				project_id: "project-001",
+				detected_at: "2026-04-21T03:00:00.000Z"
+			}),
+			expect.objectContaining({
+				project_id: "project-002",
+				detected_at: "2026-04-21T05:00:00.000Z"
+			})
+		]);
+		expect(allocation.project_intervals).toEqual([
+			expect.objectContaining({
+				project_id: "project-001",
+				interval_minutes: 120
+			}),
+			expect.objectContaining({
+				project_id: "project-002",
+				interval_minutes: 180
+			})
+		]);
+		expect(allocation.project_minutes).toEqual([
+			expect.objectContaining({
+				project_id: "project-001",
+				raw_project_minutes: 120
+			}),
+			expect.objectContaining({
+				project_id: "project-002",
+				raw_project_minutes: 180
+			})
+		]);
+	});
+
+	it("builds the previous Shanghai business day window", () => {
+		const window = buildTargetDayWindow({
+			now: new Date("2026-04-21T20:30:00.000Z"),
+			timezone: "Asia/Shanghai"
+		});
+
+		expect(window.targetWorkDate).toBe("2026-04-21");
+		expect(window.rangeStartIso).toBe("2026-04-20T16:00:00.000Z");
+		expect(window.rangeEndIso).toBe("2026-04-21T16:00:00.000Z");
+		expect(window.dayOfWeek).toBe(2);
+	});
+
+	it("skips weekend targets before creating a run record", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn(),
+			finalizeRun: vi.fn()
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig({
+				targetWorkDate: "2026-04-19"
+			}),
+			repository
+		});
+
+		expect(result.status).toBe("skipped");
+		expect(result.summary.skipReason).toBe("weekend");
+		expect(repository.createRun).not.toHaveBeenCalled();
+		expect(repository.finalizeRun).not.toHaveBeenCalled();
+	});
+
+	it("skips configured holidays before creating a run record", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn(),
+			finalizeRun: vi.fn()
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig({
+				targetWorkDate: "2026-05-01"
+			}),
+			repository
+		});
+
+		expect(result.status).toBe("skipped");
+		expect(result.summary.skipReason).toBe("holiday");
+		expect(repository.createRun).not.toHaveBeenCalled();
+		expect(repository.finalizeRun).not.toHaveBeenCalled();
+	});
+
+	it("creates and finalizes a skeleton run on workdays", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn().mockResolvedValue({
+				id: "run-001"
+			}),
+			finalizeRun: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.createRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				org_id: "00000000-0000-0000-0000-000000000001",
+				target_work_date: "2026-04-21",
+				status: "running"
+			})
+		);
+		expect(repository.finalizeRun).toHaveBeenCalledWith(
+			"run-001",
+			"skipped",
+			expect.objectContaining({
+				stage: "skeleton_pending_implementation",
+				total_logs_scanned: 0
+			})
+		);
+		expect(result.status).toBe("skipped");
+		expect(result.runId).toBe("run-001");
+	});
+
+	it("loads asset logs and filters ignored or incomplete records during dry-run", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn(),
+			finalizeRun: vi.fn(),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue(["wenshunhe"]),
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-001",
+					file_path: "/Projects/A/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-20T18:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-20T18:00:05.000Z"
+				},
+				{
+					id: "log-002",
+					file_path: "/Projects/A/file-2.psd",
+					nas_username: "wenshunhe",
+					action: "write",
+					detected_at: "2026-04-20T19:00:00.000Z",
+					sa_ai_user_id: null,
+					created_at: "2026-04-20T19:00:05.000Z"
+				},
+				{
+					id: "log-003",
+					file_path: "",
+					nas_username: "bob",
+					action: "rename",
+					detected_at: "2026-04-20T20:00:00.000Z",
+					sa_ai_user_id: null,
+					created_at: "2026-04-20T20:00:05.000Z"
+				},
+				{
+					id: "log-004",
+					file_path: "/Projects/B/file-4.psd",
+					nas_username: "",
+					action: "create",
+					detected_at: "2026-04-20T21:00:00.000Z",
+					sa_ai_user_id: null,
+					created_at: "2026-04-20T21:00:05.000Z"
+				}
+			])
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig({
+				dryRun: true
+			}),
+			repository
+		});
+
+		expect(repository.loadAssetLogs).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sourceTable: "public.asset_version_log",
+				rangeStartIso: "2026-04-20T16:00:00.000Z",
+				rangeEndIso: "2026-04-21T16:00:00.000Z",
+				actions: ["create", "write", "rename", "delete"]
+			})
+		);
+		expect(repository.loadIgnoreAccounts).toHaveBeenCalledWith("00000000-0000-0000-0000-000000000001");
+		expect(result.status).toBe("dry-run");
+		expect(result.summary.stage).toBe("logs_loaded");
+		expect(result.summary.total_logs_scanned).toBe(4);
+		expect(result.summary.total_logs_accepted).toBe(1);
+		expect(result.summary.total_logs_ignored_accounts).toBe(1);
+		expect(result.summary.total_logs_rejected_incomplete).toBe(2);
+	});
+
+	it("maps users and projects, then deduplicates by user-date-project during dry-run", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn(),
+			finalizeRun: vi.fn(),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue(["wenshunhe"]),
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-101",
+					file_path: "/Projects/A/concept/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-20T18:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-20T18:00:05.000Z"
+				},
+				{
+					id: "log-102",
+					file_path: "/Projects/A/render/file-2.psd",
+					nas_username: "alice",
+					action: "rename",
+					detected_at: "2026-04-20T19:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-20T19:00:05.000Z"
+				},
+				{
+					id: "log-103",
+					file_path: "/Projects/B/model/file-3.psd",
+					nas_username: "longxiao",
+					action: "write",
+					detected_at: "2026-04-20T20:00:00.000Z",
+					sa_ai_user_id: null,
+					created_at: "2026-04-20T20:00:05.000Z"
+				},
+				{
+					id: "log-104",
+					file_path: "/Projects/C/misc/file-4.psd",
+					nas_username: "ghost-user",
+					action: "write",
+					detected_at: "2026-04-20T21:00:00.000Z",
+					sa_ai_user_id: null,
+					created_at: "2026-04-20T21:00:05.000Z"
+				},
+				{
+					id: "log-105",
+					file_path: "/Unknown/file-5.psd",
+					nas_username: "alice",
+					action: "create",
+					detected_at: "2026-04-20T22:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-20T22:00:05.000Z"
+				}
+			]),
+			loadNasUserAliases: vi.fn().mockResolvedValue([
+				{
+					nas_username: "longxiao",
+					user_id: "user-002"
+				}
+			]),
+			loadProjectRoots: vi.fn().mockResolvedValue([
+				{
+					id: "root-001",
+					project_id: "project-001",
+					root_path: "/Projects/A"
+				},
+				{
+					id: "root-002",
+					project_id: "project-002",
+					root_path: "/Projects/B"
+				}
+			])
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig({
+				dryRun: true
+			}),
+			repository
+		});
+
+		expect(repository.loadNasUserAliases).toHaveBeenCalledWith("00000000-0000-0000-0000-000000000001");
+		expect(repository.loadProjectRoots).toHaveBeenCalledWith("00000000-0000-0000-0000-000000000001");
+		expect(result.summary.stage).toBe("candidates_aggregated");
+		expect(result.summary.total_logs_scanned).toBe(5);
+		expect(result.summary.total_logs_accepted).toBe(5);
+		expect(result.summary.total_logs_unmapped_users).toBe(1);
+		expect(result.summary.total_logs_unmapped_projects).toBe(1);
+		expect(result.summary.total_candidate_items).toBe(2);
+	});
+
+	it("writes run items with manual override skip and 480/N duration allocation", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn().mockResolvedValue({
+				id: "run-101"
+			}),
+			finalizeRun: vi.fn().mockResolvedValue(undefined),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-201",
+					file_path: "/Projects/A/concept/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-21T03:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-21T03:00:05.000Z"
+				},
+				{
+					id: "log-202",
+					file_path: "/Projects/B/model/file-2.psd",
+					nas_username: "alice",
+					action: "rename",
+					detected_at: "2026-04-21T04:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-21T04:00:05.000Z"
+				},
+				{
+					id: "log-202b",
+					file_path: "/Unmapped/misc/file-2.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-21T05:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-21T05:00:05.000Z"
+				},
+				{
+					id: "log-203",
+					file_path: "/Projects/C/model/file-3.psd",
+					nas_username: "longxiao",
+					action: "write",
+					detected_at: "2026-04-21T05:00:00.000Z",
+					sa_ai_user_id: null,
+					created_at: "2026-04-21T05:00:05.000Z"
+				}
+			]),
+			loadNasUserAliases: vi.fn().mockResolvedValue([
+				{
+					nas_username: "longxiao",
+					user_id: "user-002"
+				}
+			]),
+			loadProjectRoots: vi.fn().mockResolvedValue([
+				{
+					id: "root-001",
+					project_id: "project-001",
+					root_path: "/Projects/A"
+				},
+				{
+					id: "root-002",
+					project_id: "project-002",
+					root_path: "/Projects/B"
+				},
+				{
+					id: "root-003",
+					project_id: "project-003",
+					root_path: "/Projects/C"
+				}
+			]),
+			loadManualTaskUserIds: vi.fn().mockResolvedValue(["user-002"]),
+			insertRunItems: vi.fn().mockImplementation(async (_runId, items) =>
+				items.map((item: any, index: number) => ({
+					id: `item-${index + 1}`,
+					...item
+				}))
+			)
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.loadManualTaskUserIds).toHaveBeenCalledWith(
+			"00000000-0000-0000-0000-000000000001",
+			"2026-04-21"
+		);
+		expect(repository.insertRunItems).toHaveBeenCalledWith(
+			"run-101",
+			expect.arrayContaining([
+				expect.objectContaining({
+					user_id: "user-001",
+					project_id: "project-001",
+					resolution_status: "accepted",
+					generated_duration_minutes: 240,
+					source_event_count: 1,
+					raw_last_activity_at: "2026-04-21T05:00:00.000Z",
+					raw_total_minutes: 180,
+					unattributed_minutes: 60,
+					raw_project_minutes: 60,
+					normalized_project_minutes: 240,
+					allocation_method: "interval_to_previous_project",
+					allocation_version: "stage_a_v1",
+					allocation_meta: expect.objectContaining({
+						diagnostic_normalized_project_minutes: 240,
+						formal_generated_minutes: 240,
+						formal_allocation_mode: "even_split",
+						conservative_mode_hit: false,
+						large_gap_hit: false
+					})
+				}),
+				expect.objectContaining({
+					user_id: "user-001",
+					project_id: "project-002",
+					resolution_status: "accepted",
+					generated_duration_minutes: 240,
+					source_event_count: 1,
+					raw_last_activity_at: "2026-04-21T05:00:00.000Z",
+					raw_total_minutes: 180,
+					unattributed_minutes: 60,
+					raw_project_minutes: 60,
+					normalized_project_minutes: 240,
+					allocation_method: "interval_to_previous_project",
+					allocation_version: "stage_a_v1",
+					allocation_meta: expect.objectContaining({
+						diagnostic_normalized_project_minutes: 240,
+						formal_generated_minutes: 240,
+						formal_allocation_mode: "even_split",
+						conservative_mode_hit: false,
+						large_gap_hit: false
+					})
+				}),
+				expect.objectContaining({
+					user_id: "user-002",
+					project_id: "project-003",
+					resolution_status: "manual_override_skipped",
+					generated_duration_minutes: null,
+					source_event_count: 1,
+					raw_last_activity_at: "2026-04-21T05:00:00.000Z",
+					raw_total_minutes: 180,
+					unattributed_minutes: 180,
+					raw_project_minutes: 0,
+					normalized_project_minutes: 0,
+					allocation_method: "interval_to_previous_project",
+					allocation_version: "stage_a_v1",
+					allocation_meta: expect.objectContaining({
+						diagnostic_normalized_project_minutes: 0,
+						formal_generated_minutes: null,
+						formal_allocation_mode: "even_split",
+						conservative_mode_hit: false,
+						large_gap_hit: false
+					})
+				})
+			])
+		);
+		expect(repository.finalizeRun).toHaveBeenCalledWith(
+			"run-101",
+			"completed",
+			expect.objectContaining({
+				stage: "run_items_written",
+				total_candidate_items: 3,
+				total_run_items_written: 3,
+				total_manual_override_items: 1,
+				total_tasks_written: 0,
+				formal_allocation_mode: "even_split",
+				allocation_sample_rows: expect.arrayContaining([
+					expect.objectContaining({
+						user_id: "user-001",
+						target_work_date: "2026-04-21",
+						raw_last_activity_at: "2026-04-21T05:00:00.000Z",
+						raw_total_minutes: 180,
+						unattributed_minutes: 60,
+						distinct_project_count: 2,
+						large_gap_hit: false,
+						conservative_mode_hit: false,
+						projects: expect.arrayContaining([
+							expect.objectContaining({
+								project_id: "project-001",
+								raw_project_minutes: 60,
+								normalized_project_minutes: 240,
+								formal_generated_minutes: 240
+							})
+						])
+					})
+				]),
+				allocation_diagnostics: expect.arrayContaining([
+					expect.objectContaining({
+						user_id: "user-001",
+						raw_last_activity_at: "2026-04-21T05:00:00.000Z",
+						raw_total_minutes: 180,
+						unattributed_minutes: 60,
+						distinct_project_count: 2,
+						attributed_total_minutes: 120,
+						conservative_mode_hit: false,
+						large_gap_hit: false,
+						project_minutes: expect.arrayContaining([
+							expect.objectContaining({
+								project_id: "project-001",
+								raw_project_minutes: 60,
+								normalized_project_minutes: 240,
+								formal_generated_minutes: 240
+							})
+						])
+					})
+				])
+			})
+		);
+		expect(result.status).toBe("completed");
+		expect(result.runId).toBe("run-101");
+	});
+
+	it("flags 3+ project days as conservative-mode diagnostics without changing current formal allocation", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn().mockResolvedValue({
+				id: "run-301"
+			}),
+			finalizeRun: vi.fn().mockResolvedValue(undefined),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-401",
+					file_path: "/Projects/A/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-21T03:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-21T03:00:05.000Z"
+				},
+				{
+					id: "log-402",
+					file_path: "/Projects/B/file-2.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-21T04:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-21T04:00:05.000Z"
+				},
+				{
+					id: "log-403",
+					file_path: "/Projects/C/file-3.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-21T05:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-21T05:00:05.000Z"
+				}
+			]),
+			loadNasUserAliases: vi.fn().mockResolvedValue([]),
+			loadProjectRoots: vi.fn().mockResolvedValue([
+				{
+					id: "root-001",
+					project_id: "project-001",
+					root_path: "/Projects/A"
+				},
+				{
+					id: "root-002",
+					project_id: "project-002",
+					root_path: "/Projects/B"
+				},
+				{
+					id: "root-003",
+					project_id: "project-003",
+					root_path: "/Projects/C"
+				}
+			]),
+			loadManualTaskUserIds: vi.fn().mockResolvedValue([]),
+			insertRunItems: vi.fn().mockImplementation(async (_runId, items) =>
+				items.map((item: any, index: number) => ({
+					id: `item-${index + 1}`,
+					...item
+				}))
+			)
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.insertRunItems).toHaveBeenCalledWith(
+			"run-301",
+			expect.arrayContaining([
+				expect.objectContaining({
+					project_id: "project-001",
+					generated_duration_minutes: 160,
+					allocation_meta: expect.objectContaining({
+						conservative_mode_hit: true,
+						conservative_mode_reason: "distinct_project_count_gte_3",
+						formal_allocation_mode: "even_split"
+					})
+				}),
+				expect.objectContaining({
+					project_id: "project-002",
+					generated_duration_minutes: 160,
+					allocation_meta: expect.objectContaining({
+						conservative_mode_hit: true,
+						conservative_mode_reason: "distinct_project_count_gte_3"
+					})
+				}),
+				expect.objectContaining({
+					project_id: "project-003",
+					generated_duration_minutes: 160,
+					allocation_meta: expect.objectContaining({
+						conservative_mode_hit: true,
+						conservative_mode_reason: "distinct_project_count_gte_3"
+					})
+				})
+			])
+		);
+		expect(result.summary.allocation_diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					user_id: "user-001",
+					distinct_project_count: 3,
+					conservative_mode_hit: true,
+					conservative_mode_reason: "distinct_project_count_gte_3",
+					formal_write_skipped: false,
+					formal_write_skip_reason: null
+				})
+			])
+		);
+	});
+
+	it("writes formal split for 3+ project days when interval_to_previous_project mode is enabled", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn().mockResolvedValue({
+				id: "run-302"
+			}),
+			finalizeRun: vi.fn().mockResolvedValue(undefined),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-501",
+					file_path: "/Projects/A/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-21T03:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-21T03:00:05.000Z"
+				},
+				{
+					id: "log-502",
+					file_path: "/Projects/B/file-2.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-21T04:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-21T04:00:05.000Z"
+				},
+				{
+					id: "log-503",
+					file_path: "/Projects/C/file-3.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-21T05:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-21T05:00:05.000Z"
+				},
+				{
+					id: "log-504",
+					file_path: "/Unmapped/final-signal.txt",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-21T06:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-21T06:00:05.000Z"
+				}
+			]),
+			loadNasUserAliases: vi.fn().mockResolvedValue([]),
+			loadProjectRoots: vi.fn().mockResolvedValue([
+				{
+					id: "root-001",
+					project_id: "project-001",
+					root_path: "/Projects/A"
+				},
+				{
+					id: "root-002",
+					project_id: "project-002",
+					root_path: "/Projects/B"
+				},
+				{
+					id: "root-003",
+					project_id: "project-003",
+					root_path: "/Projects/C"
+				}
+			]),
+			loadManualTaskUserIds: vi.fn().mockResolvedValue([]),
+			loadExistingAutoTaskKeys: vi.fn().mockResolvedValue([]),
+			insertRunItems: vi.fn().mockResolvedValue([
+				{
+					id: "item-501",
+					org_id: "00000000-0000-0000-0000-000000000001",
+					user_id: "user-001",
+					project_id: "project-001",
+					target_work_date: "2026-04-21",
+					resolution_status: "accepted",
+					generated_duration_minutes: 160
+				},
+				{
+					id: "item-502",
+					org_id: "00000000-0000-0000-0000-000000000001",
+					user_id: "user-001",
+					project_id: "project-002",
+					target_work_date: "2026-04-21",
+					resolution_status: "accepted",
+					generated_duration_minutes: 160
+				},
+				{
+					id: "item-503",
+					org_id: "00000000-0000-0000-0000-000000000001",
+					user_id: "user-001",
+					project_id: "project-003",
+					target_work_date: "2026-04-21",
+					resolution_status: "accepted",
+					generated_duration_minutes: 160
+				}
+			]),
+			insertTasks: vi.fn().mockResolvedValue([
+				{
+					id: "task-501",
+					source_item_id: "item-501"
+				},
+				{
+					id: "task-502",
+					source_item_id: "item-502"
+				},
+				{
+					id: "task-503",
+					source_item_id: "item-503"
+				}
+			]),
+			linkGeneratedTasks: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig({
+				allocationMode: "interval_to_previous_project"
+			}),
+			repository
+		});
+
+		expect(repository.insertRunItems).toHaveBeenCalledWith(
+			"run-302",
+			expect.arrayContaining([
+				expect.objectContaining({
+					project_id: "project-001",
+					resolution_status: "accepted",
+					resolution_reason: null,
+					generated_duration_minutes: 160,
+					allocation_meta: expect.objectContaining({
+						conservative_mode_hit: true,
+						formal_write_skipped: false,
+						formal_write_skip_reason: null,
+						formal_allocation_mode: "interval_to_previous_project"
+					})
+				}),
+				expect.objectContaining({
+					project_id: "project-002",
+					resolution_status: "accepted",
+					generated_duration_minutes: 160
+				}),
+				expect.objectContaining({
+					project_id: "project-003",
+					resolution_status: "accepted",
+					generated_duration_minutes: 160
+				})
+			])
+		);
+		expect(repository.insertTasks).toHaveBeenCalledWith(
+			"run-302",
+			expect.arrayContaining([
+				expect.objectContaining({
+					project_id: "project-001",
+					duration_minutes: 160,
+					work_date: "2026-04-21"
+				}),
+				expect.objectContaining({
+					project_id: "project-002",
+					duration_minutes: 160
+				}),
+				expect.objectContaining({
+					project_id: "project-003",
+					duration_minutes: 160
+				})
+			])
+		);
+		expect(result.summary.total_policy_guard_items).toBe(0);
+		expect(result.summary.allocation_diagnostics).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					user_id: "user-001",
+					conservative_mode_hit: true,
+					formal_write_skipped: false,
+					formal_write_skip_reason: null,
+					formal_allocation_mode: "interval_to_previous_project"
+				})
+			])
+		);
+	});
+
+	it("writes tasks for accepted run items and links generated task ids back to run items", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn().mockResolvedValue({
+				id: "run-201"
+			}),
+			finalizeRun: vi.fn().mockResolvedValue(undefined),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-301",
+					file_path: "/Projects/A/concept/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-20T18:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-20T18:00:05.000Z"
+				},
+				{
+					id: "log-302",
+					file_path: "/Projects/B/model/file-2.psd",
+					nas_username: "alice",
+					action: "rename",
+					detected_at: "2026-04-20T19:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-20T19:00:05.000Z"
+				},
+				{
+					id: "log-303",
+					file_path: "/Projects/C/model/file-3.psd",
+					nas_username: "longxiao",
+					action: "write",
+					detected_at: "2026-04-20T20:00:00.000Z",
+					sa_ai_user_id: null,
+					created_at: "2026-04-20T20:00:05.000Z"
+				}
+			]),
+			loadNasUserAliases: vi.fn().mockResolvedValue([
+				{
+					nas_username: "longxiao",
+					user_id: "user-002"
+				}
+			]),
+			loadProjectRoots: vi.fn().mockResolvedValue([
+				{
+					id: "root-001",
+					project_id: "project-001",
+					root_path: "/Projects/A"
+				},
+				{
+					id: "root-002",
+					project_id: "project-002",
+					root_path: "/Projects/B"
+				},
+				{
+					id: "root-003",
+					project_id: "project-003",
+					root_path: "/Projects/C"
+				}
+			]),
+			loadManualTaskUserIds: vi.fn().mockResolvedValue(["user-002"]),
+			loadExistingAutoTaskKeys: vi.fn().mockResolvedValue([]),
+			insertRunItems: vi.fn().mockResolvedValue([
+				{
+					id: "item-001",
+					org_id: "00000000-0000-0000-0000-000000000001",
+					user_id: "user-001",
+					project_id: "project-001",
+					target_work_date: "2026-04-21",
+					resolution_status: "accepted",
+					generated_duration_minutes: 240
+				},
+				{
+					id: "item-002",
+					org_id: "00000000-0000-0000-0000-000000000001",
+					user_id: "user-001",
+					project_id: "project-002",
+					target_work_date: "2026-04-21",
+					resolution_status: "accepted",
+					generated_duration_minutes: 240
+				},
+				{
+					id: "item-003",
+					org_id: "00000000-0000-0000-0000-000000000001",
+					user_id: "user-002",
+					project_id: "project-003",
+					target_work_date: "2026-04-21",
+					resolution_status: "manual_override_skipped",
+					generated_duration_minutes: null
+				}
+			]),
+			insertTasks: vi.fn().mockResolvedValue([
+				{
+					id: "task-001",
+					source_item_id: "item-001"
+				},
+				{
+					id: "task-002",
+					source_item_id: "item-002"
+				}
+			]),
+			linkGeneratedTasks: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.insertTasks).toHaveBeenCalledWith(
+			"run-201",
+			expect.arrayContaining([
+				expect.objectContaining({
+					org_id: "00000000-0000-0000-0000-000000000001",
+					user_id: "user-001",
+					project_id: "project-001",
+					task_name: "NAS自动工时",
+					work_date: "2026-04-21",
+					duration_minutes: 240,
+					entry_source: "nas_auto",
+					source_run_id: "run-201",
+					source_item_id: "item-001"
+				}),
+				expect.objectContaining({
+					project_id: "project-002",
+					duration_minutes: 240,
+					source_item_id: "item-002"
+				})
+			])
+		);
+		expect(repository.linkGeneratedTasks).toHaveBeenCalledWith(
+			expect.arrayContaining([
+				{
+					run_item_id: "item-001",
+					generated_task_id: "task-001"
+				},
+				{
+					run_item_id: "item-002",
+					generated_task_id: "task-002"
+				}
+			])
+		);
+		expect(repository.finalizeRun).toHaveBeenCalledWith(
+			"run-201",
+			"completed",
+			expect.objectContaining({
+				stage: "tasks_written",
+				total_run_items_written: 3,
+				total_manual_override_items: 1,
+				total_tasks_written: 2
+			})
+		);
+	expect(result.status).toBe("completed");
+	expect(result.runId).toBe("run-201");
+	});
+
+	it("does not write duplicate nas_auto tasks when the target work date already has auto-generated entries", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn().mockResolvedValue({
+				id: "run-301"
+			}),
+			finalizeRun: vi.fn().mockResolvedValue(undefined),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-401",
+					file_path: "/Projects/A/concept/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-20T18:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-20T18:00:05.000Z"
+				}
+			]),
+			loadNasUserAliases: vi.fn().mockResolvedValue([]),
+			loadProjectRoots: vi.fn().mockResolvedValue([
+				{
+					id: "root-001",
+					project_id: "project-001",
+					root_path: "/Projects/A"
+				}
+			]),
+			loadManualTaskUserIds: vi.fn().mockResolvedValue([]),
+			loadExistingAutoTaskKeys: vi.fn().mockResolvedValue([
+				"user-001|project-001|2026-04-21"
+			]),
+			insertRunItems: vi.fn().mockResolvedValue([
+				{
+					id: "item-101",
+					user_id: "user-001",
+					project_id: "project-001",
+					target_work_date: "2026-04-21",
+					resolution_status: "accepted",
+					generated_duration_minutes: 480
+				}
+			]),
+			insertTasks: vi.fn().mockResolvedValue([]),
+			linkGeneratedTasks: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.loadExistingAutoTaskKeys).toHaveBeenCalledWith(
+			"00000000-0000-0000-0000-000000000001",
+			"2026-04-21"
+		);
+		expect(repository.insertTasks).not.toHaveBeenCalled();
+		expect(repository.linkGeneratedTasks).not.toHaveBeenCalled();
+		expect(repository.finalizeRun).toHaveBeenCalledWith(
+			"run-301",
+			"completed",
+			expect.objectContaining({
+				stage: "run_items_written",
+				total_existing_auto_tasks_skipped: 1,
+				total_tasks_written: 0
+			})
+		);
+		expect(result.status).toBe("completed");
+		expect(result.runId).toBe("run-301");
+	});
+
+	it("clears existing nas_auto tasks before writing fresh tasks in rebuild mode", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn().mockResolvedValue({
+				id: "run-rebuild-001"
+			}),
+			finalizeRun: vi.fn().mockResolvedValue(undefined),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-rebuild-001",
+					file_path: "/Projects/A/concept/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-20T18:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-20T18:00:05.000Z"
+				}
+			]),
+			loadNasUserAliases: vi.fn().mockResolvedValue([]),
+			loadProjectRoots: vi.fn().mockResolvedValue([
+				{
+					id: "root-001",
+					project_id: "project-001",
+					root_path: "/Projects/A"
+				}
+			]),
+			loadManualTaskUserIds: vi.fn().mockResolvedValue([]),
+			loadExistingAutoTaskKeys: vi.fn().mockResolvedValue([
+				"user-001|project-001|2026-04-21"
+			]),
+			deleteExistingAutoTasks: vi.fn().mockResolvedValue(["old-task-001"]),
+			insertRunItems: vi.fn().mockResolvedValue([
+				{
+					id: "item-rebuild-001",
+					org_id: "00000000-0000-0000-0000-000000000001",
+					user_id: "user-001",
+					project_id: "project-001",
+					target_work_date: "2026-04-21",
+					resolution_status: "accepted",
+					generated_duration_minutes: 480
+				}
+			]),
+			insertTasks: vi.fn().mockResolvedValue([
+				{
+					id: "task-rebuild-001",
+					source_item_id: "item-rebuild-001"
+				}
+			]),
+			linkGeneratedTasks: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig({
+				rebuildNasAuto: true
+			}),
+			repository
+		});
+
+		expect(repository.deleteExistingAutoTasks).toHaveBeenCalledWith(
+			"00000000-0000-0000-0000-000000000001",
+			"2026-04-21"
+		);
+		expect(repository.loadExistingAutoTaskKeys).not.toHaveBeenCalled();
+		expect(repository.insertTasks).toHaveBeenCalledWith(
+			"run-rebuild-001",
+			[
+				expect.objectContaining({
+					source_item_id: "item-rebuild-001",
+					duration_minutes: 480
+				})
+			]
+		);
+		expect(repository.finalizeRun).toHaveBeenCalledWith(
+			"run-rebuild-001",
+			"completed",
+			expect.objectContaining({
+				rebuild_nas_auto: true,
+				total_existing_auto_tasks_deleted: 1,
+				total_existing_auto_tasks_skipped: 0,
+				total_tasks_written: 1
+			})
+		);
+		expect(result.status).toBe("completed");
+	});
+
+	it("does not write zero-minute nas_auto tasks", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn().mockResolvedValue({
+				id: "run-302"
+			}),
+			finalizeRun: vi.fn().mockResolvedValue(undefined),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-402",
+					file_path: "/Projects/A/concept/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-20T18:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-20T18:00:05.000Z"
+				}
+			]),
+			loadNasUserAliases: vi.fn().mockResolvedValue([]),
+			loadProjectRoots: vi.fn().mockResolvedValue([
+				{
+					id: "root-001",
+					project_id: "project-001",
+					root_path: "/Projects/A"
+				},
+				{
+					id: "root-002",
+					project_id: "project-002",
+					root_path: "/Projects/B"
+				}
+			]),
+			loadManualTaskUserIds: vi.fn().mockResolvedValue([]),
+			loadExistingAutoTaskKeys: vi.fn().mockResolvedValue([]),
+			insertRunItems: vi.fn().mockResolvedValue([
+				{
+					id: "item-201",
+					org_id: "00000000-0000-0000-0000-000000000001",
+					user_id: "user-001",
+					project_id: "project-001",
+					target_work_date: "2026-04-21",
+					resolution_status: "accepted",
+					generated_duration_minutes: 480
+				},
+				{
+					id: "item-202",
+					org_id: "00000000-0000-0000-0000-000000000001",
+					user_id: "user-001",
+					project_id: "project-002",
+					target_work_date: "2026-04-21",
+					resolution_status: "accepted",
+					generated_duration_minutes: 0
+				}
+			]),
+			insertTasks: vi.fn().mockResolvedValue([
+				{
+					id: "task-201",
+					source_item_id: "item-201"
+				}
+			]),
+			linkGeneratedTasks: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await runAutoTimeCapture({
+			config: createConfig(),
+			repository
+		});
+
+		expect(repository.insertTasks).toHaveBeenCalledWith(
+			"run-302",
+			[
+				expect.objectContaining({
+					project_id: "project-001",
+					duration_minutes: 480,
+					source_item_id: "item-201"
+				})
+			]
+		);
+		expect(repository.linkGeneratedTasks).toHaveBeenCalledWith([
+			{
+				run_item_id: "item-201",
+				generated_task_id: "task-201"
+			}
+		]);
+		expect(repository.finalizeRun).toHaveBeenCalledWith(
+			"run-302",
+			"completed",
+			expect.objectContaining({
+				stage: "tasks_written",
+				total_run_items_written: 2,
+				total_tasks_written: 1
+			})
+		);
+		expect(result.status).toBe("completed");
+		expect(result.runId).toBe("run-302");
+	});
+
+	it("finalizes the run as failed when run item insertion throws", async () => {
+		const repository: AutoTimeRunnerRepository = {
+			createRun: vi.fn().mockResolvedValue({
+				id: "run-401"
+			}),
+			finalizeRun: vi.fn().mockResolvedValue(undefined),
+			loadIgnoreAccounts: vi.fn().mockResolvedValue([]),
+			loadAssetLogs: vi.fn().mockResolvedValue([
+				{
+					id: "log-501",
+					file_path: "/Projects/A/concept/file-1.psd",
+					nas_username: "alice",
+					action: "write",
+					detected_at: "2026-04-20T18:00:00.000Z",
+					sa_ai_user_id: "user-001",
+					created_at: "2026-04-20T18:00:05.000Z"
+				}
+			]),
+			loadNasUserAliases: vi.fn().mockResolvedValue([]),
+			loadProjectRoots: vi.fn().mockResolvedValue([
+				{
+					id: "root-001",
+					project_id: "project-001",
+					root_path: "/Projects/A"
+				}
+			]),
+			loadManualTaskUserIds: vi.fn().mockResolvedValue([]),
+			insertRunItems: vi.fn().mockRejectedValue(new Error("boom"))
+		};
+
+		await expect(
+			runAutoTimeCapture({
+				config: createConfig(),
+				repository
+			})
+		).rejects.toThrow("boom");
+
+		expect(repository.createRun).toHaveBeenCalledWith(
+			expect.objectContaining({
+				status: "running",
+				target_work_date: "2026-04-21"
+			})
+		);
+		expect(repository.finalizeRun).toHaveBeenCalledWith(
+			"run-401",
+			"failed",
+			expect.objectContaining({
+				stage: "candidates_aggregated",
+				total_candidate_items: 1
+			}),
+			"boom"
+		);
+	});
+});

--- a/src/autoTime/sampleReportCore.test.ts
+++ b/src/autoTime/sampleReportCore.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildRecentWorkDates,
+	buildSampleReportMarkdown,
+	buildSampleReportSummary
+} from "../../scripts/asset-log-time-capture/sampleReportCore";
+
+describe("asset-log-time-capture sample report core", () => {
+	it("builds recent work dates by skipping weekends", () => {
+		const dates = buildRecentWorkDates({
+			endDate: "2026-04-21",
+			days: 5
+		});
+
+		expect(dates).toEqual([
+			"2026-04-15",
+			"2026-04-16",
+			"2026-04-17",
+			"2026-04-20",
+			"2026-04-21"
+		]);
+	});
+
+	it("aggregates sample rows into a leader-readable report summary", () => {
+		const report = buildSampleReportSummary({
+			targetDates: ["2026-04-20", "2026-04-21"],
+			results: [
+				{
+					target_work_date: "2026-04-20",
+					allocation_sample_rows: [
+						{
+							user_id: "user-001",
+							nas_username: "alice",
+							target_work_date: "2026-04-20",
+							distinct_project_count: 1,
+							large_gap_hit: false,
+							conservative_mode_hit: false
+						},
+						{
+							user_id: "user-002",
+							nas_username: "bob",
+							target_work_date: "2026-04-20",
+							distinct_project_count: 3,
+							large_gap_hit: true,
+							conservative_mode_hit: true
+						}
+					]
+				},
+				{
+					target_work_date: "2026-04-21",
+					allocation_sample_rows: [
+						{
+							user_id: "user-003",
+							nas_username: "carol",
+							target_work_date: "2026-04-21",
+							distinct_project_count: 2,
+							large_gap_hit: false,
+							conservative_mode_hit: false
+						}
+					]
+				}
+			]
+		});
+
+		expect(report.total_dates).toBe(2);
+		expect(report.total_sample_rows).toBe(3);
+		expect(report.single_project_days).toBe(1);
+		expect(report.two_project_days).toBe(1);
+		expect(report.three_plus_project_days).toBe(1);
+		expect(report.large_gap_hit_days).toBe(1);
+		expect(report.conservative_mode_hit_days).toBe(1);
+		expect(report.sample_rows).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					user_id: "user-001",
+					target_work_date: "2026-04-20"
+				}),
+				expect.objectContaining({
+					user_id: "user-003",
+					target_work_date: "2026-04-21"
+				})
+			])
+		);
+	});
+
+	it("renders a markdown sample report for leadership review", () => {
+		const markdown = buildSampleReportMarkdown({
+			report: {
+				target_dates: ["2026-04-20", "2026-04-21"],
+				total_dates: 2,
+				total_sample_rows: 3,
+				single_project_days: 1,
+				two_project_days: 1,
+				three_plus_project_days: 1,
+				large_gap_hit_days: 1,
+				conservative_mode_hit_days: 1,
+				sample_rows: [
+					{
+						target_work_date: "2026-04-20",
+						nas_username: "alice",
+						user_id: "user-001",
+						raw_last_activity_at: "2026-04-20T10:00:00.000Z",
+						raw_total_minutes: 120,
+						unattributed_minutes: 30,
+						large_gap_hit: false,
+						conservative_mode_hit: false,
+						projects: [
+							{
+								project_id: "project-001",
+								raw_project_minutes: 90,
+								normalized_project_minutes: 360,
+								formal_generated_minutes: 240
+							}
+						]
+					}
+				]
+			}
+		});
+
+		expect(markdown).toContain("# SA-TIME Allocation Sample Report");
+		expect(markdown).toContain("2026-04-20 -> 2026-04-21");
+		expect(markdown).toContain("| Total Dates | 2 |");
+		expect(markdown).toContain("| alice | user-001 | 2026-04-20 |");
+		expect(markdown).toContain("project-001: raw 90m, normalized 360m, formal 240m");
+	});
+});

--- a/src/components/ProjectSidebar.test.tsx
+++ b/src/components/ProjectSidebar.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import ProjectSidebar from './ProjectSidebar';
+
+vi.mock('@/lib/embed', () => ({
+  isSaTimeEmbedded: () => false,
+}));
+
+vi.mock('@/hooks/useAdminSidebarData', () => ({
+  useAdminSidebarData: () => ({
+    isLoading: false,
+    data: {
+      organizationName: '测试组织',
+      members: [],
+      activeProjects: [
+        { id: 'p1', name: 'Alpha', status: 'active', color: '#22C55E' },
+        { id: 'p2', name: 'Beta', status: 'active', color: '#3B82F6' },
+        { id: 'p3', name: 'Gamma', status: 'active', color: '#EF4444' },
+      ],
+      archivedProjects: [
+        { id: 'p4', name: 'Archived', status: 'archived', color: '#999999' },
+      ],
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useTimesheetData', () => ({
+  useParticipatedProjects: () => ({
+    data: [
+      { projectId: 'p2', projectName: 'Beta', usedAt: '2026-04-24T12:00:00.000Z' },
+    ],
+  }),
+}));
+
+describe('ProjectSidebar project grouping', () => {
+  it('splits projects into participated and other project groups', () => {
+    render(
+      <ProjectSidebar
+        activeView="calendar"
+        onViewChange={vi.fn()}
+        selectedProjectId={null}
+        onProjectSelect={vi.fn()}
+      />
+    );
+
+    const participatedGroup = screen.getByTestId('participated-projects');
+    const otherGroup = screen.getByTestId('other-projects');
+
+    expect(screen.getByText('参与过的项目')).toBeInTheDocument();
+    expect(screen.getByText('其他项目')).toBeInTheDocument();
+    expect(screen.queryByText('归档的项目')).not.toBeInTheDocument();
+
+    expect(within(participatedGroup).getByText('Beta')).toBeInTheDocument();
+    expect(within(participatedGroup).queryByText('Alpha')).not.toBeInTheDocument();
+    expect(within(participatedGroup).queryByText('Gamma')).not.toBeInTheDocument();
+
+    expect(within(otherGroup).getByText('Alpha')).toBeInTheDocument();
+    expect(within(otherGroup).getByText('Gamma')).toBeInTheDocument();
+    expect(within(otherGroup).queryByText('Beta')).not.toBeInTheDocument();
+  });
+
+  it('collapses and expands each project group from the group header button', () => {
+    render(
+      <ProjectSidebar
+        activeView="calendar"
+        onViewChange={vi.fn()}
+        selectedProjectId={null}
+        onProjectSelect={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /其他项目/i }));
+    expect(screen.queryByText('Alpha')).not.toBeInTheDocument();
+    expect(screen.queryByText('Gamma')).not.toBeInTheDocument();
+    expect(screen.getByText('Beta')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /其他项目/i }));
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Gamma')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /参与过的项目/i }));
+    expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Gamma')).toBeInTheDocument();
+  });
+});

--- a/src/components/ProjectSidebar.tsx
+++ b/src/components/ProjectSidebar.tsx
@@ -1,0 +1,191 @@
+/**
+ * ProjectSidebar — 左侧项目导航边栏
+ *
+ * 显示当前项目、视图切换（报表/日历）、项目列表
+ */
+
+import React, { useMemo, useState } from 'react';
+import { BarChart3, FolderOpen, ChevronDown } from 'lucide-react';
+import { useAdminSidebarData } from '@/hooks/useAdminSidebarData';
+import { useParticipatedProjects } from '@/hooks/useTimesheetData';
+import { isSaTimeEmbedded } from '@/lib/embed';
+
+interface ProjectSidebarProps {
+  activeView: 'report' | 'calendar';
+  onViewChange: (view: 'report' | 'calendar') => void;
+  selectedProjectId: string | null;
+  onProjectSelect: (projectId: string | null) => void;
+}
+
+export default function ProjectSidebar({
+  activeView,
+  onViewChange,
+  selectedProjectId,
+  onProjectSelect,
+}: ProjectSidebarProps) {
+  const embedded = isSaTimeEmbedded();
+  const { data, isLoading } = useAdminSidebarData();
+  const { data: participatedProjects = [] } = useParticipatedProjects();
+  const [isParticipatedOpen, setIsParticipatedOpen] = useState(true);
+  const [isOtherOpen, setIsOtherOpen] = useState(true);
+  const activeProjects = data?.activeProjects ?? [];
+
+  const activeProjectMap = useMemo(() => {
+    return new Map(activeProjects.map((project) => [project.id, project]));
+  }, [activeProjects]);
+
+  const participatedSidebarProjects = useMemo(() => {
+    return participatedProjects
+      .map((project) => activeProjectMap.get(project.projectId))
+      .filter((project): project is NonNullable<typeof project> => Boolean(project));
+  }, [activeProjectMap, participatedProjects]);
+
+  const participatedProjectIds = useMemo(() => {
+    return new Set(participatedSidebarProjects.map((project) => project.id));
+  }, [participatedSidebarProjects]);
+
+  const otherProjects = useMemo(() => {
+    return activeProjects.filter((project) => !participatedProjectIds.has(project.id));
+  }, [activeProjects, participatedProjectIds]);
+
+  return (
+    <aside
+      className={`flex w-[220px] flex-shrink-0 flex-col overflow-hidden border-r border-[#2a2a2a] bg-[#111111] text-gray-200 ${
+        embedded ? 'h-screen' : 'h-[calc(100vh-56px)]'
+      }`}
+    >
+      {/* 导航菜单 */}
+      <nav className="space-y-0.5 border-b border-[#2a2a2a] px-2 pt-2 pb-3">
+        <SidebarItem
+          icon={<BarChart3 className="w-4 h-4" />}
+          label="我的报表"
+          active={activeView === 'report'}
+          onClick={() => onViewChange('report')}
+        />
+      </nav>
+
+      {/* 项目列表 */}
+      <div className="flex min-h-0 flex-1 flex-col px-2 pt-2">
+        <div className="px-2 pb-2 text-[10px] font-medium uppercase tracking-wider text-gray-500">
+          项目列表
+        </div>
+
+        <div className="admin-sidebar-scrollbar min-h-0 flex-1 overflow-y-scroll pb-4">
+          {/* 参与过的项目 */}
+          <div className="mb-1" data-testid="participated-projects">
+            <button
+              type="button"
+              aria-expanded={isParticipatedOpen}
+              onClick={() => setIsParticipatedOpen((open) => !open)}
+              className="w-full flex items-center gap-1.5 px-2 py-1.5 text-xs text-gray-400 transition-colors hover:text-white"
+            >
+              <ChevronDown className={`w-3 h-3 transition-transform ${isParticipatedOpen ? '' : '-rotate-90'}`} />
+              <FolderOpen className="w-3.5 h-3.5" />
+              <span>参与过的项目</span>
+            </button>
+            {isParticipatedOpen && (
+              <div className="pl-4 space-y-0.5">
+                {isLoading && (
+                  <div className="px-2 py-1.5 text-xs text-gray-500">正在加载项目...</div>
+                )}
+                {!isLoading && participatedSidebarProjects.length === 0 && (
+                  <div className="px-2 py-1.5 text-xs text-gray-500">暂无参与过项目</div>
+                )}
+                {participatedSidebarProjects.map((proj) => (
+                  <button
+                    key={proj.id}
+                    onClick={() => {
+                      onProjectSelect(proj.id === selectedProjectId ? null : proj.id);
+                      onViewChange('report');
+                    }}
+                    className={`
+                      w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors
+                      ${selectedProjectId === proj.id
+                        ? 'bg-white/10 text-white font-medium'
+                        : 'text-gray-300 hover:bg-white/5 hover:text-white'
+                      }
+                    `}
+                  >
+                    <span
+                      className="w-2 h-2 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: proj.color }}
+                    />
+                    <span className="truncate">{proj.name}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* 其他项目 */}
+          <div data-testid="other-projects">
+            <button
+              type="button"
+              aria-expanded={isOtherOpen}
+              onClick={() => setIsOtherOpen((open) => !open)}
+              className="w-full flex items-center gap-1.5 px-2 py-1.5 text-xs text-gray-400 transition-colors hover:text-white"
+            >
+              <ChevronDown className={`w-3 h-3 transition-transform ${isOtherOpen ? '' : '-rotate-90'}`} />
+              <FolderOpen className="w-3.5 h-3.5" />
+              <span>其他项目</span>
+            </button>
+            {isOtherOpen && (
+              <div className="pl-4 space-y-0.5">
+                {!isLoading && otherProjects.length === 0 && (
+                  <div className="px-2 py-1.5 text-xs text-gray-500">暂无其他项目</div>
+                )}
+                {otherProjects.map((proj) => (
+                  <button
+                    key={proj.id}
+                    onClick={() => {
+                      onProjectSelect(proj.id === selectedProjectId ? null : proj.id);
+                      onViewChange('report');
+                    }}
+                    className={`
+                      w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors
+                      ${selectedProjectId === proj.id
+                        ? 'bg-white/10 text-white font-medium'
+                        : 'text-gray-300 hover:bg-white/5 hover:text-white'
+                      }
+                    `}
+                  >
+                    <span
+                      className="w-2 h-2 rounded-full flex-shrink-0"
+                      style={{ backgroundColor: proj.color }}
+                    />
+                    <span className="truncate">{proj.name}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+// ===== 边栏导航项 =====
+
+function SidebarItem({ icon, label, active, onClick }: {
+  icon: React.ReactNode;
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`
+        w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-all
+        ${active
+          ? 'bg-white/10 text-white'
+          : 'text-gray-300 hover:bg-white/5 hover:text-white'
+        }
+      `}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}

--- a/src/config/holidays.ts
+++ b/src/config/holidays.ts
@@ -1,0 +1,73 @@
+/**
+ * holidays.ts — 中国法定节假日与调休工作日静态配置
+ *
+ * 数据来源：国务院办公厅 2025-11-04 发布
+ * 《国务院办公厅关于 2026 年部分节假日安排的通知》（国办发明电〔2025〕7 号）
+ *
+ * 使用方式：
+ *   import { getHolidayEntry } from '@/config/holidays';
+ *   const entry = getHolidayEntry('2026-10-01');
+ *   // entry => { date: '2026-10-01', name: '国庆节', isOffDay: true }
+ */
+
+export interface HolidayEntry {
+  date: string;          // YYYY-MM-DD
+  name: string;          // 元旦 / 春节 / 清明节 / ...
+  isOffDay: boolean;     // true=放假日, false=调休工作日
+}
+
+export const HOLIDAYS_2026: HolidayEntry[] = [
+  { date: '2026-01-01', name: '元旦', isOffDay: true },
+  { date: '2026-01-02', name: '元旦', isOffDay: true },
+  { date: '2026-01-03', name: '元旦', isOffDay: true },
+  { date: '2026-01-04', name: '元旦调休上班', isOffDay: false },
+
+  { date: '2026-02-14', name: '春节调休上班', isOffDay: false },
+  { date: '2026-02-15', name: '春节', isOffDay: true },
+  { date: '2026-02-16', name: '春节', isOffDay: true },
+  { date: '2026-02-17', name: '春节', isOffDay: true },
+  { date: '2026-02-18', name: '春节', isOffDay: true },
+  { date: '2026-02-19', name: '春节', isOffDay: true },
+  { date: '2026-02-20', name: '春节', isOffDay: true },
+  { date: '2026-02-21', name: '春节', isOffDay: true },
+  { date: '2026-02-22', name: '春节', isOffDay: true },
+  { date: '2026-02-23', name: '春节', isOffDay: true },
+  { date: '2026-02-28', name: '春节调休上班', isOffDay: false },
+
+  { date: '2026-04-04', name: '清明节', isOffDay: true },
+  { date: '2026-04-05', name: '清明节', isOffDay: true },
+  { date: '2026-04-06', name: '清明节', isOffDay: true },
+
+  { date: '2026-05-01', name: '劳动节', isOffDay: true },
+  { date: '2026-05-02', name: '劳动节', isOffDay: true },
+  { date: '2026-05-03', name: '劳动节', isOffDay: true },
+  { date: '2026-05-04', name: '劳动节', isOffDay: true },
+  { date: '2026-05-05', name: '劳动节', isOffDay: true },
+  { date: '2026-05-09', name: '劳动节调休上班', isOffDay: false },
+
+  { date: '2026-06-19', name: '端午节', isOffDay: true },
+  { date: '2026-06-20', name: '端午节', isOffDay: true },
+  { date: '2026-06-21', name: '端午节', isOffDay: true },
+
+  { date: '2026-09-20', name: '国庆节调休上班', isOffDay: false },
+  { date: '2026-09-25', name: '中秋节', isOffDay: true },
+  { date: '2026-09-26', name: '中秋节', isOffDay: true },
+  { date: '2026-09-27', name: '中秋节', isOffDay: true },
+
+  { date: '2026-10-01', name: '国庆节', isOffDay: true },
+  { date: '2026-10-02', name: '国庆节', isOffDay: true },
+  { date: '2026-10-03', name: '国庆节', isOffDay: true },
+  { date: '2026-10-04', name: '国庆节', isOffDay: true },
+  { date: '2026-10-05', name: '国庆节', isOffDay: true },
+  { date: '2026-10-06', name: '国庆节', isOffDay: true },
+  { date: '2026-10-07', name: '国庆节', isOffDay: true },
+  { date: '2026-10-10', name: '国庆节调休上班', isOffDay: false },
+];
+
+export const HOLIDAY_MAP_2026 = new Map<string, HolidayEntry>(
+  HOLIDAYS_2026.map((item) => [item.date, item])
+);
+
+export function getHolidayEntry(dateKey: string): HolidayEntry | null {
+  return HOLIDAY_MAP_2026.get(dateKey) ?? null;
+}

--- a/src/hooks/useAdminSidebarData.ts
+++ b/src/hooks/useAdminSidebarData.ts
@@ -1,0 +1,136 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useAuth } from '@/hooks/useAuth';
+import { supabase } from '@/lib/supabase';
+
+export interface AdminSidebarMember {
+  userId: string;
+  name: string;
+  initial: string;
+  color: string;
+}
+
+export interface AdminSidebarProject {
+  id: string;
+  name: string;
+  status: 'active' | 'completed' | 'archived';
+  color: string;
+}
+
+export interface AdminSidebarBundle {
+  organizationName: string;
+  members: AdminSidebarMember[];
+  activeProjects: AdminSidebarProject[];
+  archivedProjects: AdminSidebarProject[];
+}
+
+interface MembershipRow {
+  user_id: string;
+}
+
+interface ProfileRow {
+  id: string;
+  display_name: string | null;
+  username: string | null;
+  email: string | null;
+}
+
+interface ProjectRow {
+  id: string;
+  name: string;
+  status: 'active' | 'completed' | 'archived';
+}
+
+const MEMBER_COLORS = ['#53BD8C', '#F97316', '#EF4444', '#8B5CF6', '#3B82F6', '#EC4899', '#14B8A6', '#F59E0B'];
+const PROJECT_COLORS = ['#22C55E', '#3B82F6', '#EF4444', '#F97316', '#8B5CF6', '#14B8A6', '#EAB308', '#6366F1'];
+
+function getDisplayName(profile: ProfileRow): string {
+  return profile.display_name || profile.username || profile.email || '未命名成员';
+}
+
+async function fetchSidebarData(userId: string): Promise<AdminSidebarBundle> {
+  const tt = supabase.schema('time_tracker');
+
+  const { data: currentMembership, error: currentMembershipError } = await tt
+    .from('org_members')
+    .select('org_id')
+    .eq('user_id', userId)
+    .eq('employment_status', 'active')
+    .limit(1)
+    .maybeSingle();
+
+  if (currentMembershipError) {
+    throw currentMembershipError;
+  }
+
+  if (!currentMembership?.org_id) {
+    return {
+      organizationName: '未加入组织',
+      members: [],
+      activeProjects: [],
+      archivedProjects: [],
+    };
+  }
+
+  const orgId = currentMembership.org_id;
+
+  const [organizationRes, membersRes, projectsRes] = await Promise.all([
+    tt.from('organizations').select('name').eq('id', orgId).maybeSingle(),
+    tt.from('org_members').select('user_id').eq('org_id', orgId).eq('employment_status', 'active').order('joined_at', { ascending: true }),
+    tt.from('projects').select('id, name, status').eq('org_id', orgId).order('created_at', { ascending: false }),
+  ]);
+
+  if (organizationRes.error) throw organizationRes.error;
+  if (membersRes.error) throw membersRes.error;
+
+  const memberUserIds = (membersRes.data ?? []).map((row: MembershipRow) => row.user_id);
+  let profiles: ProfileRow[] = [];
+
+  if (memberUserIds.length > 0) {
+    const { data: profileRows, error: profileError } = await tt
+      .from('v_user_profiles')
+      .select('id, display_name, username, email')
+      .in('id', memberUserIds);
+
+    if (profileError) throw profileError;
+    profiles = profileRows ?? [];
+  }
+
+  const profileMap = new Map(profiles.map((profile) => [profile.id, profile]));
+  const members = memberUserIds.map((memberId, index) => {
+    const profile = profileMap.get(memberId);
+    const name = profile ? getDisplayName(profile) : '未命名成员';
+    return {
+      userId: memberId,
+      name,
+      initial: name.trim().charAt(0).toUpperCase() || '?',
+      color: MEMBER_COLORS[index % MEMBER_COLORS.length],
+    };
+  });
+
+  const projects = (projectsRes.data ?? []) as ProjectRow[];
+  const decorateProject = (project: ProjectRow, index: number): AdminSidebarProject => ({
+    id: project.id,
+    name: project.name,
+    status: project.status,
+    color: PROJECT_COLORS[index % PROJECT_COLORS.length],
+  });
+
+  return {
+    organizationName: organizationRes.data?.name || '未命名组织',
+    members,
+    activeProjects: projects.filter((project) => project.status === 'active').map(decorateProject),
+    archivedProjects: projects.filter((project) => project.status === 'archived').map(decorateProject),
+  };
+}
+
+export function useAdminSidebarData() {
+  const { user, isAuthenticated, loading } = useAuth();
+
+  return useQuery({
+    queryKey: ['admin-sidebar', user?.id ?? null],
+    queryFn: () => fetchSidebarData(user!.id),
+    enabled: !loading && isAuthenticated && !!user?.id,
+    staleTime: 60_000,
+  });
+}

--- a/src/hooks/useTimesheetData.ts
+++ b/src/hooks/useTimesheetData.ts
@@ -1,0 +1,300 @@
+/**
+ * useTimesheetData — 工时日历数据 Hooks
+ *
+ * 基于 React Query 的统一数据获取层，替代 TimeTrackingContext 中的
+ * archivedDays 内存缓存。所有日历和首页图表通过这些 hooks 获取数据。
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '@/hooks/useAuth';
+import { createDataService, ManualTimeEntry, DailyTimesheetEntry } from '@/services/dataService';
+import { queryKeys } from '@/lib/queryClient';
+import { toast } from '@/hooks/use-toast';
+
+export interface DeleteManualEntryInput {
+	taskId: string;
+	workDate: string;
+	hours?: number;
+}
+
+/**
+ * 获取指定月份的日历工时数据
+ * 自动按月缓存，翻月时独立请求，30 秒内复用缓存
+ */
+export function useMonthlyTimesheet(year: number, month: number) {
+	const { isAuthenticated } = useAuth();
+
+	return useQuery({
+		queryKey: queryKeys.timesheet.monthly(year, month),
+		queryFn: () => {
+			const ds = createDataService(isAuthenticated);
+			return ds.getMonthlyTimesheet(year, month);
+		},
+		enabled: !!year && !!month,
+	});
+}
+
+/**
+ * 获取指定日期的详细工时记录
+ */
+export function useDayEntries(date: string | null) {
+	const { isAuthenticated } = useAuth();
+
+	return useQuery({
+		queryKey: queryKeys.timesheet.day(date || ''),
+		queryFn: () => {
+			const ds = createDataService(isAuthenticated);
+			return ds.getDayEntries(date!);
+		},
+		enabled: !!date,
+	});
+}
+
+/**
+ * 获取当前用户参与过的项目
+ * 参与依据：当前用户曾经成功写入过该项目工时。
+ */
+export function useParticipatedProjects() {
+	const { isAuthenticated } = useAuth();
+
+	return useQuery({
+		queryKey: queryKeys.timesheet.participatedProjects(),
+		queryFn: () => {
+			const ds = createDataService(isAuthenticated);
+			return ds.getParticipatedProjects();
+		},
+		enabled: isAuthenticated,
+		staleTime: 60_000,
+	});
+}
+
+/**
+ * 提交手动工时记录（乐观更新 + 自动失效缓存）
+ */
+export function useSubmitManualEntry() {
+	const { isAuthenticated } = useAuth();
+	const qc = useQueryClient();
+
+	return useMutation({
+		mutationFn: (entry: ManualTimeEntry) => {
+			const ds = createDataService(isAuthenticated);
+			return ds.submitManualEntry(entry);
+		},
+		onMutate: async (entry) => {
+			// 乐观更新：立即在日历上显示新条目
+			const d = new Date(entry.workDate);
+			const key = queryKeys.timesheet.monthly(d.getFullYear(), d.getMonth() + 1);
+
+			await qc.cancelQueries({ queryKey: key });
+			const previous = qc.getQueryData<DailyTimesheetEntry[]>(key);
+
+			if (previous) {
+				const updated = [...previous];
+				const dayIdx = updated.findIndex(day => day.date === entry.workDate);
+				const newEntry = {
+					projectName: entry.projectName,
+					projectId: entry.projectId,
+					hours: entry.hours,
+					entryType: 'manual' as const,
+					approvalStatus: 'pending' as const,
+					taskId: `optimistic-${Date.now()}`,
+					description: entry.description,
+				};
+
+				if (dayIdx >= 0) {
+					updated[dayIdx] = {
+						...updated[dayIdx],
+						entries: [...updated[dayIdx].entries, newEntry],
+						totalHours: updated[dayIdx].totalHours + entry.hours,
+					};
+				} else {
+					updated.push({
+						date: entry.workDate,
+						totalHours: entry.hours,
+						entries: [newEntry],
+					});
+				}
+
+				qc.setQueryData(key, updated);
+			}
+
+			return { previous, key };
+		},
+		onError: (error, _entry, context) => {
+			// 回滚乐观更新
+			if (context?.previous) {
+				qc.setQueryData(context.key, context.previous);
+			}
+			toast({
+				title: '填报失败',
+				description: error instanceof Error ? error.message : '网络异常，请重试',
+				variant: 'destructive',
+			});
+		},
+		onSuccess: (_data, variables) => {
+			// 精确失效受影响的缓存
+			const d = new Date(variables.workDate);
+			qc.invalidateQueries({
+				queryKey: queryKeys.timesheet.monthly(d.getFullYear(), d.getMonth() + 1),
+			});
+			qc.invalidateQueries({ queryKey: queryKeys.timesheet.day(variables.workDate) });
+			qc.invalidateQueries({ queryKey: queryKeys.timesheet.participatedProjects() });
+			qc.invalidateQueries({ queryKey: queryKeys.approval.pending() });
+
+			toast({
+				title: '填报成功',
+				description: `${variables.workDate} 已录入 ${variables.hours}h`,
+			});
+		},
+	});
+}
+
+/**
+ * 更新手动工时记录
+ */
+export function useUpdateManualEntry() {
+	const { isAuthenticated } = useAuth();
+	const qc = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({ taskId, updates }: { taskId: string; updates: Partial<ManualTimeEntry> }) => {
+			const ds = createDataService(isAuthenticated);
+			return ds.updateManualEntry(taskId, updates);
+		},
+		onSuccess: () => {
+			qc.invalidateQueries({ queryKey: queryKeys.timesheet.all() });
+			qc.invalidateQueries({ queryKey: queryKeys.timesheet.participatedProjects() });
+			qc.invalidateQueries({ queryKey: queryKeys.approval.pending() });
+			toast({ title: '更新成功' });
+		},
+		onError: () => {
+			toast({ title: '更新失败', variant: 'destructive' });
+		},
+	});
+}
+
+/**
+ * 删除手动工时记录
+ */
+export function useDeleteManualEntry() {
+	const { isAuthenticated } = useAuth();
+	const qc = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({ taskId }: DeleteManualEntryInput) => {
+			const ds = createDataService(isAuthenticated);
+			return ds.deleteManualEntry(taskId);
+		},
+		onMutate: async (input) => {
+			const workDateValue = new Date(`${input.workDate}T00:00:00`);
+			const monthKey = queryKeys.timesheet.monthly(workDateValue.getFullYear(), workDateValue.getMonth() + 1);
+			const dayKey = queryKeys.timesheet.day(input.workDate);
+
+			await qc.cancelQueries({ queryKey: dayKey });
+			await qc.cancelQueries({ queryKey: monthKey });
+
+			const previousDay = qc.getQueryData<any[]>(dayKey);
+			const previousMonth = qc.getQueryData<DailyTimesheetEntry[]>(monthKey);
+
+			if (previousDay) {
+				qc.setQueryData(dayKey, previousDay.filter((task) => task.id !== input.taskId));
+			}
+
+			if (previousMonth) {
+				qc.setQueryData(
+					monthKey,
+					previousMonth
+						.map((day) => {
+							if (day.date !== input.workDate) return day;
+
+							const nextEntries = day.entries.filter((entry) => entry.taskId !== input.taskId);
+							const removedEntry = day.entries.find((entry) => entry.taskId === input.taskId);
+							const removedHours = removedEntry?.hours ?? input.hours ?? 0;
+							const nextTotalHours = Math.max(0, day.totalHours - removedHours);
+
+							return {
+								...day,
+								entries: nextEntries,
+								totalHours: Math.round(nextTotalHours * 10) / 10,
+							};
+						})
+						.filter((day) => day.entries.length > 0)
+				);
+			}
+
+			return { previousDay, previousMonth, dayKey, monthKey };
+		},
+		onSuccess: (_data, input) => {
+			qc.invalidateQueries({ queryKey: queryKeys.timesheet.day(input.workDate) });
+			const workDateValue = new Date(`${input.workDate}T00:00:00`);
+			qc.invalidateQueries({
+				queryKey: queryKeys.timesheet.monthly(workDateValue.getFullYear(), workDateValue.getMonth() + 1),
+			});
+			qc.invalidateQueries({ queryKey: queryKeys.timesheet.participatedProjects() });
+			qc.invalidateQueries({ queryKey: queryKeys.approval.pending() });
+			toast({ title: '已删除' });
+		},
+		onError: (_error, _input, context) => {
+			if (context?.previousDay) {
+				qc.setQueryData(context.dayKey, context.previousDay);
+			}
+			if (context?.previousMonth) {
+				qc.setQueryData(context.monthKey, context.previousMonth);
+			}
+			toast({ title: '删除失败', description: '仅可删除待审批的手动记录', variant: 'destructive' });
+		},
+	});
+}
+
+/**
+ * 获取待审批任务列表
+ */
+export function usePendingApprovalTasks() {
+	const { isAuthenticated } = useAuth();
+
+	return useQuery({
+		queryKey: queryKeys.approval.pending(),
+		queryFn: () => {
+			const ds = createDataService(isAuthenticated);
+			return ds.getPendingApprovalTasks();
+		},
+		enabled: isAuthenticated,
+	});
+}
+
+/**
+ * 批量审批
+ */
+export function useBatchApprove() {
+	const { isAuthenticated } = useAuth();
+	const qc = useQueryClient();
+
+	return useMutation({
+		mutationFn: (taskIds: string[]) => {
+			const ds = createDataService(isAuthenticated);
+			return ds.batchApproveTasks(taskIds);
+		},
+		onSuccess: (_data, _variables) => {
+			qc.invalidateQueries({ queryKey: queryKeys.approval.pending() });
+			qc.invalidateQueries({ queryKey: queryKeys.timesheet.all() });
+			qc.invalidateQueries({ queryKey: queryKeys.dashboard.health() });
+		},
+	});
+}
+
+/**
+ * 获取项目健康度统计（Dashboard 用）
+ */
+export function useProjectHealthStats() {
+	const { isAuthenticated } = useAuth();
+
+	return useQuery({
+		queryKey: queryKeys.dashboard.health(),
+		queryFn: () => {
+			const ds = createDataService(isAuthenticated);
+			return ds.getProjectHealthStats();
+		},
+		enabled: isAuthenticated,
+		staleTime: 60_000, // Dashboard 数据 1 分钟刷新一次即可
+	});
+}

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,0 +1,60 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30_000,
+      gcTime: 5 * 60_000,
+      retry: 2,
+      refetchOnWindowFocus: true,
+    },
+    mutations: {
+      retry: 1,
+    },
+  },
+});
+
+export const queryKeys = {
+  timesheet: {
+    all: () => ['timesheet'] as const,
+    monthly: (year: number, month: number) => ['timesheet', 'monthly', year, month] as const,
+    day: (date: string) => ['timesheet', 'day', date] as const,
+    participatedProjects: () => ['timesheet', 'participated-projects'] as const,
+  },
+  projects: {
+    all: () => ['projects'] as const,
+  },
+  categories: {
+    all: () => ['categories'] as const,
+  },
+  approval: {
+    pending: () => ['approval', 'pending'] as const,
+  },
+  dashboard: {
+    health: () => ['dashboard', 'health'] as const,
+  },
+  admin: {
+    settings: () => ['admin', 'settings'] as const,
+  },
+  memberReport: {
+    all: () => ['member-report'] as const,
+  },
+  projectReport: {
+    all: () => ['project-report'] as const,
+  },
+  projectDetail: {
+    current: (projectId: string) => ['project-detail', projectId] as const,
+  },
+  projectMembers: {
+    current: (projectId: string) => ['project-members', projectId] as const,
+  },
+  orgReport: {
+    all: () => ['org-report'] as const,
+  },
+  orgLog: {
+    all: () => ['org-log'] as const,
+  },
+  orgAccess: {
+    current: (userId: string | null) => ['org-access', userId] as const,
+  },
+};

--- a/src/pages/TimesheetCalendar.tsx
+++ b/src/pages/TimesheetCalendar.tsx
@@ -1,0 +1,930 @@
+/**
+ * TimesheetCalendar — 回溯式工时日历
+ *
+ * Phase 2 核心交付件：7 列月度日历矩阵 + 极简填报弹窗
+ * 完全基于 React Query hooks，不依赖 TimeTrackingContext
+ */
+
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { ChevronLeft, ChevronRight, Plus, Clock, Pencil, Trash2, CalendarDays, CheckCircle2, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import SiteNavigationMenu from '@/components/Navigation';
+import ProjectSidebar from '@/components/ProjectSidebar';
+import ReportTabView from '@/components/ReportTabView';
+import { useMonthlyTimesheet, useSubmitManualEntry, useDeleteManualEntry, useDayEntries, useParticipatedProjects, DeleteManualEntryInput } from '@/hooks/useTimesheetData';
+import { useAuth } from '@/hooks/useAuth';
+import { supabase } from '@/lib/supabase';
+import { DailyTimesheetEntry, ParticipatedProjectOption } from '@/services/dataService';
+import { useLocation } from 'react-router-dom';
+import { getHolidayEntry } from '@/config/holidays';
+import {
+  getRecentTaskOptions,
+  addRecentTaskOption,
+  filterValidRecentTaskOptions,
+} from '@/utils/recentSelections';
+
+// ===== 日历算法 =====
+
+function getCalendarGrid(year: number, month: number) {
+  const firstDay = new Date(year, month - 1, 1);
+  // 以周一为起始日（0=Mon ... 6=Sun）
+  let startDow = firstDay.getDay() - 1;
+  if (startDow < 0) startDow = 6;
+
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const daysInPrevMonth = new Date(year, month - 1, 0).getDate();
+
+  const cells: { day: number; month: number; year: number; isCurrentMonth: boolean }[] = [];
+
+  // 上月尾部填充
+  for (let i = startDow - 1; i >= 0; i--) {
+    const d = daysInPrevMonth - i;
+    const m = month - 1 <= 0 ? 12 : month - 1;
+    const y = month - 1 <= 0 ? year - 1 : year;
+    cells.push({ day: d, month: m, year: y, isCurrentMonth: false });
+  }
+
+  // 本月
+  for (let d = 1; d <= daysInMonth; d++) {
+    cells.push({ day: d, month, year, isCurrentMonth: true });
+  }
+
+  // 下月头部填充到 42 格（6行）
+  const remaining = 42 - cells.length;
+  for (let d = 1; d <= remaining; d++) {
+    const m = month + 1 > 12 ? 1 : month + 1;
+    const y = month + 1 > 12 ? year + 1 : year;
+    cells.push({ day: d, month: m, year: y, isCurrentMonth: false });
+  }
+
+  return cells;
+}
+
+function toDateKey(year: number, month: number, day: number) {
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+function isWeekend(year: number, month: number, day: number) {
+  const d = new Date(year, month - 1, day).getDay();
+  return d === 0 || d === 6;
+}
+
+function isToday(year: number, month: number, day: number) {
+  const now = new Date();
+  return now.getFullYear() === year && now.getMonth() + 1 === month && now.getDate() === day;
+}
+
+const WEEKDAY_LABELS = ['一', '二', '三', '四', '五', '六', '日'];
+const SHOW_CALENDAR_INTENT_KEY = 'satime:show-calendar-intent';
+
+// ===== 项目颜色映射 =====
+const PROJECT_COLORS = [
+  '#53BD8C', '#3B82F6', '#F59E0B', '#8B5CF6', '#EC4899',
+  '#14B8A6', '#F97316', '#6366F1', '#EF4444', '#06B6D4',
+];
+
+interface QuickFillProjectOption {
+  id: string;
+  name: string;
+}
+
+interface QuickFillTaskOption {
+  id: string;
+  label: string;
+  groupName: string | null;
+}
+
+function getProjectColor(name: string, index: number): string {
+  return PROJECT_COLORS[index % PROJECT_COLORS.length];
+}
+
+// ===== 主组件 =====
+
+export default function TimesheetCalendar() {
+  const now = new Date();
+  const location = useLocation();
+  const { isAuthenticated, user } = useAuth();
+  const [viewYear, setViewYear] = useState(now.getFullYear());
+  const [viewMonth, setViewMonth] = useState(now.getMonth() + 1);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [isQuickFillOpen, setIsQuickFillOpen] = useState(false);
+  const [isDayDetailOpen, setIsDayDetailOpen] = useState(false);
+
+  // 视图切换 + 项目筛选
+  const [activeView, setActiveView] = useState<'report' | 'calendar'>('report');
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+
+  const showCalendarView = useCallback(() => {
+    setIsDayDetailOpen(false);
+    setIsQuickFillOpen(false);
+    setActiveView('calendar');
+  }, []);
+
+  // URL hash → 视图切换（兼容旧入口）
+  useEffect(() => {
+    if (location.hash === '#calendar') {
+      setActiveView('calendar');
+      setIsQuickFillOpen(false);
+    }
+  }, [location.hash]);
+
+  useEffect(() => {
+    const handleShowCalendar = () => {
+      showCalendarView();
+    };
+
+    window.addEventListener('satime:show-calendar', handleShowCalendar);
+    return () => {
+      window.removeEventListener('satime:show-calendar', handleShowCalendar);
+    };
+  }, [showCalendarView]);
+
+  useEffect(() => {
+    try {
+      const shouldShowCalendar = sessionStorage.getItem(SHOW_CALENDAR_INTENT_KEY) === '1';
+      if (!shouldShowCalendar) return;
+
+      sessionStorage.removeItem(SHOW_CALENDAR_INTENT_KEY);
+      showCalendarView();
+    } catch {
+      // Ignore storage failures; direct event dispatch already covers in-page transitions.
+    }
+  }, [location.key, showCalendarView]);
+
+
+
+  // 数据 hooks
+  const { data: monthData, isLoading, error } = useMonthlyTimesheet(viewYear, viewMonth);
+  const { data: dayEntries } = useDayEntries(selectedDate);
+  const { data: participatedProjects = [] } = useParticipatedProjects();
+  const submitMutation = useSubmitManualEntry();
+  const deleteMutation = useDeleteManualEntry();
+  const { data: orgProjects = [] } = useQuery({
+    queryKey: ['timesheet', 'quick-fill', 'projects'],
+    queryFn: async (): Promise<QuickFillProjectOption[]> => {
+      const { data, error } = await supabase
+        .schema('time_tracker')
+        .from('projects')
+        .select('id, name')
+        .eq('status', 'active')
+        .order('name', { ascending: true });
+
+      if (error) throw error;
+      return (data ?? []).map((project) => ({
+        id: project.id,
+        name: project.name,
+      }));
+    },
+    enabled: isAuthenticated,
+    staleTime: 60_000,
+  });
+  const { data: taskOptions = [] } = useQuery({
+    queryKey: ['timesheet', 'quick-fill', 'task-templates'],
+    queryFn: async (): Promise<QuickFillTaskOption[]> => {
+      const { data, error } = await supabase
+        .schema('time_tracker')
+        .from('task_templates')
+        .select('id, task_name, group_name')
+        .eq('is_active', true)
+        .order('group_name', { ascending: true })
+        .order('sort_order', { ascending: true });
+
+      if (error) throw error;
+      return (data ?? []).map((task) => ({
+        id: task.id,
+        label: task.task_name,
+        groupName: task.group_name ?? null,
+      }));
+    },
+    enabled: isAuthenticated,
+    staleTime: 60_000,
+  });
+
+  // 按日期索引月数据
+  const dayDataMap = useMemo(() => {
+    const map = new Map<string, DailyTimesheetEntry>();
+    if (monthData) {
+      for (const day of monthData) {
+        map.set(day.date, day);
+      }
+    }
+    return map;
+  }, [monthData]);
+
+  // 项目颜色映射
+  const projectColorMap = useMemo(() => {
+    const map = new Map<string, string>();
+    orgProjects.forEach((p, i) => {
+      map.set(p.name, getProjectColor(p.name, i));
+    });
+    return map;
+  }, [orgProjects]);
+
+  // 月份导航
+  const goToPrevMonth = () => {
+    if (viewMonth === 1) { setViewMonth(12); setViewYear(y => y - 1); }
+    else setViewMonth(m => m - 1);
+  };
+  const goToNextMonth = () => {
+    if (viewMonth === 12) { setViewMonth(1); setViewYear(y => y + 1); }
+    else setViewMonth(m => m + 1);
+  };
+  const goToToday = () => {
+    setViewYear(now.getFullYear());
+    setViewMonth(now.getMonth() + 1);
+  };
+
+  // 日历网格
+  const calendarCells = useMemo(() => getCalendarGrid(viewYear, viewMonth), [viewYear, viewMonth]);
+
+  // 月度统计
+  const monthStats = useMemo(() => {
+    if (!monthData) return { totalHours: 0, daysWorked: 0, avgHours: 0, pendingCount: 0 };
+    const totalHours = monthData.reduce((sum, d) => sum + d.totalHours, 0);
+    const daysWorked = monthData.length;
+    const pendingCount = monthData.reduce((sum, d) =>
+      sum + d.entries.filter(e => e.approvalStatus === 'pending').length, 0
+    );
+    return {
+      totalHours: Math.round(totalHours * 10) / 10,
+      daysWorked,
+      avgHours: daysWorked > 0 ? Math.round((totalHours / daysWorked) * 10) / 10 : 0,
+      pendingCount,
+    };
+  }, [monthData]);
+
+  // 点击日期格：有数据→详情弹窗（可删除）；无数据→快速填报
+  const handleCellClick = useCallback((dateKey: string, isCurrentMonth: boolean) => {
+    if (!isCurrentMonth) return;
+    setSelectedDate(dateKey);
+    const hasData = dayDataMap.has(dateKey) && (dayDataMap.get(dateKey)!.entries.length > 0);
+    if (hasData) {
+      setIsDayDetailOpen(true);
+    } else {
+      setIsQuickFillOpen(true);
+    }
+  }, [dayDataMap]);
+
+  // 快捷填报弹窗
+  const openQuickFill = useCallback((date?: string) => {
+    if (date) setSelectedDate(date);
+    setIsDayDetailOpen(false);
+    setIsQuickFillOpen(true);
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <SiteNavigationMenu />
+
+      <div className="flex">
+        {/* 左侧边栏 */}
+        <ProjectSidebar
+          activeView={activeView}
+          onViewChange={setActiveView}
+          selectedProjectId={selectedProjectId}
+          onProjectSelect={setSelectedProjectId}
+        />
+
+        {/* 主内容区 */}
+        {activeView === 'report' ? (
+          <ReportTabView
+            selectedProjectId={selectedProjectId}
+            onStartFill={showCalendarView}
+          />
+        ) : (
+          /* 日历视图 */
+          <div className="flex-1 overflow-y-auto">
+            <main className="max-w-5xl mx-auto px-4 md:px-6 py-6 space-y-6">
+
+              {/* 页头 */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <h1 className="text-xl font-bold text-foreground flex items-center gap-2">
+                    <CalendarDays className="w-5 h-5 text-[#111]" />
+                    工时日历
+                  </h1>
+                  <p className="text-sm text-muted-foreground mt-0.5">
+                    回溯式工时填报，随时补录、修改、追溯
+                  </p>
+                </div>
+              </div>
+
+              {/* 月份切换 + 日历 */}
+              <Card className="tc-card overflow-hidden">
+                {/* 月份导航条 */}
+                <div className="flex items-center justify-between px-6 py-4 border-b border-border bg-muted/30">
+                  <Button variant="ghost" size="icon" onClick={goToPrevMonth}>
+                    <ChevronLeft className="w-5 h-5" />
+                  </Button>
+                  <div className="flex items-center gap-3">
+                    <h2 className="text-lg font-semibold text-foreground">
+                      {viewYear}年{viewMonth}月
+                    </h2>
+                    <Button variant="outline" size="sm" onClick={goToToday} className="text-xs h-7">
+                      今天
+                    </Button>
+                  </div>
+                  <Button variant="ghost" size="icon" onClick={goToNextMonth}>
+                    <ChevronRight className="w-5 h-5" />
+                  </Button>
+                </div>
+
+                {/* 星期表头 */}
+                <div className="grid grid-cols-7 border-b border-border">
+                  {WEEKDAY_LABELS.map((label, i) => (
+                    <div
+                      key={label}
+                      className={`text-center text-xs font-medium py-2 ${
+                        i >= 5 ? 'text-muted-foreground/60 bg-muted/20' : 'text-muted-foreground'
+                      }`}
+                    >
+                      {label}
+                    </div>
+                  ))}
+                </div>
+
+                {/* 日历网格 */}
+                {isLoading ? (
+                  <div className="h-96 flex items-center justify-center">
+                    <div className="animate-spin rounded-full h-8 w-8 border-2 border-[#111] border-t-transparent"></div>
+                  </div>
+                ) : error ? (
+                  <div className="h-96 flex flex-col items-center justify-center text-muted-foreground gap-2">
+                    <AlertCircle className="w-8 h-8" />
+                    <p>加载失败，请刷新重试</p>
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-7">
+                    {calendarCells.map((cell, idx) => {
+                      const dateKey = toDateKey(cell.year, cell.month, cell.day);
+                      const dayData = dayDataMap.get(dateKey);
+                      const weekend = isWeekend(cell.year, cell.month, cell.day);
+                      const today = isToday(cell.year, cell.month, cell.day);
+
+                      // 功能2: 节假日状态判定
+                      const holidayEntry = getHolidayEntry(dateKey);
+                      const isHoliday = holidayEntry?.isOffDay === true;
+                      const isWorkdayOverride = holidayEntry?.isOffDay === false;
+                      const isRestDay = isHoliday || (weekend && !isWorkdayOverride);
+                      const holidayName = isHoliday ? holidayEntry!.name : null;
+
+                      return (
+                        <CalendarCell
+                          key={idx}
+                          day={cell.day}
+                          isCurrentMonth={cell.isCurrentMonth}
+                          isWeekend={weekend}
+                          isRestDay={isRestDay}
+                          isWorkdayOverride={isWorkdayOverride}
+                          holidayName={holidayName}
+                          isToday={today}
+                          dayData={dayData}
+                          projectColorMap={projectColorMap}
+                          onClick={() => handleCellClick(dateKey, cell.isCurrentMonth)}
+                          onQuickFill={() => openQuickFill(dateKey)}
+                        />
+                      );
+                    })}
+                  </div>
+                )}
+              </Card>
+
+            </main>
+          </div>
+        )}
+      </div>
+
+      {/* 日期详情弹窗 */}
+      <DayDetailDialog
+        isOpen={isDayDetailOpen}
+        onClose={() => setIsDayDetailOpen(false)}
+        date={selectedDate}
+        dayEntries={dayEntries || []}
+        projectColorMap={projectColorMap}
+        onAddEntry={() => openQuickFill()}
+        onDeleteEntry={(entry) => deleteMutation.mutate(entry)}
+      />
+
+      {/* 快速填报弹窗 */}
+      <QuickFillDialog
+        isOpen={isQuickFillOpen}
+        onClose={() => setIsQuickFillOpen(false)}
+        date={selectedDate}
+        projects={orgProjects}
+        participatedProjects={participatedProjects}
+        taskOptions={taskOptions}
+        userId={user?.id}
+        onSubmit={(entry) => submitMutation.mutateAsync(entry)}
+        isSubmitting={submitMutation.isPending}
+      />
+    </div>
+  );
+}
+
+// ===== 统计卡片 =====
+
+function StatCard({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+  return (
+    <div className={`rounded-xl border p-4 ${accent ? 'border-amber-200 bg-amber-50/50' : 'border-border bg-card'}`}>
+      <div className={`text-xl font-bold ${accent ? 'text-amber-600' : 'text-foreground'}`}>{value}</div>
+      <div className="text-xs text-muted-foreground mt-0.5">{label}</div>
+    </div>
+  );
+}
+
+// ===== 日历格子 =====
+
+export function CalendarCell({
+  day, isCurrentMonth, isWeekend, isRestDay, isWorkdayOverride, holidayName, isToday, dayData, projectColorMap, onClick, onQuickFill
+}: {
+  day: number;
+  isCurrentMonth: boolean;
+  isWeekend: boolean;
+  isRestDay: boolean;
+  isWorkdayOverride: boolean;
+  holidayName: string | null;
+  isToday: boolean;
+  dayData?: DailyTimesheetEntry;
+  projectColorMap: Map<string, string>;
+  onClick: () => void;
+  onQuickFill: () => void;
+}) {
+  const hasData = dayData && dayData.entries.length > 0;
+  const overEightHours = dayData && dayData.totalHours > 8;
+
+  // 功能5: 异常判定
+  const hasEntries = !!dayData && dayData.entries.length > 0;
+  const isOvertime = !!dayData && dayData.totalHours > 8;
+  const isRestWork = isRestDay && hasEntries;
+  const isAnomaly = isOvertime || isRestWork;
+
+  // 功能5: 异常样式 — 工作日超时用浅红底+红环，休息日异常仅叠红环保留灰底
+  const anomalyRing = isAnomaly ? 'ring-2 ring-inset ring-red-400/70' : '';
+  const anomalyBg = isAnomaly && !isRestDay ? 'bg-red-50/30' : '';
+
+  return (
+    <div
+      className={`
+        relative min-h-[100px] border-b border-r border-border p-1.5 cursor-pointer
+        transition-colors group
+        ${!isCurrentMonth ? 'opacity-30 pointer-events-none' : ''}
+        ${isRestDay ? 'bg-muted/20' : 'bg-card'}
+        ${anomalyBg}
+        ${isAnomaly ? anomalyRing : ''}
+        ${!isAnomaly && isToday ? 'ring-2 ring-inset ring-[#111]/60' : ''}
+        ${isAnomaly && isToday ? 'ring-2 ring-inset ring-red-500' : ''}
+        hover:bg-gray-50/40
+      `}
+      onClick={onClick}
+    >
+      {/* 日期数字 */}
+      <div className="flex items-center justify-between mb-1">
+        <span className={`
+          text-sm font-medium leading-none
+          ${isToday ? 'bg-[#111] text-white w-6 h-6 rounded-full flex items-center justify-center text-xs' : ''}
+          ${!isToday && isRestDay ? 'text-muted-foreground/60' : ''}
+          ${!isToday && !isRestDay ? 'text-foreground' : ''}
+        `}>
+          {day}
+        </span>
+        {/* 调休工作日角标 */}
+        {isWorkdayOverride && (
+          <span className="text-[9px] font-medium text-orange-500 leading-none">班</span>
+        )}
+        {/* 悬浮时显示 + 按钮 */}
+        {isCurrentMonth && (
+          <button
+            className="opacity-0 group-hover:opacity-100 transition-opacity w-5 h-5 rounded-full bg-[#111] text-white flex items-center justify-center hover:bg-[#333]"
+            onClick={(e) => { e.stopPropagation(); onQuickFill(); }}
+          >
+            <Plus className="w-3 h-3" />
+          </button>
+        )}
+      </div>
+
+      {/* 节假日名称标签 */}
+      {holidayName && !hasData && (
+        <div className="text-[9px] text-muted-foreground/70 leading-tight px-0.5 truncate">
+          {holidayName}
+        </div>
+      )}
+
+      {/* 项目胶囊 */}
+      {hasData && (
+        <div className="space-y-0.5 overflow-hidden">
+          {dayData.entries.slice(0, 3).map((entry, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-1 text-[10px] leading-tight rounded px-1 py-0.5 truncate"
+              style={{ backgroundColor: `${projectColorMap.get(entry.projectName) || '#94A3B8'}18` }}
+            >
+              <span
+                className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                style={{ backgroundColor: projectColorMap.get(entry.projectName) || '#94A3B8' }}
+              />
+              <span className="truncate text-foreground/80">{entry.projectName}</span>
+              {entry.isAutoTime ? (
+                <span className="rounded bg-amber-500 px-1 py-0.5 text-[9px] font-semibold text-white flex-shrink-0">
+                  AUTO
+                </span>
+              ) : null}
+              <span className="ml-auto font-medium text-foreground/60 flex-shrink-0">{entry.hours}h</span>
+            </div>
+          ))}
+          {dayData.entries.length > 3 && (
+            <div className="text-[10px] text-muted-foreground px-1">+{dayData.entries.length - 3} 更多</div>
+          )}
+        </div>
+      )}
+
+      {/* 节假日名称（有工时数据时显示在胶囊下方） */}
+      {holidayName && hasData && (
+        <div className="text-[9px] text-muted-foreground/70 leading-tight px-0.5 mt-0.5 truncate">
+          {holidayName}
+        </div>
+      )}
+
+      {/* 日合计 */}
+      {hasData && (
+        <div className={`absolute bottom-1 right-1.5 text-[10px] font-semibold ${overEightHours ? 'text-red-500' : 'text-[#111]'}`}>
+          {Math.round(dayData.totalHours * 10) / 10}h
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ===== 日期详情弹窗 =====
+
+export function DayDetailDialog({
+  isOpen, onClose, date, dayEntries, projectColorMap, onAddEntry, onDeleteEntry
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  date: string | null;
+  dayEntries: any[];
+  projectColorMap: Map<string, string>;
+  onAddEntry: () => void;
+  onDeleteEntry: (entry: DeleteManualEntryInput) => void;
+}) {
+  if (!date) return null;
+
+  const formatted = new Date(date + 'T00:00:00').toLocaleDateString('zh-CN', {
+    year: 'numeric', month: 'long', day: 'numeric', weekday: 'long'
+  });
+
+  const totalHours = dayEntries.reduce((sum: number, t: any) => {
+    const h = t.hours ?? ((t.duration || 0) / 3600000);
+    return sum + h;
+  }, 0);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <CalendarDays className="w-5 h-5 text-[#111]" />
+            {formatted}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3 max-h-80 overflow-y-auto">
+          {dayEntries.length === 0 ? (
+            <div className="text-center py-8 text-muted-foreground">
+              <Clock className="w-10 h-10 mx-auto mb-2 opacity-30" />
+              <p className="text-sm">暂无工时记录</p>
+            </div>
+          ) : (
+            dayEntries.map((task: any) => {
+              const hours = task.hours ?? ((task.duration || 0) / 3600000);
+              const isManual = task.entry_type === 'manual';
+              const isPending = task.approval_status === 'pending';
+              const color = projectColorMap.get(task.project || '') || '#94A3B8';
+
+              return (
+                <div
+                  key={task.id}
+                  className="flex items-start gap-3 p-3 rounded-lg border border-border bg-card hover:bg-muted/30 transition-colors"
+                >
+                  <span className="w-2 h-2 rounded-full mt-2 flex-shrink-0" style={{ backgroundColor: color }} />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium text-sm truncate">{task.project || '未分类'}</span>
+                      <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${
+                        isManual ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-600'
+                      }`}>
+                        {isManual ? '✏️ 手动' : '⏱ 计时器'}
+                      </span>
+                    </div>
+                    {task.description && (
+                      <p className="text-xs text-muted-foreground mt-0.5 truncate">{task.description}</p>
+                    )}
+                    <div className="flex items-center gap-2 mt-1">
+                      <span className="text-sm font-semibold text-foreground">{Math.round(hours * 100) / 100}h</span>
+                      {task.approval_status !== 'pending' && (
+                        <span className={`text-[10px] px-1.5 py-0.5 rounded-full ${
+                          task.approval_status === 'approved'
+                            ? 'bg-gray-100 text-[#111]'
+                            : 'bg-red-100 text-red-700'
+                        }`}>
+                          {task.approval_status === 'approved' ? '✅ 已审批' : '❌ 已驳回'}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  {/* 操作按钮 — 仅 manual + pending 可删除 */}
+                  {isManual && isPending && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-muted-foreground hover:text-red-500"
+                      onClick={() => onDeleteEntry({
+                        taskId: task.id,
+                        workDate: date,
+                        hours,
+                      })}
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </Button>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <DialogFooter className="flex-row justify-between items-center gap-2 sm:justify-between">
+          <div className="text-sm text-muted-foreground">
+            合计 <span className="font-semibold text-foreground">{Math.round(totalHours * 100) / 100}h</span>
+          </div>
+          <Button onClick={onAddEntry} className="tc-btn-primary">
+            <Plus className="w-4 h-4 mr-1" /> 添加工时
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ===== 快速填报弹窗 =====
+
+const QUICK_HOURS = [2, 4, 8];
+
+export function QuickFillDialog({
+  isOpen, onClose, date, projects, participatedProjects, taskOptions, userId, onSubmit, isSubmitting
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  date: string | null;
+  projects: QuickFillProjectOption[];
+  participatedProjects: ParticipatedProjectOption[];
+  taskOptions: QuickFillTaskOption[];
+  userId: string | undefined;
+  onSubmit: (entry: any) => Promise<unknown>;
+  isSubmitting: boolean;
+}) {
+  const [projectId, setProjectId] = useState('');
+  const [projectSearch, setProjectSearch] = useState('');
+  const [taskOptionId, setTaskOptionId] = useState('');
+  const [hours, setHours] = useState('8');
+  const [recentTaskOptions, setRecentTaskOptions] = useState<ReturnType<typeof getRecentTaskOptions>>([]);
+
+  // 功能1: 参与过的项目 — 有效项目/任务 ID 集合
+  const validProjectIds = useMemo(() => new Set(projects.map((p) => p.id)), [projects]);
+  const validTaskIds = useMemo(() => new Set(taskOptions.map((t) => t.id)), [taskOptions]);
+
+  const validParticipatedProjects = useMemo(() => {
+    return participatedProjects.filter((project) => validProjectIds.has(project.projectId));
+  }, [participatedProjects, validProjectIds]);
+
+  useEffect(() => {
+    setRecentTaskOptions(filterValidRecentTaskOptions(getRecentTaskOptions(userId), validTaskIds));
+  }, [isOpen, userId, validTaskIds]);
+
+  // 功能1: 参与过的项目 — 默认选中优先参与过项目
+  useEffect(() => {
+    if (!projectId && projects.length > 0) {
+      const firstParticipated = validParticipatedProjects[0];
+      setProjectId(firstParticipated ? firstParticipated.projectId : projects[0].id);
+    }
+  }, [projectId, projects, validParticipatedProjects]);
+
+  useEffect(() => {
+    if (!taskOptionId && taskOptions.length > 0) {
+      const firstRecent = recentTaskOptions[0];
+      setTaskOptionId(firstRecent ? firstRecent.taskOptionId : taskOptions[0].id);
+    }
+  }, [taskOptionId, taskOptions, recentTaskOptions]);
+
+  // 功能1: 项目搜索 — 搜索时不显示最近分组
+  const isSearching = projectSearch.trim().length > 0;
+
+  const filteredProjects = useMemo(() => {
+    const keyword = projectSearch.trim().toLowerCase();
+    if (!keyword) return projects;
+    return projects.filter((project) => project.name.toLowerCase().includes(keyword));
+  }, [projectSearch, projects]);
+
+  useEffect(() => {
+    if (!filteredProjects.some((project) => project.id === projectId)) {
+      setProjectId(filteredProjects[0]?.id || '');
+    }
+  }, [filteredProjects, projectId]);
+
+  // 功能1: 全部项目中去除已在参与过项目中的项
+  const participatedProjectIds = useMemo(() => {
+    return new Set(validParticipatedProjects.map((project) => project.projectId));
+  }, [validParticipatedProjects]);
+  const nonParticipatedProjects = useMemo(() => {
+    if (isSearching) return filteredProjects;
+    return filteredProjects.filter((p) => !participatedProjectIds.has(p.id));
+  }, [filteredProjects, participatedProjectIds, isSearching]);
+
+  const recentTaskIds = useMemo(() => new Set(recentTaskOptions.map((r) => r.taskOptionId)), [recentTaskOptions]);
+  const nonRecentTasks = useMemo(() => {
+    return taskOptions.filter((t) => !recentTaskIds.has(t.id));
+  }, [taskOptions, recentTaskIds]);
+
+  const handleSubmit = async () => {
+    if (!projectId || !hours || !date) return;
+    const selectedProject = projects.find((project) => project.id === projectId);
+    if (!selectedProject) return;
+
+    const selectedTaskOption = taskOptions.find((option) => option.id === taskOptionId);
+    const taskLabel = selectedTaskOption?.label || '工时填报';
+    const taskDescription = selectedTaskOption?.groupName
+      ? `${selectedTaskOption.groupName} / ${taskLabel}`
+      : taskLabel;
+
+    try {
+      await onSubmit({
+        projectId: selectedProject.id,
+        projectName: selectedProject.name,
+        categoryId: selectedTaskOption?.id,
+        categoryName: taskLabel,
+        workDate: date,
+        hours: parseFloat(hours),
+        description: taskDescription,
+      });
+
+      if (selectedTaskOption) {
+        addRecentTaskOption(userId, {
+          taskOptionId: selectedTaskOption.id,
+          taskLabel: selectedTaskOption.label,
+          taskGroupName: selectedTaskOption.groupName,
+        });
+      }
+
+      setRecentTaskOptions(filterValidRecentTaskOptions(getRecentTaskOptions(userId), validTaskIds));
+      setHours('8');
+      onClose();
+    } catch {
+      // Errors are handled by the submit mutation/toast path.
+    }
+  };
+
+  const formatted = date ? new Date(date + 'T00:00:00').toLocaleDateString('zh-CN', {
+    year: 'numeric', month: 'long', day: 'numeric', weekday: 'long'
+  }) : '';
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Pencil className="w-5 h-5 text-[#111]" />
+            填报工时 — {formatted}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* 项目选择 */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">项目 *</Label>
+            <Input
+              value={projectSearch}
+              onChange={(e) => setProjectSearch(e.target.value)}
+              placeholder="搜索项目"
+              className="h-9"
+            />
+            <Select value={projectId} onValueChange={setProjectId}>
+              <SelectTrigger>
+                <SelectValue placeholder="请选择项目" />
+              </SelectTrigger>
+              <SelectContent>
+                {filteredProjects.length === 0 && (
+                  <div className="px-3 py-2 text-sm text-muted-foreground">没有匹配的项目</div>
+                )}
+                {!isSearching && validParticipatedProjects.length > 0 && (
+                  <>
+                    <div className="px-3 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">参与过的项目</div>
+                    {validParticipatedProjects.map((project) => (
+                      <SelectItem key={`participated-${project.projectId}`} value={project.projectId}>
+                        {project.projectName}
+                      </SelectItem>
+                    ))}
+                    {nonParticipatedProjects.length > 0 && (
+                      <div className="px-3 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider border-t border-border mt-1 pt-1.5">全部项目</div>
+                    )}
+                  </>
+                )}
+                {(isSearching ? filteredProjects : (validParticipatedProjects.length > 0 ? nonParticipatedProjects : filteredProjects)).map((project) => (
+                  <SelectItem key={project.id} value={project.id}>
+                    {project.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* 工作内容选择 */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">工作内容</Label>
+            <Select value={taskOptionId} onValueChange={setTaskOptionId}>
+              <SelectTrigger>
+                <SelectValue placeholder="请选择工作内容" />
+              </SelectTrigger>
+              <SelectContent>
+                {/* 功能1: 最近使用分组 */}
+                {recentTaskOptions.length > 0 && (
+                  <>
+                    <div className="px-3 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider">最近使用</div>
+                    {recentTaskOptions.map((rt) => (
+                      <SelectItem key={`recent-${rt.taskOptionId}`} value={rt.taskOptionId}>
+                        {rt.taskGroupName ? `${rt.taskGroupName} / ${rt.taskLabel}` : rt.taskLabel}
+                      </SelectItem>
+                    ))}
+                    <div className="px-3 py-1 text-[10px] font-medium text-muted-foreground uppercase tracking-wider border-t border-border mt-1 pt-1.5">全部工作内容</div>
+                  </>
+                )}
+                {nonRecentTasks.map((option) => (
+                  <SelectItem key={option.id} value={option.id}>
+                    {option.groupName ? `${option.groupName} / ${option.label}` : option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* 功能3: 快捷输入键 + 自定义输入 */}
+          <div className="space-y-1.5">
+            <Label className="text-sm font-medium">工时 (小时) *</Label>
+            <div className="flex items-center gap-1.5 mb-1.5">
+              {QUICK_HOURS.map((qh) => (
+                <button
+                  key={qh}
+                  type="button"
+                  onClick={() => setHours(String(qh))}
+                  className={`
+                    h-8 px-3 rounded-lg text-sm font-medium transition-colors
+                    ${Number(hours) === qh
+                      ? 'bg-[#111] text-white border border-[#111]'
+                      : 'border border-border bg-card text-foreground hover:bg-muted/50'
+                    }
+                  `}
+                >
+                  {qh}
+                </button>
+              ))}
+              <span className="text-xs text-muted-foreground ml-1">快捷</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Input
+                type="number"
+                step="0.5"
+                min="0.5"
+                max="24"
+                value={hours}
+                onChange={(e) => setHours(e.target.value)}
+                placeholder="自定义..."
+                className="flex-1"
+              />
+              <span className="text-sm text-muted-foreground font-medium">h</span>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>取消</Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={!projectId || !hours || parseFloat(hours) <= 0 || isSubmitting}
+            className="tc-btn-primary"
+          >
+            {isSubmitting ? (
+              <><div className="animate-spin rounded-full h-4 w-4 border-2 border-white border-t-transparent mr-1.5" /> 提交中...</>
+            ) : (
+              <><CheckCircle2 className="w-4 h-4 mr-1.5" /> 确认提交</>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -14,6 +14,313 @@ export interface CurrentDayData {
 	tasks: Task[];
 }
 
+// ===== v2.0 新增类型定义：回溯式工时填报 =====
+
+/** 日历单日工时汇总条目 */
+export interface DailyTimesheetEntry {
+	date: string;           // '2026-04-15'
+	totalHours: number;     // 当日合计小时数
+	entries: {
+		projectName: string;
+		projectId?: string;
+		projectColor?: string;
+		hours: number;
+		entryType: 'timer' | 'manual';
+		approvalStatus: 'pending' | 'approved' | 'rejected';
+		taskId: string;
+		description?: string;
+		isAutoTime?: boolean;
+	}[];
+}
+
+/** 手动填报工时条目 */
+export interface ManualTimeEntry {
+	projectId: string;
+	projectName: string;
+	categoryId?: string;
+	categoryName?: string;
+	workDate: string;       // ISO date: '2026-04-15'
+	hours: number;          // 支持 0.5 精度
+	description?: string;
+}
+
+/** 项目健康度统计 */
+export interface ProjectHealthStat {
+	project_id: string;
+	project_name: string;
+	actual_cost: number;
+	total_hours: number;
+}
+
+/** 当前用户曾经写入过工时的项目，用于快速填报中的“参与过的项目”分组 */
+export interface ParticipatedProjectOption {
+	projectId: string;
+	projectName: string;
+	usedAt: string;
+}
+
+export interface AdminOrganizationProfile {
+	id: string;
+	name: string;
+	description: string | null;
+	ownerUserId: string;
+	ownerName: string;
+	ownerEmail: string;
+	logoUrl: string | null;
+	standardDailyHours: number;
+	standardWeeklyHours: number;
+	defaultHumanCostRatio: number;
+}
+
+export interface AdminMemberSettingsRecord {
+	membershipId: string;
+	orgId: string;
+	userId: string;
+	name: string;
+	email: string;
+	username: string | null;
+	department: string | null;
+	avatarUrl: string | null;
+	role: 'owner' | 'admin' | 'finance' | 'hr' | 'project_manager' | 'member';
+	employmentStatus: 'active' | 'inactive' | 'departed';
+	dataScope: 'self' | 'team' | 'org' | 'finance_only';
+	annualSalary: number | null;
+	annualWorkHours: number | null;
+	hourlyCost: number | null;
+}
+
+export interface AdminProjectSettingsRecord {
+	id: string;
+	orgId: string;
+	name: string;
+	sourceSystem: string | null;
+	sourceProjectId: string | null;
+	sourceProjectCode: string | null;
+	managerUserId: string | null;
+	managerName: string | null;
+	contractAmount: number | null;
+	humanCostBudget: number | null;
+	humanCostRatio: number | null;
+	completionProgress: number | null;
+	estimatedCompletionDate: string | null;
+	managerCostRatio: number | null;
+	companyCostRatio: number | null;
+	status: 'active' | 'completed' | 'archived';
+}
+
+export interface AdminTaskTemplateRecord {
+	id: string;
+	orgId: string;
+	groupName: string;
+	taskName: string;
+	sortOrder: number;
+	isActive: boolean;
+}
+
+export interface AdminSettingsBundle {
+	organization: AdminOrganizationProfile;
+	currentUserId: string;
+	currentUserRole: AdminMemberSettingsRecord['role'];
+	members: AdminMemberSettingsRecord[];
+	projects: AdminProjectSettingsRecord[];
+	taskTemplates: AdminTaskTemplateRecord[];
+}
+
+export interface MemberReportRecord {
+	orgId: string;
+	userId: string;
+	name: string;
+	email: string;
+	department: string | null;
+	avatarUrl: string | null;
+	role: AdminMemberSettingsRecord['role'];
+	employmentStatus: AdminMemberSettingsRecord['employmentStatus'];
+	hours: number;
+	hourlyRate: number;
+	laborCost: number;
+	output: number;
+	unitPrice: number;
+	efficiency: number;
+}
+
+export interface ProjectReportRecord {
+	projectId: string;
+	orgId: string;
+	name: string;
+	status: '激活' | '已完成' | '已归档';
+	receivable: number;
+	externalRisk: number;
+	internalRisk: number;
+	progress: number;
+	cashAsset: number;
+	mainCost: number;
+	prepaid: number;
+	equity: number;
+	revenue: number;
+	cost: number;
+	profit: number;
+	profitRate: number;
+	hours: number;
+	hourlyValue: number;
+	cashIn: number;
+	cashOut: number;
+	netCashFlow: number;
+	contractAmount: number;
+	hoursBudget: number;
+	actualHours: number;
+	hoursRate: number;
+	laborCost: number;
+	costRate: number;
+}
+
+export interface ProjectDetailRecord {
+	projectId: string;
+	orgId: string;
+	name: string;
+	status: '激活' | '已完成' | '已归档';
+	managerName: string | null;
+	sourceProjectCode: string | null;
+	contractAmount: number;
+	humanCostBudget: number;
+	completionProgress: number;
+	estimatedCompletionDate: string | null;
+	remainingDays: number | null;
+	recognizedRevenue: number;
+	totalReceived: number;
+	totalHours: number;
+	laborCost: number;
+	expenseCost: number;
+	totalCost: number;
+	grossProfit: number;
+	receivable: number;
+	cashNetFlow: number;
+	hourlyValue: number | null;
+	externalRisk: number | null;
+	internalRisk: number | null;
+	paymentCount: number;
+	expenseCount: number;
+}
+
+export interface ProjectMemberRecord {
+	projectMemberId: string;
+	userId: string;
+	name: string;
+	email: string | null;
+	role: 'owner' | 'admin' | 'finance' | 'hr' | 'project_manager' | 'member';
+	status: 'active' | 'exited';
+	joinedAt: string | null;
+	leftAt: string | null;
+	initial: string;
+	color: string;
+}
+
+export interface ProjectMembersBundle {
+	projectId: string;
+	activeMembers: ProjectMemberRecord[];
+	exitedMembers: ProjectMemberRecord[];
+	availableMembers: ProjectMemberRecord[];
+	canManageMembers: boolean;
+}
+
+export interface OrgCapacityMonthlyRecord {
+	monthStart: string;
+	totalHours: number;
+	capacityHours: number;
+	capacityUtilization: number;
+}
+
+export interface OrgReportSnapshot {
+	orgId: string;
+	orgName: string;
+	activeMemberCount: number;
+	projectCount: number;
+	remainingContractAmount: number;
+	totalReceivable: number;
+	totalReceived: number;
+	totalCost: number;
+	currentMonthHours: number;
+	currentMonthCapacityHours: number;
+	capacityUtilization: number;
+	estimatedMonthlyCapacityValue: number;
+	estimatedDailyCapacityValue: number;
+	productionDays: number;
+	inventoryDays: number;
+	avgWeeklyHoursPerMember: number;
+	avgMonthlyHoursPerMember: number;
+}
+
+export interface OrgReportBundle {
+	snapshot: OrgReportSnapshot;
+	monthly: OrgCapacityMonthlyRecord[];
+}
+export interface OrgActivityLogRecord {
+	id: string;
+	orgId: string;
+	actorUserId: string | null;
+	actorName: string;
+	actorEmail: string;
+	actorAvatarUrl: string | null;
+	actionType: string;
+	targetType: 'org' | 'project' | 'member' | 'template' | 'task';
+	description: string;
+	createdAt: string;
+}
+export interface SaveAdminOrganizationInput {
+	orgId: string;
+	name: string;
+	description: string | null;
+	logoUrl: string | null;
+	standardDailyHours: number;
+	standardWeeklyHours: number;
+	defaultHumanCostRatio: number;
+}
+
+export interface SaveAdminMemberInput {
+	membershipId: string;
+	orgId: string;
+	userId: string;
+	role: AdminMemberSettingsRecord['role'];
+	employmentStatus: AdminMemberSettingsRecord['employmentStatus'];
+	dataScope: AdminMemberSettingsRecord['dataScope'];
+	annualSalary: number | null;
+	annualWorkHours: number | null;
+	hourlyCost: number | null;
+}
+
+export interface SaveAdminProjectInput {
+	id?: string;
+	orgId: string;
+	name: string;
+	sourceSystem?: string | null;
+	sourceProjectId?: string | null;
+	sourceProjectCode?: string | null;
+	managerUserId: string | null;
+	contractAmount: number | null;
+	humanCostBudget: number | null;
+	humanCostRatio: number | null;
+	completionProgress: number | null;
+	estimatedCompletionDate: string | null;
+	managerCostRatio: number | null;
+	companyCostRatio: number | null;
+	status: AdminProjectSettingsRecord['status'];
+}
+
+export interface SaveAdminTaskTemplateInput {
+	id?: string;
+	orgId: string;
+	groupName: string;
+	taskName: string;
+	sortOrder: number;
+	isActive: boolean;
+}
+
+export interface SyncAdminProjectsResult {
+	sourceTotal: number;
+	inserted: number;
+	updated: number;
+	skipped: number;
+}
+
 // Data service interface
 export interface DataService {
 	// Current day operations
@@ -41,6 +348,82 @@ export interface DataService {
 	// Migration operations
 	migrateFromLocalStorage: () => Promise<void>;
 	migrateToLocalStorage: () => Promise<void>;
+
+	// ===== v2.0 新增：回溯式工时填报 =====
+
+	/** 获取指定月份的日工时汇总（日历渲染用） */
+	getMonthlyTimesheet: (year: number, month: number) => Promise<DailyTimesheetEntry[]>;
+
+	/** 获取当前用户参与过的项目，按工时记录提交/更新时间倒序 */
+	getParticipatedProjects: () => Promise<ParticipatedProjectOption[]>;
+
+	/** 提交一条回溯工时记录 */
+	submitManualEntry: (entry: ManualTimeEntry) => Promise<Task>;
+
+	/** 更新一条已有的回溯记录 */
+	updateManualEntry: (taskId: string, updates: Partial<ManualTimeEntry>) => Promise<void>;
+
+	/** 删除一条回溯记录（仅限 pending 状态） */
+	deleteManualEntry: (taskId: string) => Promise<void>;
+
+	/** 获取指定日期的详细工时记录列表 */
+	getDayEntries: (date: string) => Promise<Task[]>;
+
+	// ===== v2.0 新增：审批流（从 as any 提升为正式接口） =====
+
+	/** 批量审批 */
+	batchApproveTasks: (taskIds: string[]) => Promise<void>;
+
+	/** 获取待审批任务列表 */
+	getPendingApprovalTasks: () => Promise<Task[]>;
+
+	/** 获取项目健康度统计 */
+	getProjectHealthStats: () => Promise<ProjectHealthStat[]>;
+
+	/** 获取管理后台组织/成员/项目/模板数据 */
+	getAdminSettingsBundle: () => Promise<AdminSettingsBundle | null>;
+
+	/** 更新组织设置 */
+	saveAdminOrganization: (input: SaveAdminOrganizationInput) => Promise<void>;
+
+	/** 更新成员角色/成本设置 */
+	saveAdminMember: (input: SaveAdminMemberInput) => Promise<void>;
+
+	/** 新增或更新项目设置 */
+	saveAdminProject: (input: SaveAdminProjectInput) => Promise<void>;
+
+	/** 从 SA-AI-APP 项目主数据同步项目名称 */
+	syncAdminProjectsFromSource: () => Promise<SyncAdminProjectsResult>;
+
+	/** 新增或更新任务模板 */
+	saveAdminTaskTemplate: (input: SaveAdminTaskTemplateInput) => Promise<void>;
+
+	/** 获取成员全局报表数据 */
+	getMemberReportRecords: () => Promise<MemberReportRecord[]>;
+
+	/** 获取项目全局报表数据 */
+	getProjectReportRecords: () => Promise<ProjectReportRecord[]>;
+
+	/** 获取单个项目详情 */
+	getProjectDetailRecord: (projectId: string) => Promise<ProjectDetailRecord | null>;
+
+	/** 获取项目成员配置 */
+	getProjectMembersBundle: (projectId: string) => Promise<ProjectMembersBundle | null>;
+
+	/** 添加项目成员 */
+	addProjectMember: (projectId: string, userId: string) => Promise<void>;
+
+	/** 移出项目成员 */
+	exitProjectMember: (projectId: string, userId: string) => Promise<void>;
+
+	/** 恢复已退出项目成员 */
+	restoreProjectMember: (projectId: string, userId: string) => Promise<void>;
+
+	/** 获取组织报表主卡与趋势数据 */
+	getOrgReportBundle: () => Promise<OrgReportBundle | null>;
+
+	/** 获取组织日志 */
+	getOrgActivityLogRecords: () => Promise<OrgActivityLogRecord[]>;
 }
 
 // Factory function to get the appropriate service

--- a/src/services/supabaseService.timesheetAutoTime.test.ts
+++ b/src/services/supabaseService.timesheetAutoTime.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { SupabaseService } from "@/services/supabaseService";
+
+describe("SupabaseService monthly timesheet auto-time mapping", () => {
+	it("marks nas_auto tasks as auto-time entries in monthly timesheet data", () => {
+		const service = new SupabaseService();
+		const result = (service as any).buildMonthlyTimesheetEntries([
+			{
+				id: "task-1",
+				work_date: "2026-04-21",
+				duration_minutes: 120,
+				project_id: "project-a",
+				entry_source: "nas_auto",
+				approval_status: "pending",
+				task_name: "A",
+				notes: null,
+				start_time: null,
+				end_time: null,
+				project: { name: "项目A" },
+			},
+			{
+				id: "task-2",
+				work_date: "2026-04-21",
+				duration_minutes: 60,
+				project_id: "project-b",
+				entry_source: "manual",
+				approval_status: "approved",
+				task_name: "B",
+				notes: null,
+				start_time: null,
+				end_time: null,
+				project: { name: "项目B" },
+			},
+		]);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].entries).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					taskId: "task-1",
+					projectName: "项目A",
+					isAutoTime: true,
+					hours: 2,
+				}),
+				expect.objectContaining({
+					taskId: "task-2",
+					projectName: "项目B",
+					isAutoTime: false,
+					hours: 1,
+				}),
+			]),
+		);
+	});
+
+	it("builds participated projects from all submitted or updated time entries without truncating", () => {
+		const service = new SupabaseService();
+		const rows = Array.from({ length: 8 }, (_, index) => ({
+			project_id: `project-${index + 1}`,
+			created_at: `2026-04-${String(index + 1).padStart(2, "0")}T09:00:00.000Z`,
+			updated_at: null,
+			project: { name: `项目${index + 1}` },
+		}));
+
+		const result = (service as any).buildParticipatedProjects([
+			...rows,
+			{
+				project_id: "project-3",
+				created_at: "2026-04-01T08:00:00.000Z",
+				updated_at: "2026-04-24T12:00:00.000Z",
+				project: { name: "项目3 新名称" },
+			},
+			{
+				project_id: null,
+				created_at: "2026-04-25T08:00:00.000Z",
+				updated_at: null,
+				project: { name: "未分配项目" },
+			},
+		]);
+
+		expect(result).toHaveLength(8);
+		expect(result[0]).toEqual({
+			projectId: "project-3",
+			projectName: "项目3 新名称",
+			usedAt: "2026-04-24T12:00:00.000Z",
+		});
+		expect(result.map((project: any) => project.projectId)).toEqual([
+			"project-3",
+			"project-8",
+			"project-7",
+			"project-6",
+			"project-5",
+			"project-4",
+			"project-2",
+			"project-1",
+		]);
+	});
+});

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -11,14 +11,40 @@ import {
 } from "@/lib/supabase";
 import { Task, DayRecord, Project, TodoItem } from "@/contexts/TimeTrackingContext";
 import { TaskCategory } from "@/config/categories";
-import { DataService, CurrentDayData } from "@/services/dataService";
+import {
+	DataService,
+	CurrentDayData,
+	DailyTimesheetEntry,
+	ManualTimeEntry,
+	ParticipatedProjectOption,
+	ProjectHealthStat,
+	AdminSettingsBundle,
+	AdminMemberSettingsRecord,
+	MemberReportRecord,
+	ProjectReportRecord,
+	ProjectDetailRecord,
+	ProjectMembersBundle,
+	OrgReportBundle,
+	OrgActivityLogRecord,
+	AdminProjectSettingsRecord,
+	AdminTaskTemplateRecord,
+	SaveAdminMemberInput,
+	SaveAdminOrganizationInput,
+	SaveAdminProjectInput,
+	SaveAdminTaskTemplateInput,
+	SyncAdminProjectsResult,
+} from "@/services/dataService";
 import { LocalStorageService } from "@/services/localStorageService";
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const PROJECT_MEMBER_COLORS = ['#53BD8C', '#F97316', '#EF4444', '#8B5CF6', '#3B82F6', '#EC4899', '#14B8A6', '#F59E0B'];
 
 export class SupabaseService implements DataService {
 	// Schema detection with permanent caching
 	private hasNewSchema: boolean | null = null;
 	private static schemaChecked: boolean = false;
 	private static globalSchemaResult: boolean | null = null;
+	private projectSourceFieldsAvailable: boolean | null = null;
 
 	/**
 	 * Resolves the authenticated user and validates their ID.
@@ -31,6 +57,308 @@ export class SupabaseService implements DataService {
 			throw new Error("Authenticated user has no ID — cannot perform database operation");
 		}
 		return cachedUser;
+	}
+
+	private tt() {
+		return supabase.schema('time_tracker');
+	}
+
+	private extractProjectName(project: any): string {
+		if (Array.isArray(project)) {
+			return project[0]?.name || '未分类';
+		}
+
+		return project?.name || '未分类';
+	}
+
+	private buildMonthlyTimesheetEntries(taskRows: any[]): DailyTimesheetEntry[] {
+		const dayMap = new Map<string, DailyTimesheetEntry>();
+
+		for (const row of taskRows || []) {
+			const effectiveDate = row.work_date
+				|| (row.start_time ? new Date(row.start_time).toISOString().slice(0, 10) : null);
+			if (!effectiveDate) continue;
+
+			if (!dayMap.has(effectiveDate)) {
+				dayMap.set(effectiveDate, { date: effectiveDate, totalHours: 0, entries: [] });
+			}
+			const day = dayMap.get(effectiveDate)!;
+
+			const effectiveHours = row.duration_minutes != null
+				? Math.round((Number(row.duration_minutes) / 60) * 100) / 100
+				: 0;
+
+			day.entries.push({
+				projectName: this.extractProjectName(row.project),
+				projectId: row.project_id || undefined,
+				hours: effectiveHours,
+				entryType: row.start_time || row.end_time ? 'timer' : 'manual',
+				approvalStatus: row.approval_status || 'pending',
+				taskId: row.id,
+				description: row.notes || row.task_name || undefined,
+				isAutoTime: row.entry_source === 'nas_auto',
+			});
+			day.totalHours += effectiveHours;
+		}
+
+		return Array.from(dayMap.values());
+	}
+
+	private buildParticipatedProjects(taskRows: any[]): ParticipatedProjectOption[] {
+		const projectMap = new Map<string, ParticipatedProjectOption>();
+
+		for (const row of taskRows || []) {
+			const relatedProject = Array.isArray(row.project) ? row.project[0] : row.project;
+			const projectId = row.project_id || relatedProject?.id;
+			if (!projectId) continue;
+
+			const usedAt = row.updated_at || row.created_at;
+			if (!usedAt) continue;
+
+			const current = projectMap.get(projectId);
+			if (current && new Date(current.usedAt).getTime() >= new Date(usedAt).getTime()) {
+				continue;
+			}
+
+			projectMap.set(projectId, {
+				projectId,
+				projectName: this.extractProjectName(row.project),
+				usedAt,
+			});
+		}
+
+		return Array.from(projectMap.values()).sort((a, b) => {
+			return new Date(b.usedAt).getTime() - new Date(a.usedAt).getTime();
+		});
+	}
+
+	private async requireActiveOrgMembership(userId?: string): Promise<{ orgId: string; role: string | null }> {
+		const resolvedUserId = userId || (await this.requireUser()).id;
+		const tt = this.tt();
+		const { data, error } = await tt
+			.from('org_members')
+			.select('org_id, role')
+			.eq('user_id', resolvedUserId)
+			.eq('employment_status', 'active')
+			.order('created_at', { ascending: true })
+			.limit(1)
+			.maybeSingle();
+		trackDbCall('select', 'time_tracker.org_members', 'requireActiveOrgMembership');
+
+		if (error) throw error;
+		if (!data?.org_id) {
+			throw new Error('Current user is not an active organization member');
+		}
+
+		return {
+			orgId: data.org_id,
+			role: data.role || null,
+		};
+	}
+
+	private canManageProjectsRole(role: string | null): boolean {
+		return ['owner', 'admin', 'project_manager'].includes(role || '');
+	}
+
+	private normalizeProjectName(value: string | null | undefined): string {
+		return String(value || '').trim();
+	}
+
+	private getProjectMemberColor(seed: string): string {
+		let hash = 0;
+		for (let i = 0; i < seed.length; i += 1) {
+			hash = seed.charCodeAt(i) + ((hash << 5) - hash);
+		}
+		return PROJECT_MEMBER_COLORS[Math.abs(hash) % PROJECT_MEMBER_COLORS.length];
+	}
+
+	private mapProjectStatus(value: string | null | undefined): AdminProjectSettingsRecord['status'] {
+		if (value === 'completed' || value === 'archived') {
+			return value;
+		}
+		return 'active';
+	}
+
+	private async hasProjectSourceFields(): Promise<boolean> {
+		if (this.projectSourceFieldsAvailable !== null) {
+			return this.projectSourceFieldsAvailable;
+		}
+
+		const { error } = await this.tt()
+			.from('projects')
+			.select('id, source_system')
+			.limit(1);
+		trackDbCall('select', 'time_tracker.projects', 'hasProjectSourceFields');
+
+		if (!error) {
+			this.projectSourceFieldsAvailable = true;
+			return true;
+		}
+
+		const details = [error.message, error.details, error.hint]
+			.filter(Boolean)
+			.join(' ')
+			.toLowerCase();
+		if (details.includes('source_system')) {
+			this.projectSourceFieldsAvailable = false;
+			return false;
+		}
+
+		throw error;
+	}
+
+	private parseSyncAdminProjectsResult(data: any): SyncAdminProjectsResult | null {
+		const result = Array.isArray(data) ? data[0] : data;
+		if (!result || typeof result !== 'object') {
+			return null;
+		}
+
+		return {
+			sourceTotal: Number(result.source_total ?? result.sourceTotal ?? 0),
+			inserted: Number(result.inserted ?? 0),
+			updated: Number(result.updated ?? 0),
+			skipped: Number(result.skipped ?? 0),
+		};
+	}
+
+	private async trySyncAdminProjectsViaRpc(orgId: string): Promise<SyncAdminProjectsResult | null> {
+		const rpcClient = this.tt() as typeof supabase & {
+			rpc: (fn: string, args?: Record<string, unknown>) => Promise<{ data: any; error: any }>;
+		};
+		const { data, error } = await rpcClient.rpc('sync_sa_app_project_names', {
+			target_org_id: orgId,
+		});
+		trackDbCall('rpc', 'time_tracker.sync_sa_app_project_names', 'syncAdminProjectsFromSource.rpc');
+
+		if (!error) {
+			return this.parseSyncAdminProjectsResult(data);
+		}
+
+		const details = [error.message, error.details, error.hint]
+			.filter(Boolean)
+			.join(' ')
+			.toLowerCase();
+		if (
+			details.includes('sync_sa_app_project_names') &&
+			(details.includes('does not exist') || details.includes('schema cache'))
+		) {
+			return null;
+		}
+
+		throw error;
+	}
+
+	private async logProjectSync(
+		orgId: string,
+		actorUserId: string,
+		result: SyncAdminProjectsResult
+	): Promise<void> {
+		const { error } = await this.tt()
+			.from('org_activity_logs')
+			.insert({
+				org_id: orgId,
+				actor_user_id: actorUserId,
+				action_type: 'sync_sa_app_projects',
+				target_type: 'project',
+				description: `同步 SA-AI-APP 项目名称：新增 ${result.inserted}，更新 ${result.updated}，跳过 ${result.skipped}`,
+				metadata: {
+					source: 'sa_ai_app',
+					source_total: result.sourceTotal,
+					inserted: result.inserted,
+					updated: result.updated,
+					skipped: result.skipped,
+				},
+			});
+		trackDbCall('insert', 'time_tracker.org_activity_logs', 'syncAdminProjectsFromSource.log');
+
+		if (error) {
+			console.warn('Failed to write project sync log', error);
+		}
+	}
+
+	private async resolveManualEntryProject(
+		orgId: string,
+		projectId?: string,
+		projectName?: string
+	): Promise<{ id: string; name: string }> {
+		const tt = this.tt();
+
+		if (projectId && UUID_PATTERN.test(projectId)) {
+			const { data, error } = await tt
+				.from('projects')
+				.select('id, name')
+				.eq('org_id', orgId)
+				.eq('id', projectId)
+				.eq('status', 'active')
+				.maybeSingle();
+			trackDbCall('select', 'time_tracker.projects', 'resolveManualEntryProject.byId');
+
+			if (error) throw error;
+			if (data?.id) {
+				return { id: data.id, name: data.name };
+			}
+		}
+
+		if (projectName) {
+			const { data, error } = await tt
+				.from('projects')
+				.select('id, name')
+				.eq('org_id', orgId)
+				.eq('name', projectName)
+				.eq('status', 'active')
+				.maybeSingle();
+			trackDbCall('select', 'time_tracker.projects', 'resolveManualEntryProject.byName');
+
+			if (error) throw error;
+			if (data?.id) {
+				return { id: data.id, name: data.name };
+			}
+		}
+
+		const { data, error } = await tt
+			.from('projects')
+			.select('id, name')
+			.eq('org_id', orgId)
+			.eq('status', 'active')
+			.order('name', { ascending: true })
+			.limit(1)
+			.maybeSingle();
+		trackDbCall('select', 'time_tracker.projects', 'resolveManualEntryProject.fallback');
+
+		if (error) throw error;
+		if (!data?.id) {
+			throw new Error('No active project is available for manual entry');
+		}
+
+		return { id: data.id, name: data.name };
+	}
+
+	async getProjectHealthStats(): Promise<any[]> {
+		await this.requireUser();
+		const { data, error } = await supabase
+			.from("project_health_stats")
+			.select("*");
+		if (error && error.code !== '42P01') {
+			console.warn("⚠️ Error loading project_health_stats or view missing:", error);
+			return [];
+		}
+		return data || [];
+	}
+
+	async batchApproveTasks(taskIds: string[]): Promise<void> {
+		const user = await this.requireUser();
+		const { error } = await supabase
+			.from("tasks")
+			.update({
+				approval_status: 'approved',
+				approved_at: new Date().toISOString(),
+				approved_by: user.id
+			})
+			.in('id', taskIds);
+		if (error) {
+			console.error("❌ Error batch approving tasks:", error);
+			throw error;
+		}
 	}
 
 	private async checkNewSchema(): Promise<boolean> {
@@ -433,8 +761,8 @@ export class SupabaseService implements DataService {
 				console.error("❌ Archive verification failed: Task count mismatch");
 				throw new Error(
 					`Archive verification failed: Expected ${expectedTasksCount} tasks, found ${savedTasks?.length}`
-				);
-			}
+			);
+	}
 
 		} catch (error) {
 			console.error("❌ Archive verification failed:", error);
@@ -982,5 +1310,1311 @@ export class SupabaseService implements DataService {
 		} catch (error) {
 			console.error("❌ Error migrating data to localStorage:", error);
 		}
+	}
+
+	// ===== v2.0 新增：回溯式工时填报 =====
+
+	async getMonthlyTimesheet(year: number, month: number): Promise<DailyTimesheetEntry[]> {
+		const user = await this.requireUser();
+		const membership = await this.requireActiveOrgMembership(user.id);
+		const tt = this.tt();
+
+		const startDate = `${year}-${String(month).padStart(2, '0')}-01`;
+		const lastDay = new Date(year, month, 0).getDate();
+		const endDate = `${year}-${String(month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`;
+
+		const { data, error } = await tt
+			.from('tasks')
+			.select('id, task_name, notes, approval_status, start_time, end_time, work_date, duration_minutes, project_id, entry_source, project:projects(name)')
+			.eq('org_id', membership.orgId)
+			.eq('user_id', user.id)
+			.gte('work_date', startDate)
+			.lte('work_date', endDate)
+			.order('work_date', { ascending: true })
+			.order('created_at', { ascending: true });
+		trackDbCall('select', 'time_tracker.tasks', 'getMonthlyTimesheet');
+
+		if (error) throw error;
+
+		return this.buildMonthlyTimesheetEntries(
+			(data || []).filter((row) => {
+				const effectiveDate = row.work_date
+					|| (row.start_time ? new Date(row.start_time).toISOString().slice(0, 10) : null);
+				return Boolean(effectiveDate && effectiveDate >= startDate && effectiveDate <= endDate);
+			})
+		);
+		}
+
+	async getParticipatedProjects(): Promise<ParticipatedProjectOption[]> {
+		const user = await this.requireUser();
+		const membership = await this.requireActiveOrgMembership(user.id);
+		const tt = this.tt();
+
+		const { data, error } = await tt
+			.from('tasks')
+			.select('project_id, created_at, updated_at, project:projects(id, name)')
+			.eq('org_id', membership.orgId)
+			.eq('user_id', user.id)
+			.not('project_id', 'is', null)
+			.order('updated_at', { ascending: false, nullsFirst: false })
+			.order('created_at', { ascending: false });
+		trackDbCall('select', 'time_tracker.tasks', 'getParticipatedProjects');
+
+		if (error) throw error;
+
+		return this.buildParticipatedProjects(data || []);
+	}
+
+	async submitManualEntry(entry: ManualTimeEntry): Promise<Task> {
+		const user = await this.requireUser();
+		const membership = await this.requireActiveOrgMembership(user.id);
+		const project = await this.resolveManualEntryProject(membership.orgId, entry.projectId, entry.projectName);
+		const tt = this.tt();
+
+		const row = {
+			org_id: membership.orgId,
+			user_id: user.id,
+			project_id: project.id,
+			task_template_id: entry.categoryId && UUID_PATTERN.test(entry.categoryId) ? entry.categoryId : null,
+			task_name: entry.categoryName || entry.description || `${project.name} 工时`,
+			work_date: entry.workDate,
+			start_time: null,
+			end_time: null,
+			duration_minutes: Math.round(entry.hours * 60),
+			notes: entry.description || null,
+			approval_status: 'pending',
+		};
+
+		const { data, error } = await tt
+			.from('tasks')
+			.insert(row)
+			.select()
+			.single();
+		trackDbCall('insert', 'time_tracker.tasks', 'submitManualEntry');
+
+		if (error) throw error;
+
+		return this.mapTaskRow(data);
+	}
+
+	async updateManualEntry(taskId: string, updates: Partial<ManualTimeEntry>): Promise<void> {
+		const user = await this.requireUser();
+		const membership = await this.requireActiveOrgMembership(user.id);
+		const tt = this.tt();
+
+		const updateData: Record<string, unknown> = {};
+		if (updates.hours !== undefined) {
+			updateData.duration_minutes = Math.round(updates.hours * 60);
+		}
+		if (updates.workDate) updateData.work_date = updates.workDate;
+		if (updates.projectId || updates.projectName) {
+			const project = await this.resolveManualEntryProject(
+				membership.orgId,
+				updates.projectId,
+				updates.projectName
+			);
+			updateData.project_id = project.id;
+		}
+		if (updates.categoryId && UUID_PATTERN.test(updates.categoryId)) updateData.task_template_id = updates.categoryId;
+		if (updates.categoryName) updateData.task_name = updates.categoryName;
+		if (updates.description !== undefined) updateData.notes = updates.description;
+
+		updateData.approval_status = 'pending';
+
+		const { error } = await tt
+			.from('tasks')
+			.update(updateData)
+			.eq('id', taskId)
+			.eq('org_id', membership.orgId)
+			.eq('user_id', user.id);
+		trackDbCall('update', 'time_tracker.tasks', 'updateManualEntry');
+
+		if (error) throw error;
+	}
+
+		async deleteManualEntry(taskId: string): Promise<void> {
+			const user = await this.requireUser();
+			const membership = await this.requireActiveOrgMembership(user.id);
+			const tt = this.tt();
+
+			const { data, error } = await tt
+				.from('tasks')
+				.delete()
+				.eq('id', taskId)
+				.eq('user_id', user.id)
+				.eq('org_id', membership.orgId)
+				.eq('approval_status', 'pending')
+				.select('id');
+			trackDbCall('delete', 'time_tracker.tasks', 'deleteManualEntry');
+
+			if (error) throw error;
+			if (!data || data.length === 0) {
+				throw new Error('未找到可删除的待审批手动记录，或当前账号没有删除权限');
+			}
+		}
+
+	async getDayEntries(date: string): Promise<Task[]> {
+		const user = await this.requireUser();
+		const membership = await this.requireActiveOrgMembership(user.id);
+		const tt = this.tt();
+
+		const { data, error } = await tt
+			.from('tasks')
+			.select('id, task_name, notes, approval_status, start_time, end_time, work_date, duration_minutes, project_id, task_template_id, approved_by, approved_at, created_at, updated_at, project:projects(name)')
+			.eq('org_id', membership.orgId)
+			.eq('user_id', user.id)
+			.eq('work_date', date)
+			.order('created_at', { ascending: true });
+		trackDbCall('select', 'time_tracker.tasks', 'getDayEntries');
+
+		if (error) throw error;
+		return (data || []).map(row => this.mapTaskRow(row));
+	}
+
+	async getPendingApprovalTasks(): Promise<Task[]> {
+		await this.requireUser();
+
+		const { data, error } = await supabase
+			.from('tasks')
+			.select('*')
+			.eq('approval_status', 'pending')
+			.eq('is_current', false)
+			.order('inserted_at', { ascending: false });
+		trackDbCall('select', 'tasks', 'getPendingApprovalTasks');
+
+		if (error) throw error;
+		return (data || []).map(row => this.mapTaskRow(row));
+	}
+
+	async getAdminSettingsBundle(): Promise<AdminSettingsBundle | null> {
+		const user = await this.requireUser();
+		const tt = supabase.schema('time_tracker');
+
+		const { data: currentMembership, error: membershipError } = await tt
+			.from('org_members')
+			.select('id, org_id, user_id, role')
+			.eq('user_id', user.id)
+			.eq('employment_status', 'active')
+			.order('joined_at', { ascending: true })
+			.limit(1)
+			.maybeSingle();
+		trackDbCall('select', 'time_tracker.org_members', 'getAdminSettingsBundle.currentMembership');
+
+		if (membershipError) throw membershipError;
+		if (!currentMembership) return null;
+
+		const orgId = currentMembership.org_id;
+
+		const [orgRes, membersRes, costsRes, projectsRes, templatesRes] = await Promise.all([
+			tt
+				.from('organizations')
+				.select('*')
+				.eq('id', orgId)
+				.single(),
+			tt
+				.from('org_members')
+				.select('*')
+				.eq('org_id', orgId)
+				.order('joined_at', { ascending: true }),
+			tt
+				.from('employee_costs')
+				.select('*')
+				.eq('org_id', orgId)
+				.order('effective_from', { ascending: false }),
+			tt
+				.from('projects')
+				.select('*')
+				.eq('org_id', orgId)
+				.order('created_at', { ascending: false }),
+			tt
+				.from('task_templates')
+				.select('*')
+				.eq('org_id', orgId)
+				.order('group_name', { ascending: true })
+				.order('sort_order', { ascending: true })
+				.order('task_name', { ascending: true }),
+		]);
+		trackDbCall('select', 'time_tracker.organizations', 'getAdminSettingsBundle.organization');
+		trackDbCall('select', 'time_tracker.org_members', 'getAdminSettingsBundle.members');
+		trackDbCall('select', 'time_tracker.employee_costs', 'getAdminSettingsBundle.costs');
+		trackDbCall('select', 'time_tracker.projects', 'getAdminSettingsBundle.projects');
+		trackDbCall('select', 'time_tracker.task_templates', 'getAdminSettingsBundle.templates');
+
+		if (orgRes.error) throw orgRes.error;
+		if (membersRes.error) throw membersRes.error;
+		if (costsRes.error) throw costsRes.error;
+		if (projectsRes.error) throw projectsRes.error;
+		if (templatesRes.error) throw templatesRes.error;
+
+		const memberRows = membersRes.data || [];
+		const userIds = Array.from(new Set([
+			orgRes.data.owner_user_id,
+			...memberRows.map(row => row.user_id),
+			...(projectsRes.data || []).map(row => row.manager_user_id).filter(Boolean),
+		]));
+
+		const { data: profileRows, error: profilesError } = await tt
+			.from('v_user_profiles')
+			.select('*')
+			.in('id', userIds);
+		trackDbCall('select', 'time_tracker.v_user_profiles', 'getAdminSettingsBundle.profiles');
+
+		if (profilesError) throw profilesError;
+
+		const profileMap = new Map(
+			(profileRows || []).map((row: any) => [
+				row.id,
+				{
+					name: row.display_name || row.username || row.email || row.id,
+					email: row.email || '',
+					username: row.username || null,
+					department: row.department || null,
+					avatarUrl: row.avatar_url || null,
+				},
+			])
+		);
+
+		const activeCostMap = new Map<string, any>();
+		for (const row of costsRes.data || []) {
+			if (!activeCostMap.has(row.user_id) && (row.effective_to === null || row.effective_to === undefined)) {
+				activeCostMap.set(row.user_id, row);
+			}
+		}
+		for (const row of costsRes.data || []) {
+			if (!activeCostMap.has(row.user_id)) {
+				activeCostMap.set(row.user_id, row);
+			}
+		}
+
+		const members: AdminMemberSettingsRecord[] = memberRows.map((row: any) => {
+			const profile = profileMap.get(row.user_id);
+			const cost = activeCostMap.get(row.user_id);
+			return {
+				membershipId: row.id,
+				orgId: row.org_id,
+				userId: row.user_id,
+				name: profile?.name || row.user_id,
+				email: profile?.email || '',
+				username: profile?.username || null,
+				department: profile?.department || null,
+				avatarUrl: profile?.avatarUrl || null,
+				role: row.role,
+				employmentStatus: row.employment_status,
+				dataScope: row.data_scope,
+				annualSalary: cost ? Number(cost.annual_salary) : null,
+				annualWorkHours: cost ? Number(cost.annual_work_hours) : null,
+				hourlyCost: cost ? Number(cost.hourly_cost) : null,
+			};
+		});
+
+		const projects: AdminProjectSettingsRecord[] = (projectsRes.data || []).map((row: any) => ({
+			id: row.id,
+			orgId: row.org_id,
+			name: row.name,
+			sourceSystem: row.source_system || null,
+			sourceProjectId: row.source_project_id || null,
+			sourceProjectCode: row.source_project_code || null,
+			managerUserId: row.manager_user_id,
+			managerName: row.manager_user_id ? profileMap.get(row.manager_user_id)?.name || null : null,
+			contractAmount: row.contract_amount != null ? Number(row.contract_amount) : null,
+			humanCostBudget: row.human_cost_budget != null ? Number(row.human_cost_budget) : null,
+			humanCostRatio: row.human_cost_ratio != null ? Number(row.human_cost_ratio) : null,
+			completionProgress: row.completion_progress != null ? Number(row.completion_progress) : null,
+			estimatedCompletionDate: row.estimated_completion_date || null,
+			managerCostRatio: row.manager_cost_ratio != null ? Number(row.manager_cost_ratio) : null,
+			companyCostRatio: row.company_cost_ratio != null ? Number(row.company_cost_ratio) : null,
+			status: row.status,
+		}));
+
+		const taskTemplates: AdminTaskTemplateRecord[] = (templatesRes.data || []).map((row: any) => ({
+			id: row.id,
+			orgId: row.org_id,
+			groupName: row.group_name,
+			taskName: row.task_name,
+			sortOrder: row.sort_order,
+			isActive: row.is_active,
+		}));
+
+		const ownerProfile = profileMap.get(orgRes.data.owner_user_id);
+
+		return {
+			organization: {
+				id: orgRes.data.id,
+				name: orgRes.data.name,
+				description: orgRes.data.description || null,
+				ownerUserId: orgRes.data.owner_user_id,
+				ownerName: ownerProfile?.name || orgRes.data.owner_user_id,
+				ownerEmail: ownerProfile?.email || '',
+				logoUrl: orgRes.data.logo_url || null,
+				standardDailyHours: Number(orgRes.data.standard_daily_hours),
+				standardWeeklyHours: Number(orgRes.data.standard_weekly_hours),
+				defaultHumanCostRatio: Number(orgRes.data.default_human_cost_ratio),
+			},
+			currentUserId: user.id,
+			currentUserRole: currentMembership.role,
+			members,
+			projects,
+			taskTemplates,
+		};
+	}
+
+	async saveAdminOrganization(input: SaveAdminOrganizationInput): Promise<void> {
+		await this.requireUser();
+		const { error } = await supabase
+			.schema('time_tracker')
+			.from('organizations')
+			.update({
+				name: input.name,
+				description: input.description,
+				logo_url: input.logoUrl,
+				standard_daily_hours: input.standardDailyHours,
+				standard_weekly_hours: input.standardWeeklyHours,
+				default_human_cost_ratio: input.defaultHumanCostRatio,
+			})
+			.eq('id', input.orgId);
+		trackDbCall('update', 'time_tracker.organizations', 'saveAdminOrganization');
+
+		if (error) throw error;
+	}
+
+	async saveAdminMember(input: SaveAdminMemberInput): Promise<void> {
+		await this.requireUser();
+		const tt = supabase.schema('time_tracker');
+
+		const { error: memberError } = await tt
+			.from('org_members')
+			.update({
+				role: input.role,
+				employment_status: input.employmentStatus,
+				data_scope: input.dataScope,
+			})
+			.eq('id', input.membershipId);
+		trackDbCall('update', 'time_tracker.org_members', 'saveAdminMember.membership');
+
+		if (memberError) throw memberError;
+
+		const hasCostValues =
+			input.annualSalary !== null &&
+			input.annualWorkHours !== null &&
+			input.hourlyCost !== null;
+
+		if (!hasCostValues) {
+			return;
+		}
+
+		const { data: existingCost, error: costLookupError } = await tt
+			.from('employee_costs')
+			.select('id')
+			.eq('org_id', input.orgId)
+			.eq('user_id', input.userId)
+			.is('effective_to', null)
+			.order('effective_from', { ascending: false })
+			.limit(1)
+			.maybeSingle();
+		trackDbCall('select', 'time_tracker.employee_costs', 'saveAdminMember.lookupCost');
+
+		if (costLookupError) throw costLookupError;
+
+		if (existingCost?.id) {
+			const { error: costUpdateError } = await tt
+				.from('employee_costs')
+				.update({
+					annual_salary: input.annualSalary,
+					annual_work_hours: input.annualWorkHours,
+					hourly_cost: input.hourlyCost,
+				})
+				.eq('id', existingCost.id);
+			trackDbCall('update', 'time_tracker.employee_costs', 'saveAdminMember.updateCost');
+
+			if (costUpdateError) throw costUpdateError;
+			return;
+		}
+
+		const { error: costInsertError } = await tt
+			.from('employee_costs')
+			.insert({
+				org_id: input.orgId,
+				user_id: input.userId,
+				annual_salary: input.annualSalary,
+				annual_work_hours: input.annualWorkHours,
+				hourly_cost: input.hourlyCost,
+			});
+		trackDbCall('insert', 'time_tracker.employee_costs', 'saveAdminMember.insertCost');
+
+		if (costInsertError) throw costInsertError;
+	}
+
+	async saveAdminProject(input: SaveAdminProjectInput): Promise<void> {
+		await this.requireUser();
+		const tt = supabase.schema('time_tracker');
+		const payload: Record<string, unknown> = {
+			org_id: input.orgId,
+			name: input.name,
+			manager_user_id: input.managerUserId,
+			contract_amount: input.contractAmount ?? 0,
+			human_cost_budget: input.humanCostBudget ?? 0,
+			human_cost_ratio: input.humanCostRatio ?? 0,
+			completion_progress: input.completionProgress ?? 0,
+			estimated_completion_date: input.estimatedCompletionDate,
+			manager_cost_ratio: input.managerCostRatio ?? 0,
+			company_cost_ratio: input.companyCostRatio ?? 0,
+			status: input.status,
+		};
+		if (await this.hasProjectSourceFields()) {
+			payload.source_system = input.sourceSystem ?? null;
+			payload.source_project_id = input.sourceProjectId ?? null;
+			payload.source_project_code = input.sourceProjectCode ?? null;
+		}
+
+		if (input.id) {
+			const { error } = await tt
+				.from('projects')
+				.update(payload)
+				.eq('id', input.id);
+			trackDbCall('update', 'time_tracker.projects', 'saveAdminProject.update');
+			if (error) throw error;
+			return;
+		}
+
+		const { error } = await tt
+			.from('projects')
+			.insert(payload);
+		trackDbCall('insert', 'time_tracker.projects', 'saveAdminProject.insert');
+		if (error) throw error;
+	}
+
+	async syncAdminProjectsFromSource(): Promise<SyncAdminProjectsResult> {
+		const user = await this.requireUser();
+		const membership = await this.requireActiveOrgMembership(user.id);
+		if (!this.canManageProjectsRole(membership.role)) {
+			throw new Error('当前账号没有同步项目的权限');
+		}
+
+		const rpcResult = await this.trySyncAdminProjectsViaRpc(membership.orgId);
+		if (rpcResult) {
+			await this.logProjectSync(membership.orgId, user.id, rpcResult);
+			return rpcResult;
+		}
+
+		const sourceFieldsAvailable = await this.hasProjectSourceFields();
+		const { data: sourceRows, error: sourceError } = await supabase
+			.from('projects')
+			.select('id, name, project_code, status, is_deleted, created_at')
+			.eq('is_deleted', false)
+			.order('created_at', { ascending: true });
+		trackDbCall('select', 'public.projects', 'syncAdminProjectsFromSource.source');
+
+		if (sourceError) throw sourceError;
+
+		const targetSelect = sourceFieldsAvailable
+			? 'id, name, status, source_system, source_project_id, source_project_code'
+			: 'id, name, status';
+		const { data: targetRows, error: targetError } = await this.tt()
+			.from('projects')
+			.select(targetSelect)
+			.eq('org_id', membership.orgId)
+			.order('created_at', { ascending: true });
+		trackDbCall('select', 'time_tracker.projects', 'syncAdminProjectsFromSource.target');
+
+		if (targetError) throw targetError;
+
+		const existingByName = new Map<string, any>();
+		const existingBySourceId = new Map<string, any>();
+		for (const row of targetRows || []) {
+			const normalizedName = this.normalizeProjectName(row.name).toLowerCase();
+			if (normalizedName && !existingByName.has(normalizedName)) {
+				existingByName.set(normalizedName, row);
+			}
+			if (sourceFieldsAvailable && row.source_project_id) {
+				existingBySourceId.set(String(row.source_project_id), row);
+			}
+		}
+
+		let inserted = 0;
+		let updated = 0;
+		let skipped = 0;
+		let sourceTotal = 0;
+
+		for (const row of sourceRows || []) {
+			const normalizedName = this.normalizeProjectName(row.name);
+			if (!normalizedName) {
+				continue;
+			}
+			sourceTotal += 1;
+
+			const existing =
+				existingBySourceId.get(String(row.id)) ||
+				existingByName.get(normalizedName.toLowerCase()) ||
+				null;
+			const mappedStatus = this.mapProjectStatus(row.status);
+
+			if (existing) {
+				const updatePayload: Record<string, unknown> = {};
+				if (existing.name !== normalizedName) {
+					updatePayload.name = normalizedName;
+				}
+				if (existing.status !== mappedStatus) {
+					updatePayload.status = mappedStatus;
+				}
+				if (sourceFieldsAvailable) {
+					if (existing.source_system !== 'sa_ai_app') {
+						updatePayload.source_system = 'sa_ai_app';
+					}
+					if (String(existing.source_project_id || '') !== String(row.id)) {
+						updatePayload.source_project_id = row.id;
+					}
+					if ((existing.source_project_code || null) !== (row.project_code || null)) {
+						updatePayload.source_project_code = row.project_code || null;
+					}
+				}
+
+				if (Object.keys(updatePayload).length === 0) {
+					skipped += 1;
+					continue;
+				}
+
+				const { error } = await this.tt()
+					.from('projects')
+					.update(updatePayload)
+					.eq('id', existing.id);
+				trackDbCall('update', 'time_tracker.projects', 'syncAdminProjectsFromSource.update');
+
+				if (error) throw error;
+
+				const updatedRow = { ...existing, ...updatePayload };
+				existingByName.set(normalizedName.toLowerCase(), updatedRow);
+				if (sourceFieldsAvailable) {
+					existingBySourceId.set(String(row.id), updatedRow);
+				}
+				updated += 1;
+				continue;
+			}
+
+			const insertPayload: Record<string, unknown> = {
+				org_id: membership.orgId,
+				name: normalizedName,
+				status: mappedStatus,
+			};
+			if (sourceFieldsAvailable) {
+				insertPayload.source_system = 'sa_ai_app';
+				insertPayload.source_project_id = row.id;
+				insertPayload.source_project_code = row.project_code || null;
+			}
+
+			const { data: insertedRows, error } = await this.tt()
+				.from('projects')
+				.insert(insertPayload)
+				.select(sourceFieldsAvailable
+					? 'id, name, status, source_system, source_project_id, source_project_code'
+					: 'id, name, status')
+				.limit(1);
+			trackDbCall('insert', 'time_tracker.projects', 'syncAdminProjectsFromSource.insert');
+
+			if (error) throw error;
+
+			const insertedRow = insertedRows?.[0] || {
+				id: `new-${row.id}`,
+				name: normalizedName,
+				status: mappedStatus,
+				source_system: sourceFieldsAvailable ? 'sa_ai_app' : null,
+				source_project_id: sourceFieldsAvailable ? row.id : null,
+				source_project_code: sourceFieldsAvailable ? row.project_code || null : null,
+			};
+			existingByName.set(normalizedName.toLowerCase(), insertedRow);
+			if (sourceFieldsAvailable) {
+				existingBySourceId.set(String(row.id), insertedRow);
+			}
+			inserted += 1;
+		}
+
+		const result = { sourceTotal, inserted, updated, skipped };
+		await this.logProjectSync(membership.orgId, user.id, result);
+		return result;
+	}
+
+	async saveAdminTaskTemplate(input: SaveAdminTaskTemplateInput): Promise<void> {
+		await this.requireUser();
+		const tt = supabase.schema('time_tracker');
+		const payload = {
+			org_id: input.orgId,
+			group_name: input.groupName,
+			task_name: input.taskName,
+			sort_order: input.sortOrder,
+			is_active: input.isActive,
+		};
+
+		if (input.id) {
+			const { error } = await tt
+				.from('task_templates')
+				.update(payload)
+				.eq('id', input.id);
+			trackDbCall('update', 'time_tracker.task_templates', 'saveAdminTaskTemplate.update');
+			if (error) throw error;
+			return;
+		}
+
+		const { error } = await tt
+			.from('task_templates')
+			.insert(payload);
+		trackDbCall('insert', 'time_tracker.task_templates', 'saveAdminTaskTemplate.insert');
+		if (error) throw error;
+	}
+
+	async getMemberReportRecords(): Promise<MemberReportRecord[]> {
+		const user = await this.requireUser();
+		const tt = supabase.schema('time_tracker');
+
+		const { data: currentMembership, error: membershipError } = await tt
+			.from('org_members')
+			.select('org_id')
+			.eq('user_id', user.id)
+			.eq('employment_status', 'active')
+			.order('joined_at', { ascending: true })
+			.limit(1)
+			.maybeSingle();
+		trackDbCall('select', 'time_tracker.org_members', 'getMemberReportRecords.currentMembership');
+
+		if (membershipError) throw membershipError;
+		if (!currentMembership) return [];
+
+		const orgId = currentMembership.org_id;
+
+		const [membersRes, summaryRes] = await Promise.all([
+			tt
+				.from('org_members')
+				.select('id, org_id, user_id, role, employment_status')
+				.eq('org_id', orgId)
+				.order('joined_at', { ascending: true }),
+			tt
+				.from('v_member_hours_summary')
+				.select('*')
+				.eq('org_id', orgId),
+		]);
+		trackDbCall('select', 'time_tracker.org_members', 'getMemberReportRecords.members');
+		trackDbCall('select', 'time_tracker.v_member_hours_summary', 'getMemberReportRecords.summary');
+
+		if (membersRes.error) throw membersRes.error;
+		if (summaryRes.error) throw summaryRes.error;
+
+		const memberRows = membersRes.data || [];
+		const userIds = memberRows.map((row) => row.user_id);
+
+		const { data: profileRows, error: profilesError } = await tt
+			.from('v_user_profiles')
+			.select('id, email, display_name, username, department, avatar_url')
+			.in('id', userIds);
+		trackDbCall('select', 'time_tracker.v_user_profiles', 'getMemberReportRecords.profiles');
+
+		if (profilesError) throw profilesError;
+
+		const profileMap = new Map(
+			(profileRows || []).map((row: any) => [
+				row.id,
+				{
+					name: row.display_name || row.username || row.email || row.id,
+					email: row.email || '',
+					department: row.department || null,
+					avatarUrl: row.avatar_url || null,
+				},
+			])
+		);
+
+		const summaryMap = new Map(
+			(summaryRes.data || []).map((row: any) => [
+				row.user_id,
+				{
+					hours: row.total_hours != null ? Number(row.total_hours) : 0,
+					hourlyRate: row.hourly_cost != null ? Number(row.hourly_cost) : 0,
+					laborCost: row.labor_cost != null ? Number(row.labor_cost) : 0,
+				},
+			])
+		);
+
+		return memberRows.map((row: any) => {
+			const profile = profileMap.get(row.user_id);
+			const summary = summaryMap.get(row.user_id);
+
+			return {
+				orgId: row.org_id,
+				userId: row.user_id,
+				name: profile?.name || row.user_id,
+				email: profile?.email || '',
+				department: profile?.department || null,
+				avatarUrl: profile?.avatarUrl || null,
+				role: row.role,
+				employmentStatus: row.employment_status,
+				hours: summary?.hours || 0,
+				hourlyRate: summary?.hourlyRate || 0,
+				laborCost: summary?.laborCost || 0,
+				output: 0,
+				unitPrice: 0,
+				efficiency: 0,
+			};
+		});
+	}
+
+	async getProjectReportRecords(): Promise<ProjectReportRecord[]> {
+		const user = await this.requireUser();
+		const tt = supabase.schema('time_tracker');
+
+		const { data: currentMembership, error: membershipError } = await tt
+			.from('org_members')
+			.select('org_id')
+			.eq('user_id', user.id)
+			.eq('employment_status', 'active')
+			.order('joined_at', { ascending: true })
+			.limit(1)
+			.maybeSingle();
+		trackDbCall('select', 'time_tracker.org_members', 'getProjectReportRecords.currentMembership');
+
+		if (membershipError) throw membershipError;
+		if (!currentMembership) return [];
+
+		const orgId = currentMembership.org_id;
+
+		const { data, error } = await tt
+			.from('v_project_financial_summary')
+			.select('*')
+			.eq('org_id', orgId)
+			.order('project_name', { ascending: true });
+		trackDbCall('select', 'time_tracker.v_project_financial_summary', 'getProjectReportRecords.summary');
+
+		if (error) throw error;
+
+		return (data || []).map((row: any) => {
+			const totalReceived = row.total_received != null ? Number(row.total_received) : 0;
+			const totalCost = row.total_cost != null ? Number(row.total_cost) : 0;
+			const recognizedRevenue = row.recognized_revenue != null ? Number(row.recognized_revenue) : 0;
+			const receivable = row.receivable != null ? Number(row.receivable) : 0;
+			const laborCost = row.labor_cost != null ? Number(row.labor_cost) : 0;
+			const expenseCost = row.expense_cost != null ? Number(row.expense_cost) : 0;
+			const projectHours = row.total_hours != null ? Number(row.total_hours) : 0;
+			const contractAmount = row.contract_amount != null ? Number(row.contract_amount) : 0;
+			const grossProfit = row.gross_profit != null ? Number(row.gross_profit) : 0;
+			const cashNetFlow = row.cash_net_flow != null ? Number(row.cash_net_flow) : 0;
+			const progress = row.completion_progress != null ? Number(row.completion_progress) : 0;
+			const profitRate = recognizedRevenue > 0 ? (grossProfit / recognizedRevenue) * 100 : 0;
+			const externalRisk = recognizedRevenue > 0 ? receivable / recognizedRevenue : 0;
+			const internalRisk = recognizedRevenue > 0 ? laborCost / recognizedRevenue : 0;
+			const prepaid = totalReceived > recognizedRevenue ? totalReceived - recognizedRevenue : 0;
+			const hoursBudget = 0;
+			const hoursRate = hoursBudget > 0 ? (projectHours / hoursBudget) * 100 : 0;
+			const hourlyValue = projectHours > 0 ? recognizedRevenue / projectHours : 0;
+			const mainCost = cashNetFlow < 0 ? Math.abs(cashNetFlow) : 0;
+			const cashAsset = cashNetFlow > 0 ? cashNetFlow : 0;
+			const costRate = contractAmount > 0 ? (totalCost / contractAmount) * 100 : 0;
+
+			let status: ProjectReportRecord['status'] = '激活';
+			if (row.status === 'completed') status = '已完成';
+			if (row.status === 'archived') status = '已归档';
+
+			return {
+				projectId: row.project_id,
+				orgId: row.org_id,
+				name: row.project_name,
+				status,
+				receivable,
+				externalRisk,
+				internalRisk,
+				progress,
+				cashAsset,
+				mainCost,
+				prepaid,
+				equity: grossProfit,
+				revenue: recognizedRevenue,
+				cost: totalCost,
+				profit: grossProfit,
+				profitRate,
+				hours: projectHours,
+				hourlyValue,
+				cashIn: totalReceived,
+				cashOut: totalCost,
+				netCashFlow: cashNetFlow,
+				contractAmount,
+				hoursBudget,
+				actualHours: projectHours,
+				hoursRate,
+				laborCost,
+				costRate,
+			};
+		});
+	}
+
+	async getProjectDetailRecord(projectId: string): Promise<ProjectDetailRecord | null> {
+		await this.requireUser();
+		const { orgId } = await this.requireActiveOrgMembership();
+		const tt = this.tt();
+
+		const [projectRes, summaryRes, paymentsRes, expensesRes] = await Promise.all([
+			tt
+				.from('projects')
+				.select('id, org_id, name, manager_user_id, contract_amount, human_cost_budget, completion_progress, estimated_completion_date, status, source_project_code')
+				.eq('org_id', orgId)
+				.eq('id', projectId)
+				.maybeSingle(),
+			tt
+				.from('v_project_financial_summary')
+				.select('project_id, org_id, recognized_revenue, total_received, total_hours, labor_cost, expense_cost, total_cost, gross_profit, receivable, cash_net_flow')
+				.eq('org_id', orgId)
+				.eq('project_id', projectId)
+				.maybeSingle(),
+			tt
+				.from('project_payments')
+				.select('id', { count: 'exact', head: true })
+				.eq('org_id', orgId)
+				.eq('project_id', projectId),
+			tt
+				.from('project_expenses')
+				.select('id', { count: 'exact', head: true })
+				.eq('org_id', orgId)
+				.eq('project_id', projectId),
+		]);
+		trackDbCall('select', 'time_tracker.projects', 'getProjectDetailRecord.project');
+		trackDbCall('select', 'time_tracker.v_project_financial_summary', 'getProjectDetailRecord.summary');
+		trackDbCall('select', 'time_tracker.project_payments', 'getProjectDetailRecord.payments');
+		trackDbCall('select', 'time_tracker.project_expenses', 'getProjectDetailRecord.expenses');
+
+		if (projectRes.error) throw projectRes.error;
+		if (summaryRes.error) throw summaryRes.error;
+		if (paymentsRes.error) throw paymentsRes.error;
+		if (expensesRes.error) throw expensesRes.error;
+		if (!projectRes.data) return null;
+
+		let managerName: string | null = null;
+		if (projectRes.data.manager_user_id) {
+			const managerRes = await tt
+				.from('v_user_profiles')
+				.select('display_name, username, email')
+				.eq('id', projectRes.data.manager_user_id)
+				.maybeSingle();
+			trackDbCall('select', 'time_tracker.v_user_profiles', 'getProjectDetailRecord.manager');
+			if (managerRes.error) throw managerRes.error;
+			managerName = managerRes.data?.display_name || managerRes.data?.username || managerRes.data?.email || null;
+		}
+
+		const summary = summaryRes.data;
+		const contractAmount = projectRes.data.contract_amount != null ? Number(projectRes.data.contract_amount) : 0;
+		const humanCostBudget = projectRes.data.human_cost_budget != null ? Number(projectRes.data.human_cost_budget) : 0;
+		const completionProgress = projectRes.data.completion_progress != null ? Number(projectRes.data.completion_progress) : 0;
+		const recognizedRevenue = summary?.recognized_revenue != null ? Number(summary.recognized_revenue) : 0;
+		const totalReceived = summary?.total_received != null ? Number(summary.total_received) : 0;
+		const totalHours = summary?.total_hours != null ? Number(summary.total_hours) : 0;
+		const laborCost = summary?.labor_cost != null ? Number(summary.labor_cost) : 0;
+		const expenseCost = summary?.expense_cost != null ? Number(summary.expense_cost) : 0;
+		const totalCost = summary?.total_cost != null ? Number(summary.total_cost) : 0;
+		const grossProfit = summary?.gross_profit != null ? Number(summary.gross_profit) : 0;
+		const receivable = summary?.receivable != null ? Number(summary.receivable) : 0;
+		const cashNetFlow = summary?.cash_net_flow != null ? Number(summary.cash_net_flow) : 0;
+		const hourlyValue = totalHours > 0 ? recognizedRevenue / totalHours : null;
+		const externalRisk = recognizedRevenue > 0 ? (receivable / recognizedRevenue) * 100 : null;
+		const internalRisk = recognizedRevenue > 0 ? (laborCost / recognizedRevenue) * 100 : null;
+		const estimatedCompletionDate = projectRes.data.estimated_completion_date || null;
+		const remainingDays = estimatedCompletionDate
+			? Math.ceil((new Date(`${estimatedCompletionDate}T00:00:00`).getTime() - Date.now()) / (1000 * 60 * 60 * 24))
+			: null;
+
+		let status: ProjectDetailRecord['status'] = '激活';
+		if (projectRes.data.status === 'completed') status = '已完成';
+		if (projectRes.data.status === 'archived') status = '已归档';
+
+		return {
+			projectId: projectRes.data.id,
+			orgId: projectRes.data.org_id,
+			name: projectRes.data.name,
+			status,
+			managerName,
+			sourceProjectCode: projectRes.data.source_project_code || null,
+			contractAmount,
+			humanCostBudget,
+			completionProgress,
+			estimatedCompletionDate,
+			remainingDays,
+			recognizedRevenue,
+			totalReceived,
+			totalHours,
+			laborCost,
+			expenseCost,
+			totalCost,
+			grossProfit,
+			receivable,
+			cashNetFlow,
+			hourlyValue,
+			externalRisk,
+			internalRisk,
+			paymentCount: paymentsRes.count ?? 0,
+			expenseCount: expensesRes.count ?? 0,
+		};
+	}
+
+	async getProjectMembersBundle(projectId: string): Promise<ProjectMembersBundle | null> {
+		await this.requireUser();
+		const membership = await this.requireActiveOrgMembership();
+		const tt = this.tt();
+
+		const [projectRes, orgMembersRes, projectMembersRes] = await Promise.all([
+			tt
+				.from('projects')
+				.select('id, org_id')
+				.eq('org_id', membership.orgId)
+				.eq('id', projectId)
+				.maybeSingle(),
+			tt
+				.from('org_members')
+				.select('id, user_id, role, employment_status')
+				.eq('org_id', membership.orgId)
+				.eq('employment_status', 'active')
+				.order('joined_at', { ascending: true }),
+			tt
+				.from('project_members')
+				.select('id, user_id, status, joined_at, left_at')
+				.eq('org_id', membership.orgId)
+				.eq('project_id', projectId),
+		]);
+		trackDbCall('select', 'time_tracker.projects', 'getProjectMembersBundle.project');
+		trackDbCall('select', 'time_tracker.org_members', 'getProjectMembersBundle.orgMembers');
+		trackDbCall('select', 'time_tracker.project_members', 'getProjectMembersBundle.projectMembers');
+
+		if (projectRes.error) throw projectRes.error;
+		if (orgMembersRes.error) throw orgMembersRes.error;
+		if (projectMembersRes.error) throw projectMembersRes.error;
+		if (!projectRes.data) return null;
+
+		const orgMembers = orgMembersRes.data ?? [];
+		const projectMembers = projectMembersRes.data ?? [];
+		const userIds = orgMembers.map((row: any) => row.user_id);
+
+		const profilesRes = userIds.length > 0
+			? await tt
+				.from('v_user_profiles')
+				.select('id, email, display_name, username')
+				.in('id', userIds)
+			: { data: [], error: null };
+		trackDbCall('select', 'time_tracker.v_user_profiles', 'getProjectMembersBundle.profiles');
+		if (profilesRes.error) throw profilesRes.error;
+
+		const profileMap = new Map((profilesRes.data ?? []).map((row: any) => [row.id, row]));
+		const projectMemberMap = new Map(projectMembers.map((row: any) => [row.user_id, row]));
+
+		const materialized = orgMembers.map((row: any) => {
+			const profile = profileMap.get(row.user_id);
+			const projectMember = projectMemberMap.get(row.user_id);
+			const name = profile?.display_name || profile?.username || profile?.email || row.user_id;
+			return {
+				projectMemberId: projectMember?.id || `${projectId}:${row.user_id}`,
+				userId: row.user_id,
+				name,
+				email: profile?.email || null,
+				role: row.role,
+				status: projectMember?.status === 'exited' ? 'exited' : (projectMember ? 'active' : 'available'),
+				joinedAt: projectMember?.joined_at || null,
+				leftAt: projectMember?.left_at || null,
+				initial: String(name).trim().charAt(0).toUpperCase() || '?',
+				color: this.getProjectMemberColor(String(row.user_id)),
+			};
+		});
+
+		return {
+			projectId,
+			activeMembers: materialized.filter((row) => row.status === 'active'),
+			exitedMembers: materialized.filter((row) => row.status === 'exited'),
+			availableMembers: materialized.filter((row) => row.status === 'available'),
+			canManageMembers: this.canManageProjectsRole(membership.role),
+		};
+	}
+
+	async addProjectMember(projectId: string, userId: string): Promise<void> {
+		await this.requireUser();
+		const membership = await this.requireActiveOrgMembership();
+		if (!this.canManageProjectsRole(membership.role)) {
+			throw new Error('当前角色无权管理项目成员');
+		}
+
+		const tt = this.tt();
+		const { error } = await tt
+			.from('project_members')
+			.upsert({
+				org_id: membership.orgId,
+				project_id: projectId,
+				user_id: userId,
+				status: 'active',
+				joined_at: new Date().toISOString(),
+				left_at: null,
+				updated_at: new Date().toISOString(),
+			}, { onConflict: 'project_id,user_id' });
+		trackDbCall('upsert', 'time_tracker.project_members', 'addProjectMember');
+		if (error) throw error;
+	}
+
+	async exitProjectMember(projectId: string, userId: string): Promise<void> {
+		await this.requireUser();
+		const membership = await this.requireActiveOrgMembership();
+		if (!this.canManageProjectsRole(membership.role)) {
+			throw new Error('当前角色无权管理项目成员');
+		}
+
+		const { error } = await this.tt()
+			.from('project_members')
+			.update({
+				status: 'exited',
+				left_at: new Date().toISOString(),
+				updated_at: new Date().toISOString(),
+			})
+			.eq('org_id', membership.orgId)
+			.eq('project_id', projectId)
+			.eq('user_id', userId);
+		trackDbCall('update', 'time_tracker.project_members', 'exitProjectMember');
+		if (error) throw error;
+	}
+
+	async restoreProjectMember(projectId: string, userId: string): Promise<void> {
+		await this.requireUser();
+		const membership = await this.requireActiveOrgMembership();
+		if (!this.canManageProjectsRole(membership.role)) {
+			throw new Error('当前角色无权管理项目成员');
+		}
+
+		const { error } = await this.tt()
+			.from('project_members')
+			.update({
+				status: 'active',
+				left_at: null,
+				updated_at: new Date().toISOString(),
+			})
+			.eq('org_id', membership.orgId)
+			.eq('project_id', projectId)
+			.eq('user_id', userId);
+		trackDbCall('update', 'time_tracker.project_members', 'restoreProjectMember');
+		if (error) throw error;
+	}
+
+	async getOrgReportBundle(): Promise<OrgReportBundle | null> {
+		const user = await this.requireUser();
+		const tt = supabase.schema('time_tracker');
+
+		const { data: currentMembership, error: membershipError } = await tt
+			.from('org_members')
+			.select('org_id')
+			.eq('user_id', user.id)
+			.eq('employment_status', 'active')
+			.order('joined_at', { ascending: true })
+			.limit(1)
+			.maybeSingle();
+		trackDbCall('select', 'time_tracker.org_members', 'getOrgReportBundle.currentMembership');
+
+		if (membershipError) throw membershipError;
+		if (!currentMembership) return null;
+
+		const orgId = currentMembership.org_id;
+
+		const [orgRes, kpiRes, monthlyRes, membersRes, costRes] = await Promise.all([
+			tt
+				.from('organizations')
+				.select('id, name, default_human_cost_ratio')
+				.eq('id', orgId)
+				.single(),
+			tt
+				.from('v_org_financial_kpi')
+				.select('*')
+				.eq('org_id', orgId)
+				.maybeSingle(),
+			tt
+				.from('v_org_capacity_monthly')
+				.select('*')
+				.eq('org_id', orgId)
+				.order('month_start', { ascending: true }),
+			tt
+				.from('org_members')
+				.select('user_id')
+				.eq('org_id', orgId)
+				.eq('employment_status', 'active'),
+			tt
+				.from('employee_costs')
+				.select('user_id, hourly_cost')
+				.eq('org_id', orgId)
+				.is('effective_to', null),
+		]);
+		trackDbCall('select', 'time_tracker.organizations', 'getOrgReportBundle.organization');
+		trackDbCall('select', 'time_tracker.v_org_financial_kpi', 'getOrgReportBundle.kpi');
+		trackDbCall('select', 'time_tracker.v_org_capacity_monthly', 'getOrgReportBundle.monthly');
+		trackDbCall('select', 'time_tracker.org_members', 'getOrgReportBundle.members');
+		trackDbCall('select', 'time_tracker.employee_costs', 'getOrgReportBundle.costs');
+
+		if (orgRes.error) throw orgRes.error;
+		if (kpiRes.error) throw kpiRes.error;
+		if (monthlyRes.error) throw monthlyRes.error;
+		if (membersRes.error) throw membersRes.error;
+		if (costRes.error) throw costRes.error;
+
+		const monthly = (monthlyRes.data || []).map((row: any) => {
+			const totalHours = row.total_hours != null ? Number(row.total_hours) : 0;
+			const capacityHours = row.capacity_hours != null ? Number(row.capacity_hours) : 0;
+			return {
+				monthStart: row.month_start,
+				totalHours,
+				capacityHours,
+				capacityUtilization: capacityHours > 0 ? (totalHours / capacityHours) * 100 : 0,
+			};
+		});
+
+		const latestMonth = monthly.length > 0
+			? monthly[monthly.length - 1]
+			: {
+				monthStart: new Date().toISOString().slice(0, 10),
+				totalHours: 0,
+				capacityHours: 0,
+				capacityUtilization: 0,
+			};
+
+		const activeMemberCount = (membersRes.data || []).length;
+		const activeCosts = (costRes.data || [])
+			.map((row: any) => row.hourly_cost != null ? Number(row.hourly_cost) : 0)
+			.filter((value: number) => Number.isFinite(value) && value > 0);
+		const avgHourlyCost = activeCosts.length > 0
+			? activeCosts.reduce((sum: number, value: number) => sum + value, 0) / activeCosts.length
+			: 0;
+		const defaultHumanCostRatio = orgRes.data.default_human_cost_ratio != null
+			? Number(orgRes.data.default_human_cost_ratio)
+			: 0;
+		const ratioDecimal = defaultHumanCostRatio > 0 ? defaultHumanCostRatio / 100 : 0;
+		const estimatedMonthlyCapacityValue = ratioDecimal > 0
+			? (latestMonth.capacityHours * avgHourlyCost) / ratioDecimal
+			: 0;
+		const estimatedDailyCapacityValue = estimatedMonthlyCapacityValue > 0
+			? estimatedMonthlyCapacityValue / 21.75
+			: 0;
+
+		const remainingContractAmount = kpiRes.data?.remaining_contract_amount != null ? Number(kpiRes.data.remaining_contract_amount) : 0;
+		const totalReceivable = kpiRes.data?.total_receivable != null ? Number(kpiRes.data.total_receivable) : 0;
+		const totalReceived = kpiRes.data?.total_received != null ? Number(kpiRes.data.total_received) : 0;
+		const totalCost = kpiRes.data?.total_cost != null ? Number(kpiRes.data.total_cost) : 0;
+		const projectCount = kpiRes.data?.project_count != null ? Number(kpiRes.data.project_count) : 0;
+		const productionDays = estimatedMonthlyCapacityValue > 0 ? (remainingContractAmount / estimatedMonthlyCapacityValue) * 30 : 0;
+		const inventoryDays = estimatedDailyCapacityValue > 0 ? totalReceivable / estimatedDailyCapacityValue : 0;
+		const avgWeeklyHoursPerMember = activeMemberCount > 0 ? latestMonth.totalHours / activeMemberCount / 4.35 : 0;
+		const avgMonthlyHoursPerMember = activeMemberCount > 0 ? latestMonth.totalHours / activeMemberCount : 0;
+
+		return {
+			snapshot: {
+				orgId,
+				orgName: orgRes.data.name,
+				activeMemberCount,
+				projectCount,
+				remainingContractAmount,
+				totalReceivable,
+				totalReceived,
+				totalCost,
+				currentMonthHours: latestMonth.totalHours,
+				currentMonthCapacityHours: latestMonth.capacityHours,
+				capacityUtilization: latestMonth.capacityUtilization,
+				estimatedMonthlyCapacityValue,
+				estimatedDailyCapacityValue,
+				productionDays,
+				inventoryDays,
+				avgWeeklyHoursPerMember,
+				avgMonthlyHoursPerMember,
+			},
+			monthly,
+		};
+	}
+	async getOrgActivityLogRecords(): Promise<OrgActivityLogRecord[]> {
+		const user = await this.requireUser();
+		const tt = supabase.schema('time_tracker');
+
+		const { data: currentMembership, error: membershipError } = await tt
+			.from('org_members')
+			.select('org_id')
+			.eq('user_id', user.id)
+			.eq('employment_status', 'active')
+			.order('joined_at', { ascending: true })
+			.limit(1)
+			.maybeSingle();
+		trackDbCall('select', 'time_tracker.org_members', 'getOrgActivityLogRecords.currentMembership');
+
+		if (membershipError) throw membershipError;
+		if (!currentMembership) return [];
+
+		const orgId = currentMembership.org_id;
+		const { data: logRows, error: logError } = await tt
+			.from('org_activity_logs')
+			.select('*')
+			.eq('org_id', orgId)
+			.order('created_at', { ascending: false });
+		trackDbCall('select', 'time_tracker.org_activity_logs', 'getOrgActivityLogRecords.logs');
+
+		if (logError) throw logError;
+
+		const actorIds = Array.from(new Set((logRows || []).map((row: any) => row.actor_user_id).filter(Boolean)));
+		let profileMap = new Map<string, { name: string; email: string; avatarUrl: string | null }>();
+
+		if (actorIds.length > 0) {
+			const { data: profileRows, error: profilesError } = await tt
+				.from('v_user_profiles')
+				.select('id, email, display_name, username, avatar_url')
+				.in('id', actorIds);
+			trackDbCall('select', 'time_tracker.v_user_profiles', 'getOrgActivityLogRecords.profiles');
+
+			if (profilesError) throw profilesError;
+
+			profileMap = new Map(
+				(profileRows || []).map((row: any) => [
+					row.id,
+					{
+						name: row.display_name || row.username || row.email || row.id,
+						email: row.email || '',
+						avatarUrl: row.avatar_url || null,
+					},
+				])
+			);
+		}
+
+		return (logRows || []).map((row: any) => {
+			const actor = row.actor_user_id ? profileMap.get(row.actor_user_id) : null;
+			return {
+				id: row.id,
+				orgId: row.org_id,
+				actorUserId: row.actor_user_id || null,
+				actorName: actor?.name || 'System',
+				actorEmail: actor?.email || '',
+				actorAvatarUrl: actor?.avatarUrl || null,
+				actionType: row.action_type,
+				targetType: row.target_type,
+				description: row.description,
+				createdAt: row.created_at,
+			};
+		});
+	}
+	// ===== 公共行映射器 =====
+
+	private mapTaskRow(row: any): Task {
+		const duration = row.duration != null
+			? row.duration
+			: row.duration_minutes != null
+				? Number(row.duration_minutes) * 60 * 1000
+				: undefined;
+		const hours = row.hours != null
+			? Number(row.hours)
+			: row.duration_minutes != null
+				? Math.round((Number(row.duration_minutes) / 60) * 100) / 100
+				: undefined;
+
+		return {
+			id: row.id,
+			title: row.title || row.task_name,
+			description: row.description || row.notes || undefined,
+			startTime: row.start_time ? new Date(row.start_time) : new Date(row.work_date || Date.now()),
+			endTime: row.end_time ? new Date(row.end_time) : undefined,
+			duration,
+			project: row.project_name || this.extractProjectName(row.project),
+			client: row.client || undefined,
+			category: row.category_id || row.task_template_id || undefined,
+			entry_type: row.entry_type || (row.start_time || row.end_time ? 'timer' : 'manual'),
+			work_date: row.work_date || undefined,
+			hours,
+			approval_status: row.approval_status || 'pending',
+			approved_by: row.approved_by || undefined,
+			approved_at: row.approved_at || undefined,
+			insertedAt: row.inserted_at ? new Date(row.inserted_at) : row.created_at ? new Date(row.created_at) : undefined,
+			updatedAt: row.updated_at ? new Date(row.updated_at) : undefined,
+		};
 	}
 }

--- a/src/utils/recentSelections.test.ts
+++ b/src/utils/recentSelections.test.ts
@@ -1,0 +1,153 @@
+/**
+ * recentSelections.test.ts — 最近使用工具函数测试
+ *
+ * 覆盖：去重、置顶、截断、失效过滤、空存储容错
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getRecentProjects,
+  addRecentProject,
+  filterValidRecentProjects,
+  getRecentTaskOptions,
+  addRecentTaskOption,
+  filterValidRecentTaskOptions,
+  RecentProject,
+  RecentTaskOption,
+} from './recentSelections';
+
+const TEST_USER = 'test-user-id-123';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('Recent Projects', () => {
+  it('returns empty array when no data stored', () => {
+    expect(getRecentProjects(TEST_USER)).toEqual([]);
+  });
+
+  it('returns empty array when userId is undefined (graceful degradation)', () => {
+    expect(getRecentProjects(undefined)).toEqual([]);
+  });
+
+  it('stores and retrieves a project', () => {
+    addRecentProject(TEST_USER, { projectId: 'p1', projectName: 'Project A' });
+    const list = getRecentProjects(TEST_USER);
+    expect(list.length).toBe(1);
+    expect(list[0].projectId).toBe('p1');
+    expect(list[0].projectName).toBe('Project A');
+    expect(list[0].usedAt).toBeTruthy();
+  });
+
+  it('deduplicates and moves to top on repeat use', () => {
+    addRecentProject(TEST_USER, { projectId: 'p1', projectName: 'A' });
+    addRecentProject(TEST_USER, { projectId: 'p2', projectName: 'B' });
+    addRecentProject(TEST_USER, { projectId: 'p1', projectName: 'A' });
+
+    const list = getRecentProjects(TEST_USER);
+    expect(list.length).toBe(2);
+    expect(list[0].projectId).toBe('p1'); // p1 moved to top
+    expect(list[1].projectId).toBe('p2');
+  });
+
+  it('truncates to 5 items', () => {
+    for (let i = 0; i < 15; i++) {
+      addRecentProject(TEST_USER, { projectId: `p${i}`, projectName: `Project ${i}` });
+    }
+    const list = getRecentProjects(TEST_USER);
+    expect(list.length).toBe(5);
+    // Most recent should be p14
+    expect(list[0].projectId).toBe('p14');
+    expect(list[4].projectId).toBe('p10');
+  });
+
+  it('does not write when userId is undefined', () => {
+    addRecentProject(undefined, { projectId: 'p1', projectName: 'A' });
+    // jsdom localStorage.length may return undefined after clear(); check no key was written
+    expect(getRecentProjects(undefined)).toEqual([]);
+  });
+
+  it('isolates data between users', () => {
+    addRecentProject('user-a', { projectId: 'p1', projectName: 'A' });
+    addRecentProject('user-b', { projectId: 'p2', projectName: 'B' });
+
+    const listA = getRecentProjects('user-a');
+    const listB = getRecentProjects('user-b');
+    expect(listA.length).toBe(1);
+    expect(listA[0].projectId).toBe('p1');
+    expect(listB.length).toBe(1);
+    expect(listB[0].projectId).toBe('p2');
+  });
+
+  it('handles corrupted localStorage gracefully', () => {
+    localStorage.setItem(`satime:recent-projects:${TEST_USER}`, 'not-json');
+    expect(getRecentProjects(TEST_USER)).toEqual([]);
+  });
+});
+
+describe('filterValidRecentProjects', () => {
+  it('filters out projects not in valid set', () => {
+    const recent: RecentProject[] = [
+      { projectId: 'p1', projectName: 'A', usedAt: new Date().toISOString() },
+      { projectId: 'p2', projectName: 'B', usedAt: new Date().toISOString() },
+      { projectId: 'p3', projectName: 'C', usedAt: new Date().toISOString() },
+    ];
+    const validIds = new Set(['p1', 'p3']);
+    const filtered = filterValidRecentProjects(recent, validIds);
+    expect(filtered.length).toBe(2);
+    expect(filtered.map((r) => r.projectId)).toEqual(['p1', 'p3']);
+  });
+});
+
+describe('Recent Task Options', () => {
+  it('returns empty array when no data stored', () => {
+    expect(getRecentTaskOptions(TEST_USER)).toEqual([]);
+  });
+
+  it('stores and retrieves a task option', () => {
+    addRecentTaskOption(TEST_USER, {
+      taskOptionId: 't1',
+      taskLabel: 'Design',
+      taskGroupName: 'Creative',
+    });
+    const list = getRecentTaskOptions(TEST_USER);
+    expect(list.length).toBe(1);
+    expect(list[0].taskOptionId).toBe('t1');
+    expect(list[0].taskLabel).toBe('Design');
+    expect(list[0].taskGroupName).toBe('Creative');
+  });
+
+  it('deduplicates and moves to top on repeat use', () => {
+    addRecentTaskOption(TEST_USER, { taskOptionId: 't1', taskLabel: 'A', taskGroupName: null });
+    addRecentTaskOption(TEST_USER, { taskOptionId: 't2', taskLabel: 'B', taskGroupName: null });
+    addRecentTaskOption(TEST_USER, { taskOptionId: 't1', taskLabel: 'A', taskGroupName: null });
+
+    const list = getRecentTaskOptions(TEST_USER);
+    expect(list.length).toBe(2);
+    expect(list[0].taskOptionId).toBe('t1');
+  });
+
+  it('truncates to 5 items', () => {
+    for (let i = 0; i < 12; i++) {
+      addRecentTaskOption(TEST_USER, { taskOptionId: `t${i}`, taskLabel: `Task ${i}`, taskGroupName: null });
+    }
+    const list = getRecentTaskOptions(TEST_USER);
+    expect(list.length).toBe(5);
+    expect(list[0].taskOptionId).toBe('t11');
+    expect(list[4].taskOptionId).toBe('t7');
+  });
+});
+
+describe('filterValidRecentTaskOptions', () => {
+  it('filters out tasks not in valid set', () => {
+    const recent: RecentTaskOption[] = [
+      { taskOptionId: 't1', taskLabel: 'A', taskGroupName: null, usedAt: new Date().toISOString() },
+      { taskOptionId: 't2', taskLabel: 'B', taskGroupName: 'G', usedAt: new Date().toISOString() },
+    ];
+    const validIds = new Set(['t2']);
+    const filtered = filterValidRecentTaskOptions(recent, validIds);
+    expect(filtered.length).toBe(1);
+    expect(filtered[0].taskOptionId).toBe('t2');
+  });
+});

--- a/src/utils/recentSelections.ts
+++ b/src/utils/recentSelections.ts
@@ -1,0 +1,124 @@
+/**
+ * recentSelections.ts — 最近使用工具函数
+ *
+ * 双 LRU 列表：最近项目、最近任务模板
+ * 存储在 localStorage，按用户维度隔离
+ * 每类最多保留 5 条
+ */
+
+// ===== 类型定义 =====
+
+export type RecentProject = {
+  projectId: string;
+  projectName: string;
+  usedAt: string; // ISO string
+};
+
+export type RecentTaskOption = {
+  taskOptionId: string;
+  taskLabel: string;
+  taskGroupName: string | null;
+  usedAt: string; // ISO string
+};
+
+const MAX_RECENT = 5;
+
+// ===== 通用存取 =====
+
+function getStorageKey(prefix: string, userId: string | undefined): string | null {
+  if (!userId) return null;
+  return `${prefix}:${userId}`;
+}
+
+function readList<T>(key: string | null): T[] {
+  if (!key) return [];
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeList<T>(key: string | null, list: T[]): void {
+  if (!key) return;
+  try {
+    localStorage.setItem(key, JSON.stringify(list));
+  } catch {
+    // localStorage 写入失败时静默降级
+  }
+}
+
+// ===== 最近项目 =====
+
+const PROJECT_PREFIX = 'satime:recent-projects';
+
+export function getRecentProjects(userId: string | undefined): RecentProject[] {
+  const key = getStorageKey(PROJECT_PREFIX, userId);
+  return readList<RecentProject>(key);
+}
+
+/**
+ * 记录一次项目使用。去重、置顶、截断至 MAX_RECENT。
+ */
+export function addRecentProject(userId: string | undefined, project: Omit<RecentProject, 'usedAt'>): void {
+  const key = getStorageKey(PROJECT_PREFIX, userId);
+  if (!key) return;
+
+  const list = readList<RecentProject>(key);
+  const filtered = list.filter((item) => item.projectId !== project.projectId);
+  const newEntry: RecentProject = {
+    ...project,
+    usedAt: new Date().toISOString(),
+  };
+  const updated = [newEntry, ...filtered].slice(0, MAX_RECENT);
+  writeList(key, updated);
+}
+
+/**
+ * 过滤掉已不在有效列表中的项目（被停用/删除）。
+ */
+export function filterValidRecentProjects(
+  recent: RecentProject[],
+  validIds: Set<string>
+): RecentProject[] {
+  return recent.filter((item) => validIds.has(item.projectId));
+}
+
+// ===== 最近任务模板 =====
+
+const TASK_PREFIX = 'satime:recent-task-options';
+
+export function getRecentTaskOptions(userId: string | undefined): RecentTaskOption[] {
+  const key = getStorageKey(TASK_PREFIX, userId);
+  return readList<RecentTaskOption>(key);
+}
+
+/**
+ * 记录一次任务模板使用。去重、置顶、截断至 MAX_RECENT。
+ */
+export function addRecentTaskOption(userId: string | undefined, task: Omit<RecentTaskOption, 'usedAt'>): void {
+  const key = getStorageKey(TASK_PREFIX, userId);
+  if (!key) return;
+
+  const list = readList<RecentTaskOption>(key);
+  const filtered = list.filter((item) => item.taskOptionId !== task.taskOptionId);
+  const newEntry: RecentTaskOption = {
+    ...task,
+    usedAt: new Date().toISOString(),
+  };
+  const updated = [newEntry, ...filtered].slice(0, MAX_RECENT);
+  writeList(key, updated);
+}
+
+/**
+ * 过滤掉已不在有效列表中的任务模板（被停用/删除）。
+ */
+export function filterValidRecentTaskOptions(
+  recent: RecentTaskOption[],
+  validIds: Set<string>
+): RecentTaskOption[] {
+  return recent.filter((item) => validIds.has(item.taskOptionId));
+}

--- a/supabase/migrations_draft_time_tracker/018_time_tracker_auto_time_full_loop.sql
+++ b/supabase/migrations_draft_time_tracker/018_time_tracker_auto_time_full_loop.sql
@@ -1,0 +1,147 @@
+-- Auto-time full-loop support:
+-- 1. allow parser statuses for auto project creation and conflict/reject states
+-- 2. persist automatic project/root/rebuild audit actions
+-- 3. persist daily health reports for operational review
+
+ALTER TABLE time_tracker.auto_time_run_items
+  DROP CONSTRAINT IF EXISTS auto_time_run_items_resolution_status_check;
+
+ALTER TABLE time_tracker.auto_time_run_items
+  ADD CONSTRAINT auto_time_run_items_resolution_status_check
+  CHECK (
+    resolution_status IN (
+      'accepted',
+      'manual_override_skipped',
+      'policy_guard_skipped'
+    )
+  );
+
+ALTER TABLE time_tracker.auto_time_project_root_candidates
+  DROP CONSTRAINT IF EXISTS auto_time_project_root_candidates_candidate_status_check;
+
+ALTER TABLE time_tracker.auto_time_project_root_candidates
+  ADD CONSTRAINT auto_time_project_root_candidates_candidate_status_check
+  CHECK (
+    candidate_status IN (
+      'auto_inserted',
+      'auto_project_created',
+      'auto_root_inserted',
+      'rebuild_queued',
+      'rebuild_completed',
+      'pending_review',
+      'missing_project_master',
+      'rejected',
+      'rejected_by_rule',
+      'conflict_needs_manual_fix',
+      'failed'
+    )
+  );
+
+CREATE TABLE IF NOT EXISTS time_tracker.auto_time_project_actions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES time_tracker.organizations(id) ON DELETE CASCADE,
+  target_work_date date NOT NULL,
+  candidate_root_path text NOT NULL,
+  parsed_project_code text,
+  parsed_project_name text,
+  action_type text NOT NULL CHECK (
+    action_type IN (
+      'auto_create_project',
+      'auto_insert_root',
+      'queue_rebuild',
+      'complete_rebuild',
+      'reject_candidate',
+      'conflict_candidate',
+      'fail_candidate'
+    )
+  ),
+  action_status text NOT NULL CHECK (
+    action_status IN ('completed', 'skipped', 'failed')
+  ),
+  project_id uuid REFERENCES time_tracker.projects(id) ON DELETE SET NULL,
+  project_root_id uuid REFERENCES time_tracker.project_nas_roots(id) ON DELETE SET NULL,
+  run_id uuid REFERENCES time_tracker.auto_time_runs(id) ON DELETE SET NULL,
+  rebuild_target_work_date date,
+  reason text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS tt_auto_time_project_actions_org_date_idx
+  ON time_tracker.auto_time_project_actions (org_id, target_work_date DESC);
+
+CREATE INDEX IF NOT EXISTS tt_auto_time_project_actions_action_idx
+  ON time_tracker.auto_time_project_actions (action_type, action_status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS tt_auto_time_project_actions_project_idx
+  ON time_tracker.auto_time_project_actions (project_id)
+  WHERE project_id IS NOT NULL;
+
+ALTER TABLE time_tracker.auto_time_project_actions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tt_auto_time_project_actions_select ON time_tracker.auto_time_project_actions;
+CREATE POLICY tt_auto_time_project_actions_select
+ON time_tracker.auto_time_project_actions
+FOR SELECT
+USING (time_tracker.is_org_member(org_id));
+
+DROP POLICY IF EXISTS tt_auto_time_project_actions_write ON time_tracker.auto_time_project_actions;
+CREATE POLICY tt_auto_time_project_actions_write
+ON time_tracker.auto_time_project_actions
+FOR ALL
+USING (time_tracker.has_org_role(org_id, ARRAY['owner', 'admin', 'project_manager', 'hr']))
+WITH CHECK (time_tracker.has_org_role(org_id, ARRAY['owner', 'admin', 'project_manager', 'hr']));
+
+COMMENT ON TABLE time_tracker.auto_time_project_actions IS
+'Audit trail for automatic project creation, root insertion, rebuild queueing and exception decisions in the NAS auto-time full loop.';
+
+CREATE TABLE IF NOT EXISTS time_tracker.auto_time_daily_health_reports (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id uuid NOT NULL REFERENCES time_tracker.organizations(id) ON DELETE CASCADE,
+  target_work_date date NOT NULL,
+  run_id uuid REFERENCES time_tracker.auto_time_runs(id) ON DELETE SET NULL,
+  parser_started_at timestamptz,
+  parser_finished_at timestamptz,
+  runner_started_at timestamptz,
+  runner_finished_at timestamptz,
+  status text NOT NULL CHECK (
+    status IN ('completed', 'completed_with_anomalies', 'failed')
+  ),
+  total_logs_scanned integer NOT NULL DEFAULT 0,
+  total_logs_accepted integer NOT NULL DEFAULT 0,
+  total_projects_auto_created integer NOT NULL DEFAULT 0,
+  total_roots_auto_inserted integer NOT NULL DEFAULT 0,
+  total_rebuild_dates_queued integer NOT NULL DEFAULT 0,
+  total_rebuild_dates_completed integer NOT NULL DEFAULT 0,
+  total_tasks_written integer NOT NULL DEFAULT 0,
+  total_zero_project_users integer NOT NULL DEFAULT 0,
+  total_high_unattributed_users integer NOT NULL DEFAULT 0,
+  total_conflict_candidates integer NOT NULL DEFAULT 0,
+  total_rejected_candidates integer NOT NULL DEFAULT 0,
+  summary jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS tt_auto_time_daily_health_reports_org_date_idx
+  ON time_tracker.auto_time_daily_health_reports (org_id, target_work_date DESC, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS tt_auto_time_daily_health_reports_status_idx
+  ON time_tracker.auto_time_daily_health_reports (status, target_work_date DESC);
+
+ALTER TABLE time_tracker.auto_time_daily_health_reports ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tt_auto_time_daily_health_reports_select ON time_tracker.auto_time_daily_health_reports;
+CREATE POLICY tt_auto_time_daily_health_reports_select
+ON time_tracker.auto_time_daily_health_reports
+FOR SELECT
+USING (time_tracker.is_org_member(org_id));
+
+DROP POLICY IF EXISTS tt_auto_time_daily_health_reports_write ON time_tracker.auto_time_daily_health_reports;
+CREATE POLICY tt_auto_time_daily_health_reports_write
+ON time_tracker.auto_time_daily_health_reports
+FOR ALL
+USING (time_tracker.has_org_role(org_id, ARRAY['owner', 'admin', 'project_manager', 'hr']))
+WITH CHECK (time_tracker.has_org_role(org_id, ARRAY['owner', 'admin', 'project_manager', 'hr']));
+
+COMMENT ON TABLE time_tracker.auto_time_daily_health_reports IS
+'Daily operational health reports produced by the NAS auto-time full-loop worker.';

--- a/vitest.auto-time.config.ts
+++ b/vitest.auto-time.config.ts
@@ -1,0 +1,16 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	resolve: {
+		alias: {
+			"@": path.resolve(__dirname, "./src")
+		}
+	},
+	test: {
+		globals: true,
+		environment: "node",
+		include: ["src/autoTime/**/*.test.ts"],
+		passWithNoTests: true
+	}
+});


### PR DESCRIPTION
## Summary
- Add the NAS auto-time full loop worker that creates active projects, inserts NAS root mappings, rebuilds affected work dates, and writes health reports.
- Add audit and health report persistence for automatic project/root actions.
- Add focused Vitest coverage for parser, runner rebuild mode, health report generation, and full-loop orchestration.

## Validation
- `TMPDIR=/mnt/f/SA-TIME/tmp/vitest-tmp TEMP=/mnt/f/SA-TIME/tmp/vitest-tmp TMP=/mnt/f/SA-TIME/tmp/vitest-tmp npm run test -- --run src/autoTime` -> 6 files, 32 tests passed.
- `git diff --cached --check` passed before commit.
- Production worker was deployed and verified manually; 2026-04-23 health report shows 6 projects created, 6 roots inserted, 6 rebuild dates completed, and 115 NAS auto tasks written.
