### PR TITLE
fix(ios): persist tasks immediately to prevent data loss on app close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed iOS task data loss where tasks entered during a session were not present after closing the app
+  — `src/contexts/TimeTrackingContext.tsx` (React batches `setState` calls asynchronously, so `saveImmediately()` was reading a stale `latestStateRef` that did not yet include the newly added task; all mutation functions — `startDay`, `startNewTask`, `endDay`, `updateTask`, `deleteTask` — now compute state synchronously and call `dataService.saveCurrentDay()` directly with the correct snapshot; `updateTask` and `deleteTask` were not persisting at all previously; added `visibilitychange` listener as a synchronous `localStorage` backup for iOS app backgrounding since `beforeunload` does not fire reliably in Capacitor/WKWebView; fixed the existing `beforeunload` backup which was missing `_v: SCHEMA_VERSION`, causing it to be discarded on next load by the schema version check in `getCurrentDay()`)
+
 - Reverted Xcode project filename from `TimeTrackerPro.xcodeproj` back to `App.xcodeproj`
   — `ios/App/App.xcodeproj/` (Capacitor CLI hardcodes `App.xcodeproj`; renaming it broke `npm run sync:ios` with ENOENT on `project.pbxproj`; the Xcode target/product name remains "TimeTrackerPro")
 - Fixed `open:ios` npm script pointing to the old renamed project path

--- a/README-EXT.md
+++ b/README-EXT.md
@@ -176,11 +176,12 @@ Task descriptions support **GitHub Flavored Markdown (GFM)**:
 
 ### How Data Storage Works
 
-Timetraked uses a **manual sync** approach optimized for single-device usage:
+Timetraked uses an **action-triggered save** approach optimized for single-device usage:
 
 1. **In-Memory First** — changes update React state immediately.
-2. **Critical Event Saves** — data persists only on day end, window close, or manual sync.
-3. **No Auto-Save** — prevents unnecessary API calls and rate limiting.
+2. **Action Saves** — every task mutation (start, update, delete) and day lifecycle event (start day, end day) triggers an immediate `saveCurrentDay()` call with the freshly computed state, keeping localStorage and Supabase in sync without a debounce delay.
+3. **Emergency Backups** — `visibilitychange` (iOS app backgrounding) and `beforeunload` (browser close) write a synchronous localStorage snapshot as a last-resort fallback before JavaScript execution is suspended.
+4. **Manual Sync** — the sync button in the navigation saves all data types (tasks, projects, categories, archived days, todos) in one batch, useful after recovering from an error.
 
 When you sign in, your `localStorage` data automatically migrates to Supabase (timestamps compared to prevent overwriting newer data, no data loss). When you sign out, Supabase data syncs back to `localStorage`.
 
