### PR TITLE
feat: expose tone prompt descriptions in Report UI

### DIFF
--- a/src/pages/Report.tsx
+++ b/src/pages/Report.tsx
@@ -9,7 +9,8 @@ import {
   ClipboardCopyIcon,
   CheckIcon,
   ReloadIcon,
-  FileTextIcon
+  FileTextIcon,
+  InfoCircledIcon
 } from '@radix-ui/react-icons';
 import { CalendarCheck } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -32,7 +33,9 @@ import {
   formatDuration,
   serializeWeekForPrompt,
   WeekGroup,
-  ReportTone
+  ReportTone,
+  TONE_INSTRUCTIONS,
+  getToneSystemPrompt
 } from '@/utils/reportUtils';
 import { useReportSummary } from '@/hooks/useReportSummary';
 import { useTimeTracking } from '@/hooks/useTimeTracking';
@@ -117,7 +120,7 @@ function WeekPreview({ week }: { week: WeekGroup }) {
 // Tone Selector
 // ---------------------------------------------------------------------------
 
-const TONE_DESCRIPTIONS: Record<ReportTone, string> = {
+const TONE_LABELS: Record<ReportTone, string> = {
   standup: 'Team update or async standup',
   client: 'Client or stakeholder facing',
   retrospective: 'Personal weekly reflection'
@@ -132,9 +135,32 @@ function ToneSelector({
 }) {
   return (
     <div className="space-y-2">
-      <Label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-        Tone
-      </Label>
+      <div className="flex items-center justify-between">
+        <Label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Tone
+        </Label>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-5 w-5 text-muted-foreground hover:text-foreground"
+              aria-label="View full system prompt for this tone"
+            >
+              <InfoCircledIcon className="h-3.5 w-3.5" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-96 space-y-3" align="end">
+            <div>
+              <p className="text-sm font-medium capitalize">{value} prompt</p>
+              <p className="text-xs text-muted-foreground mt-0.5">{TONE_LABELS[value]}</p>
+            </div>
+            <pre className="text-[11px] leading-relaxed whitespace-pre-wrap bg-muted/30 rounded-md p-3 max-h-[280px] overflow-y-auto font-mono">
+              {getToneSystemPrompt(value)}
+            </pre>
+          </PopoverContent>
+        </Popover>
+      </div>
       <Tabs value={value} onValueChange={v => onChange(v as ReportTone)}>
         <TabsList className="w-full h-auto p-1 grid grid-cols-3">
           {(['standup', 'client', 'retrospective'] as ReportTone[]).map(
@@ -150,7 +176,7 @@ function ToneSelector({
           )}
         </TabsList>
       </Tabs>
-      <p className="text-xs text-muted-foreground">{TONE_DESCRIPTIONS[value]}</p>
+      <p className="text-xs text-muted-foreground">{TONE_INSTRUCTIONS[value]}</p>
     </div>
   );
 }

--- a/src/utils/reportUtils.ts
+++ b/src/utils/reportUtils.ts
@@ -321,7 +321,7 @@ export function serializeWeekForPrompt(week: WeekGroup, todos?: TodoItem[]): str
 // Prompt builder
 // ---------------------------------------------------------------------------
 
-const TONE_INSTRUCTIONS: Record<ReportTone, string> = {
+export const TONE_INSTRUCTIONS: Record<ReportTone, string> = {
   standup:
     'Write in a concise first-person style suitable for a weekly team standup or async update. Focus on what was accomplished and any notable shifts in focus.',
   client:
@@ -331,15 +331,11 @@ const TONE_INSTRUCTIONS: Record<ReportTone, string> = {
 };
 
 /**
- * Builds the full prompt to send to the Anthropic API.
- * Returns a messages array ready for the /v1/messages endpoint.
+ * Returns the static system prompt template for a given tone.
+ * Does not include week data — useful for displaying the prompt in the UI.
  */
-export function buildSummaryPrompt(
-  week: WeekGroup,
-  tone: ReportTone = 'standup',
-  todos?: TodoItem[]
-): { system: string; userMessage: string } {
-  const system = `You are a professional writing assistant that creates concise weekly work summaries from time tracking data.
+export function getToneSystemPrompt(tone: ReportTone): string {
+  return `You are a professional writing assistant that creates concise weekly work summaries from time tracking data.
 
 Your summaries are:
 - 3 to 5 sentences in length
@@ -351,6 +347,19 @@ Your summaries are:
 ${TONE_INSTRUCTIONS[tone]}
 
 Omit breaks, lunch, and any purely administrative tasks. If multiple days covered the same project or theme, synthesize them into a single coherent statement rather than repeating.`;
+
+}
+
+/**
+ * Builds the full prompt to send to the Anthropic API.
+ * Returns a messages array ready for the /v1/messages endpoint.
+ */
+export function buildSummaryPrompt(
+  week: WeekGroup,
+  tone: ReportTone = 'standup',
+  todos?: TodoItem[]
+): { system: string; userMessage: string } {
+  const system = getToneSystemPrompt(tone);
 
   const userMessage = `Please summarize the following work week:\n\n${serializeWeekForPrompt(week, todos)}`;
 


### PR DESCRIPTION
- [x] Export `TONE_INSTRUCTIONS` from `reportUtils.ts`
- [x] Add `getToneSystemPrompt(tone)` export to `reportUtils.ts`
- [x] Refactor `buildSummaryPrompt` to reuse `getToneSystemPrompt` internally
- [x] Update `ToneSelector` to show full `TONE_INSTRUCTIONS[value]` description beneath tone tabs
- [x] Add info icon (ⓘ) button that opens a popover with the full system prompt
- [x] Rebased onto `origin/main` (v0.35.7); accidental package-lock revert commit dropped (no longer needed)