### PR TITLE
chore: Update commit message to skip CI instead of CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No version changes to commit"
           else
-            git commit -m "chore: bump version to ${{ steps.new_version.outputs.version }} [skip cd]"
+            git commit -m "chore: bump version to ${{ steps.new_version.outputs.version }} [CI Skip]"
             git push
           fi
 


### PR DESCRIPTION
If this does not work, then will add it as a [prefix](https://developers.cloudflare.com/pages/configuration/git-integration/github-integration/#skipping-a-build-via-a-commit-message).