@@ -294,7 +295,7 @@ DataService.save()
 localStorage OR Supabase
 ```
 
-**Critical save events:** day end (`postDay()`), window close (`beforeunload`), manual sync (`forceSyncToDatabase()`).
+**Save triggers:** every task mutation and day lifecycle event calls `dataService.saveCurrentDay()` directly; `postDay()` additionally saves archived days and todos; `visibilitychange` and `beforeunload` write synchronous localStorage backups; `forceSyncToDatabase()` (manual sync) saves all data types in parallel.
 
 **Service Worker caching:**
 

--- a/src/contexts/TimeTrackingContext.tsx
+++ b/src/contexts/TimeTrackingContext.tsx
@@ -535,6 +535,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
 
     if (dataService) {
       dataService.saveCurrentDay({ isDayStarted: true, dayStartTime: roundedTime, currentTask: null, tasks })
+        .then(() => setLastSyncTime(new Date()))
         .catch(error => console.error("❌ Error saving after starting day:", error));
     }
   };
@@ -556,6 +557,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     // Save with freshly computed state to avoid reading from stale latestStateRef
     if (dataService) {
       dataService.saveCurrentDay({ isDayStarted: false, dayStartTime, currentTask: null, tasks: finalTasks })
+        .then(() => setLastSyncTime(new Date()))
         .catch(error => {
           console.error("❌ Error saving state after ending day:", error);
           toast({
@@ -611,6 +613,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     // Save with freshly computed state to avoid reading from stale latestStateRef
     if (dataService) {
       dataService.saveCurrentDay({ isDayStarted, dayStartTime, currentTask: newTask, tasks: updatedTasks })
+        .then(() => setLastSyncTime(new Date()))
         .catch(error => console.error("❌ Error saving after starting task:", error));
     }
   };
@@ -625,6 +628,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     setHasUnsavedChanges(true);
     if (dataService) {
       dataService.saveCurrentDay({ isDayStarted, dayStartTime, currentTask: updatedCurrentTask ?? null, tasks: updatedTasks })
+        .then(() => setLastSyncTime(new Date()))
         .catch(error => console.error("❌ Error saving after updating task:", error));
     }
   };
@@ -639,6 +643,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     setHasUnsavedChanges(true);
     if (dataService) {
       dataService.saveCurrentDay({ isDayStarted, dayStartTime, currentTask: updatedCurrentTask, tasks: updatedTasks })
+        .then(() => setLastSyncTime(new Date()))
         .catch(error => console.error("❌ Error saving after deleting task:", error));
     }
   };

--- a/src/contexts/TimeTrackingContext.tsx
+++ b/src/contexts/TimeTrackingContext.tsx
@@ -26,6 +26,7 @@ import {
   parseCSVImport
 } from '@/utils/exportUtils';
 import { parseTaskChecklist } from '@/utils/checklistUtils';
+import { SCHEMA_VERSION } from '@/services/localStorageService';
 
 export interface Task {
   id: string;
@@ -468,7 +469,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
       try {
         localStorage.setItem(
           STORAGE_KEYS.CURRENT_DAY,
-          JSON.stringify({ isDayStarted, dayStartTime, tasks, currentTask })
+          JSON.stringify({ isDayStarted, dayStartTime, tasks, currentTask, _v: SCHEMA_VERSION })
         );
       } catch {
         // localStorage unavailable (quota exceeded, private mode); best effort only.
@@ -478,6 +479,27 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [dataService, isDayStarted, tasks, currentTask, dayStartTime]);
+
+  // iOS/Capacitor apps don't reliably fire beforeunload when backgrounded or killed.
+  // visibilitychange fires when the app is suspended, giving us a last chance to
+  // write a synchronous backup before JavaScript execution is frozen.
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "hidden") return;
+      if (!isDayStarted && tasks.length === 0) return;
+      try {
+        localStorage.setItem(
+          STORAGE_KEYS.CURRENT_DAY,
+          JSON.stringify({ isDayStarted, dayStartTime, tasks, currentTask, _v: SCHEMA_VERSION })
+        );
+      } catch {
+        // best effort
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [isDayStarted, dayStartTime, tasks, currentTask]);
 
   // Sync to backend when coming back online
   useEffect(() => {
@@ -510,36 +532,40 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     setIsDayStarted(true);
     setDayStartTime(roundedTime);
     setHasUnsavedChanges(true);
+
+    if (dataService) {
+      dataService.saveCurrentDay({ isDayStarted: true, dayStartTime: roundedTime, currentTask: null, tasks })
+        .catch(error => console.error("❌ Error saving after starting day:", error));
+    }
   };
 
   const endDay = () => {
-
+    let finalTasks = tasks;
     if (currentTask) {
-      // End the current task
-      const updatedTask = {
+      const endedTask = {
         ...currentTask,
         endTime: new Date(),
         duration: new Date().getTime() - currentTask.startTime.getTime()
       };
-      setTasks(prev =>
-        prev.map(t => (t.id === currentTask.id ? updatedTask : t))
-      );
+      finalTasks = tasks.map(t => (t.id === currentTask.id ? endedTask : t));
+      setTasks(finalTasks);
       setCurrentTask(null);
     }
     setIsDayStarted(false);
     setHasUnsavedChanges(true);
-    // Save immediately since this is a critical action
-    saveImmediately()
-      .then(() => {})
-      .catch(error => {
-        console.error('❌ Error saving state after ending day:', error);
-        toast({
-          title: 'Save Failed',
-          description: 'Your day was ended but the data could not be saved. Please use Manual Sync to retry.',
-          variant: 'destructive',
-          duration: 7000
+    // Save with freshly computed state to avoid reading from stale latestStateRef
+    if (dataService) {
+      dataService.saveCurrentDay({ isDayStarted: false, dayStartTime, currentTask: null, tasks: finalTasks })
+        .catch(error => {
+          console.error("❌ Error saving state after ending day:", error);
+          toast({
+            title: "Save Failed",
+            description: "Your day was ended but the data could not be saved. Please use Manual Sync to retry.",
+            variant: "destructive",
+            duration: 7000
+          });
         });
-      });
+    }
   };
 
   const startNewTask = (
@@ -551,16 +577,16 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
   ) => {
     const now = new Date();
 
-    // End current task if exists
+    // End current task if exists and compute the updated task list synchronously
+    let baseTasks = tasks;
     if (currentTask) {
-      const updatedTask = {
+      const endedTask = {
         ...currentTask,
         endTime: now,
         duration: now.getTime() - currentTask.startTime.getTime()
       };
-      setTasks(prev =>
-        prev.map(t => (t.id === currentTask.id ? updatedTask : t))
-      );
+      baseTasks = tasks.map(t => (t.id === currentTask.id ? endedTask : t));
+      setTasks(baseTasks);
     }
 
     // Determine start time: use dayStartTime for first task, otherwise use current time
@@ -578,29 +604,43 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
       category
     };
 
-    setTasks(prev => [...prev, newTask]);
+    const updatedTasks = [...baseTasks, newTask];
+    setTasks(updatedTasks);
     setCurrentTask(newTask);
     setHasUnsavedChanges(true);
-    // Save immediately since this is a critical action
-    saveImmediately();
+    // Save with freshly computed state to avoid reading from stale latestStateRef
+    if (dataService) {
+      dataService.saveCurrentDay({ isDayStarted, dayStartTime, currentTask: newTask, tasks: updatedTasks })
+        .catch(error => console.error("❌ Error saving after starting task:", error));
+    }
   };
 
   const updateTask = (taskId: string, updates: Partial<Task>) => {
-    setTasks(prev =>
-      prev.map(task => (task.id === taskId ? { ...task, ...updates } : task))
-    );
+    const updatedTasks = tasks.map(task => (task.id === taskId ? { ...task, ...updates } : task));
+    const updatedCurrentTask = currentTask?.id === taskId ? { ...currentTask, ...updates } : currentTask;
+    setTasks(updatedTasks);
     if (currentTask?.id === taskId) {
-      setCurrentTask(prev => (prev ? { ...prev, ...updates } : null));
+      setCurrentTask(updatedCurrentTask ?? null);
     }
     setHasUnsavedChanges(true);
+    if (dataService) {
+      dataService.saveCurrentDay({ isDayStarted, dayStartTime, currentTask: updatedCurrentTask ?? null, tasks: updatedTasks })
+        .catch(error => console.error("❌ Error saving after updating task:", error));
+    }
   };
 
   const deleteTask = (taskId: string) => {
-    setTasks(prev => prev.filter(task => task.id !== taskId));
+    const updatedTasks = tasks.filter(task => task.id !== taskId);
+    const updatedCurrentTask = currentTask?.id === taskId ? null : currentTask;
+    setTasks(updatedTasks);
     if (currentTask?.id === taskId) {
       setCurrentTask(null);
     }
     setHasUnsavedChanges(true);
+    if (dataService) {
+      dataService.saveCurrentDay({ isDayStarted, dayStartTime, currentTask: updatedCurrentTask, tasks: updatedTasks })
+        .catch(error => console.error("❌ Error saving after deleting task:", error));
+    }
   };
 
   const postDay = async (notes?: string) => {


### PR DESCRIPTION
React batches state updates, so latestStateRef.current is stale when saveImmediately() is called inside startNewTask/endDay — the save was capturing state from before the new task was appended. On iOS, before unload also does not fire reliably when the app is backgrounded or killed, so the synchronous fallback never ran either.

- startNewTask/endDay/updateTask/deleteTask now compute the new state synchronously and call dataService.saveCurrentDay() with it directly, bypassing the stale ref entirely
- startDay now persists isDayStarted/dayStartTime immediately
- Added visibility change listener: writes a synchronous localStorage backup whenever the app is hidden (fires on iOS Capacitor suspend)
- Fixed beforeunload backup to include _v: SCHEMA_VERSION so the schema check in getCurrentDay does not discard it on next load