### PR TITLE
fix: align StartDayDialog onStartDay prop signature with caller

### DIFF
--- a/src/components/StartDayDialog.tsx
+++ b/src/components/StartDayDialog.tsx
@@ -16,7 +16,7 @@ import { Calendar, Clock } from 'lucide-react';
 interface StartDayDialogProps {
   isOpen: boolean;
   onClose: () => void;
-  onStartDay: (date: Date, time: string) => void;
+  onStartDay: (date: Date) => void;
 }
 
 // Helper functions
@@ -57,7 +57,7 @@ export const StartDayDialog: React.FC<StartDayDialogProps> = ({
     const [hours, minutes] = selectedTime.split(':').map(Number);
 
     const startDateTime = new Date(year, month - 1, day, hours, minutes, 0, 0);
-    onStartDay(startDateTime, selectedTime);
+    onStartDay(startDateTime);
     onClose();
   };
 


### PR DESCRIPTION
The dialog's `onStartDay` prop was typed as `(date: Date, time: string) => void` and called with two arguments, but the handler in `Index.tsx` only accepts `(date: Date)`. The `time: string` param is redundant since the hours and minutes are already encoded in the `Date` object constructed inside the dialog. Fix removes the second parameter from the interface and the call site. No changes needed in `Index.tsx`.