### PR TITLE
feat: Improve iOS experience to align with Apple HIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Dedicated Tasks page (`/tasks`) — task list, NewTaskForm, and End Day button moved out of the dashboard column into a standalone page; starting a day auto-navigates to `/tasks`; day summary displayed on the Tasks page after ending the day; dashboard shows a compact "Day In Progress" card with task count and a "View Tasks" link while a day is active
-  — `src/pages/TaskList.tsx` (new), `src/pages/Index.tsx`, `src/App.tsx`
+- Apple HIG compliance pass for the native iOS app
+  - **Bottom sheets** — `TaskEditDialog`, `StartDayDialog`, `ArchiveEditDialog`, and `DeleteConfirmationDialog` now render as swipe-to-dismiss vaul `Drawer` sheets on iOS (snap points tuned per dialog complexity) and fall back to the existing centered Radix `Dialog` on web. `DeleteConfirmationDialog` reverses button order on iOS (destructive action above Cancel) per UIAlertController convention.
+    — `src/components/ui/adaptive-dialog.tsx` (new), `src/components/ui/drawer.tsx`, `src/components/TaskEditDialog.tsx`, `src/components/StartDayDialog.tsx`, `src/components/ArchiveEditDialog.tsx`, `src/components/DeleteConfirmationDialog.tsx`
+  - **Haptic feedback** — `useHaptics` wraps `@capacitor/haptics`; light impact on tab switches and Edit, medium on Delete, heavy on destructive confirm, success notification on task creation and day archive, error notification on sync failure. No-op on web.
+    — `src/hooks/useHaptics.ts` (new), `src/components/MobileNav.tsx`, `src/components/TaskItem.tsx`, `src/components/DeleteConfirmationDialog.tsx`, `src/contexts/TimeTrackingContext.tsx`
+  - **App lifecycle persistence** — `useAppLifecycle` uses `@capacitor/app`'s `appStateChange` event (fires at the Swift layer before WKWebView freezes) instead of `visibilitychange` for the emergency localStorage backup, eliminating the race condition on rapid app backgrounding. Falls back to `visibilitychange` on web.
+    — `src/hooks/useAppLifecycle.ts` (new), `src/contexts/TimeTrackingContext.tsx`
+  - **Status bar theming** — `useStatusBar` syncs the iOS status bar text colour (white in dark mode, black in light mode) via `@capacitor/status-bar`; `apple-mobile-web-app-status-bar-style` updated to `black-translucent` so the web view extends behind the status bar region. No-op on web.
+    — `src/hooks/useStatusBar.ts` (new), `src/App.tsx`, `index.html`
+  - **iOS navigation header** — desktop `SiteNavigationMenu` is hidden on iOS builds and replaced with `IosPageHeader`: a sticky 17px SF-style title bar with safe-area-inset-top padding, back chevron, and right-side action slot. `ios-build` class added to `<body>` on iOS to prevent double-stacking of safe-area padding.
+    — `src/components/IosPageHeader.tsx` (new), `src/components/PageLayout.tsx`, `src/main.tsx`, `public/pwa.css`
+  - **Keyboard avoidance** — `@capacitor/keyboard` configured with `resize: body` so the viewport shrinks above the keyboard. `useKeyboardHeight` hook tracks keyboard height and applies it as `paddingBottom` on `DrawerContent` so form fields inside bottom sheets remain accessible. `scroll-margin-bottom: 24px` added for native scroll-into-view on input focus.
+    — `src/hooks/useKeyboardHeight.ts` (new), `capacitor.config.ts`, `src/components/ui/drawer.tsx`, `public/pwa.css`
+  - **Long-press context menus** — `useLongPress` fires a 500 ms hold callback; `TaskItem` wraps cards in a Radix `ContextMenu` (right-click on desktop, long-press on iOS) with Edit and Delete actions. Action buttons hidden on iOS builds where context menus serve as the primary affordance.
+    — `src/hooks/useLongPress.ts` (new), `src/components/TaskItem.tsx`
+  - **Page transition animations** — route changes in the iOS build play a subtle 280 ms slide-in from the right (`cubic-bezier(0.25, 0.46, 0.45, 0.94)`), scoped to `@supports (-webkit-touch-callout: none)` so the animation never runs on web.
+    — `src/App.tsx` (`AnimatedRoutes` component), `public/pwa.css`
+  - **New Capacitor plugins** installed: `@capacitor/app`, `@capacitor/haptics`, `@capacitor/status-bar`, `@capacitor/keyboard` (all v8.x, matching the existing core/ios versions).
+
+### Changed
+
+- **Touch targets** — `Button` `size="sm"` raised from `h-9` (36 px) to `h-10` (40 px); mobile CSS now enforces `min-height: 44px` on all non-hidden buttons at ≤768 px (previously commented out).
+  — `src/components/ui/button.tsx`, `public/pwa.css`
+- **Rubber-band scroll bounce** — `overscroll-behavior-y` restored to `auto` on `#root` inside the iOS `@supports` block so the native bounce animation works again (was `contain` globally which suppressed it). vaul drawer elements gain `overscroll-behavior: contain` + `touch-action: pan-y` to prevent scroll bleed through open sheets.
+  — `public/pwa.css`
+
+
 - Tasks navigation item added to desktop top nav and mobile bottom nav; mobile nav grid updated to support up to five items for authenticated users
   — `src/components/Navigation.tsx`, `src/components/MobileNav.tsx`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md - AI Assistant Codebase Guide
 
-**Last Updated:** 2026-04-26
-**Version:** 2.2.0
+**Last Updated:** 2026-05-14
+**Version:** 2.3.0
 
 Timetraked is a React 18 + TypeScript time tracking PWA for freelancers and consultants, with dual storage (localStorage guest mode and optional Supabase cloud sync). A native iOS app is also available via Capacitor.
 
@@ -31,7 +31,7 @@ After implementing changes, run lint and tests before considering a task complet
 | Forms        | React Hook Form + Zod                       |
 | Backend      | Supabase (optional) or localStorage         |
 | PWA          | Vite PWA Plugin + Workbox                   |
-| Native iOS   | Capacitor 8 (@capacitor/core + @capacitor/ios) |
+| Native iOS   | Capacitor 8 (@capacitor/core + @capacitor/ios + @capacitor/app + @capacitor/haptics + @capacitor/status-bar + @capacitor/keyboard) |
 | Testing      | Vitest + React Testing Library + Playwright |
 
 ---
@@ -70,8 +70,15 @@ export const MyComponent = () => {
 | `src/lib/supabase.ts`                  | Supabase client configuration and caching        |
 | `src/config/categories.ts`             | Default category definitions                     |
 | `src/config/projects.ts`               | Default project definitions                      |
-| `src/components/PageLayout.tsx`        | Shared page chrome (title + optional actions slot) |
-| `capacitor.config.ts`                  | Capacitor iOS configuration                      |
+| `src/components/PageLayout.tsx`        | Shared page chrome (title + optional actions slot); renders `IosPageHeader` on iOS |
+| `src/components/IosPageHeader.tsx`     | iOS-only sticky nav bar with safe-area-inset-top, back chevron, and action slot |
+| `src/components/ui/adaptive-dialog.tsx` | Renders vaul `Drawer` on iOS, Radix `Dialog` on web |
+| `src/hooks/useHaptics.ts`             | `@capacitor/haptics` wrapper (light/medium/heavy, success/error) |
+| `src/hooks/useStatusBar.ts`           | `@capacitor/status-bar` wrapper — syncs bar style with dark/light mode |
+| `src/hooks/useAppLifecycle.ts`        | `@capacitor/app` appStateChange hook for reliable background persistence |
+| `src/hooks/useKeyboardHeight.ts`      | `@capacitor/keyboard` reactive height for bottom-sheet form padding |
+| `src/hooks/useLongPress.ts`           | 500 ms hold detector for context menu trigger on touch |
+| `capacitor.config.ts`                  | Capacitor iOS configuration (Keyboard resize plugin configured here) |
 | `.env.ios`                             | iOS build env (VITE_IOS_BUILD=true, no Supabase) |
 
 ---
@@ -92,6 +99,23 @@ The app ships as both a PWA and a native iOS app via Capacitor 8.
 - Routing uses `HashRouter` (required — Capacitor loads from filesystem, not a server)
 - CSP includes `capacitor://localhost` for WKWebView asset loading
 - Data storage is localStorage-only (no Supabase keys in `.env.ios`)
+- Desktop `SiteNavigationMenu` is hidden; `IosPageHeader` renders instead (sticky, safe-area-aware, back chevron)
+- All edit/confirm dialogs (`TaskEditDialog`, `StartDayDialog`, `ArchiveEditDialog`, `DeleteConfirmationDialog`) become bottom sheets via `AdaptiveDialog`; on web the existing Radix Dialog renders unchanged
+- Haptic feedback fires on every meaningful interaction via `useHaptics`
+- `@capacitor/app` `appStateChange` event used for emergency data persistence (more reliable than `visibilitychange`)
+- `@capacitor/status-bar` syncs status bar text colour with system dark/light mode
+- `@capacitor/keyboard` configured with `resize: body`; `useKeyboardHeight` lifts bottom-sheet content above the keyboard
+- Long-press on task cards opens a context menu (Edit / Delete); on-card action buttons are hidden
+
+**Installed Capacitor plugins** (all v8.x):
+
+| Package | Purpose |
+| ------- | ------- |
+| `@capacitor/core` + `@capacitor/ios` | Core bridge (pre-existing) |
+| `@capacitor/app` | Native app lifecycle events (pause/resume) |
+| `@capacitor/haptics` | Tactile feedback |
+| `@capacitor/status-bar` | Status bar style control |
+| `@capacitor/keyboard` | Keyboard height events and viewport resize |
 
 **iOS npm scripts:**
 
@@ -114,6 +138,9 @@ When working on iOS/Capacitor projects, remember that `cap sync` overwrites Pack
 - Gate any web-only UI (PWA install, auth, sync) behind `import.meta.env.VITE_IOS_BUILD !== "true"`
 - Avoid `window.location.reload()` in iOS paths — use `window.location.replace()` to avoid interrupting the Capacitor JS bridge
 - Test localStorage-only flow (no Supabase) before marking iOS features complete
+- For new dialogs/modals: use `AdaptiveDialog` (`src/components/ui/adaptive-dialog.tsx`) instead of `Dialog` directly — it automatically renders a bottom sheet on iOS
+- Add haptic feedback for new interactions via `useHaptics` (`src/hooks/useHaptics.ts`): `lightImpact` for navigation/selection, `mediumImpact` for intent to delete, `heavyImpact` for confirmed destructive actions, `successNotify`/`errorNotify` for outcomes
+- All new Capacitor plugin calls should be gated with `Capacitor.isNativePlatform()` or imported dynamically (see existing hooks for the pattern) so the web build never fails at runtime on missing native APIs
 
 ---
 

--- a/README-EXT.md
+++ b/README-EXT.md
@@ -163,6 +163,21 @@ Task descriptions support **GitHub Flavored Markdown (GFM)**:
 
 **Native-Like Experience:** Standalone window, app icon, splash screen on launch.
 
+### iOS Native App (Capacitor)
+
+The Capacitor build (`VITE_IOS_BUILD=true`) includes additional Apple HIG enhancements that are inactive in the PWA:
+
+| Feature | Detail |
+| ------- | ------- |
+| **Bottom sheets** | All edit/confirm dialogs slide up as swipe-to-dismiss sheets instead of centered overlays |
+| **Haptic feedback** | Light impact on navigation taps, medium on destructive intent, success/error notifications on outcomes |
+| **Status bar theming** | Status bar text colour tracks light/dark mode; content extends behind the status bar via `black-translucent` |
+| **iOS navigation header** | Sticky 17 px title bar with safe-area-inset-top padding and back chevron replaces the desktop nav bar |
+| **Keyboard avoidance** | Viewport shrinks above the software keyboard; bottom sheet forms scroll above it automatically |
+| **Long-press context menus** | Hold a task card to reveal Edit / Delete without on-card buttons cluttering the layout |
+| **Page transitions** | Subtle 280 ms slide-in animation on route changes, matching the iOS push-navigation idiom |
+| **Rubber-band bounce** | Native scroll bounce restored on the main scroll container |
+
 ---
 
 ## Authentication & Storage
@@ -180,7 +195,7 @@ Timetraked uses an **action-triggered save** approach optimized for single-devic
 
 1. **In-Memory First** — changes update React state immediately.
 2. **Action Saves** — every task mutation (start, update, delete) and day lifecycle event (start day, end day) triggers an immediate `saveCurrentDay()` call with the freshly computed state, keeping localStorage and Supabase in sync without a debounce delay.
-3. **Emergency Backups** — `visibilitychange` (iOS app backgrounding) and `beforeunload` (browser close) write a synchronous localStorage snapshot as a last-resort fallback before JavaScript execution is suspended.
+3. **Emergency Backups** — on iOS, `@capacitor/app`'s `appStateChange` event fires at the Swift layer before WKWebView freezes, giving a reliable save window; on web, `visibilitychange` and `beforeunload` write a synchronous localStorage snapshot as a last-resort fallback before JavaScript execution is suspended.
 4. **Manual Sync** — the sync button in the navigation saves all data types (tasks, projects, categories, archived days, todos) in one batch, useful after recovering from an error.
 
 When you sign in, your `localStorage` data automatically migrates to Supabase (timestamps compared to prevent overwriting newer data, no data loss). When you sign out, Supabase data syncs back to `localStorage`.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Progressive Web App (PWA) for time tracking built with React, TypeScript, and 
 - **CSV Import** — bring in existing time data from other tools
 - **Weekly Report** — AI-generated work summaries (standup, client, or retrospective tone)
 - **No Account Required** — full functionality with local storage; optional cloud sync via Supabase
-- **PWA + Native iOS** — installable on desktop/mobile; distributed as a native iOS app via Capacitor 8
+- **PWA + Native iOS** — installable on desktop/mobile; distributed as a native iOS app via Capacitor 8 with Apple HIG-compliant bottom sheets, haptic feedback, status bar theming, keyboard avoidance, and native page transitions
 
 ---
 

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -26,7 +26,13 @@ const config: CapacitorConfig = {
   },
 
   plugins: {
-    // Placeholder — native plugin config goes here in Phase 4 (widget bridge)
+    Keyboard: {
+      // Shrink the body when the keyboard appears so fixed-bottom UI (MobileNav,
+      // bottom sheets) moves up with the keyboard automatically.
+      resize: 'body',
+      style: 'default',
+      resizeOnFullScreen: true
+    }
   }
 };
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 
     <!-- iOS Specific Meta Tags -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
     <!-- Microsoft Specific Meta Tags -->
     <meta name="msapplication-TileColor" content="#3b82f6" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,12 @@
       "name": "timetraked",
       "version": "0.45.0",
       "dependencies": {
+        "@capacitor/app": "^8.1.0",
         "@capacitor/core": "^8.3.1",
+        "@capacitor/haptics": "^8.0.2",
         "@capacitor/ios": "^8.3.1",
+        "@capacitor/keyboard": "^8.0.3",
+        "@capacitor/status-bar": "^8.0.2",
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -1722,6 +1726,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
+      "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/cli": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-8.3.1.tgz",
@@ -1764,6 +1777,15 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@capacitor/haptics": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/haptics/-/haptics-8.0.2.tgz",
+      "integrity": "sha512-c2hZzRR5Fk1tbTvhG1jhh2XBAf3EhnIerMIb2sl7Mt41Gxx1fhBJFDa0/BI1IbY4loVepyyuqNC9820/GZuoWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/ios": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.3.1.tgz",
@@ -1771,6 +1793,24 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.3.0"
+      }
+    },
+    "node_modules/@capacitor/keyboard": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/keyboard/-/keyboard-8.0.3.tgz",
+      "integrity": "sha512-27Bv5/2w1Ss2njguBgTS98O0Bb8DRJhAARyzXYib0JlT/n6BrJw/EZ0CokM4C8GFUjFDjJnEKF1Ie01buTMEXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-8.0.2.tgz",
+      "integrity": "sha512-WXs8YB8B9eEaPZz+bcdY6t2nForF1FLoj/JU0Dl9RRgQnddnS98FEEyDooQhaY7wivr000j4+SC1FyeJkrFO7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,12 @@
     "screenshots:headed": "playwright test screenshots.spec.ts --headed"
   },
   "dependencies": {
+    "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.3.1",
+    "@capacitor/haptics": "^8.0.2",
     "@capacitor/ios": "^8.3.1",
+    "@capacitor/keyboard": "^8.0.3",
+    "@capacitor/status-bar": "^8.0.2",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -81,6 +85,7 @@
     "@rollup/plugin-terser": ">=0.4.4"
   },
   "devDependencies": {
+    "@capacitor/cli": "^8.3.1",
     "@eslint/js": "^9.39.4",
     "@playwright/test": "^1.56.1",
     "@tailwindcss/typography": "^0.5.15",
@@ -88,7 +93,6 @@
     "@testing-library/react": "^14.3.1",
     "@types/node": "^22.19.17",
     "@types/react": "^18.3.28",
-    "@capacitor/cli": "^8.3.1",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react-swc": "^3.11.0",
     "autoprefixer": "^10.4.21",

--- a/public/pwa.css
+++ b/public/pwa.css
@@ -15,6 +15,12 @@ body {
   padding-right: var(--safe-area-inset-right);
 }
 
+/* IosPageHeader consumes the safe-area-inset-top itself via paddingTop inline style.
+   Prevent double-stacking when running as a Capacitor iOS build. */
+.ios-build body {
+  padding-top: 0;
+}
+
 /* Add padding bottom for mobile nav on mobile devices */
 /* Note: iOS-specific padding is handled in the iOS section below */
 @media (max-width: 768px) {
@@ -85,23 +91,24 @@ button,
   }
 }
 
-/* Pull-to-refresh prevention (optional, can be enabled if needed) */
+/* Prevent pull-to-refresh on non-iOS browsers */
 body {
   overscroll-behavior-y: contain;
 }
 
+/* Restore native rubber-band bounce on iOS — body is fixed/overflow:hidden there
+   so this applies to #root (the actual scroll container). */
+@supports (-webkit-touch-callout: none) {
+  #root {
+    overscroll-behavior-y: auto;
+  }
+}
+
 /* Improve button touch targets on mobile */
 @media (max-width: 768px) {
-  /* button:not(.icon-only) { */
-  /* min-height: 44px; */
-  /* min-width: 44px; */
-  /* padding: 0.75rem 1rem; */
-  /* } */
-
-  /* Larger tap targets for icon buttons */
-  button.icon-only {
-    min-width: 44px;
+  button:not([aria-hidden="true"]) {
     min-height: 44px;
+    min-width: 44px;
   }
 }
 
@@ -136,6 +143,15 @@ body {
   font-weight: 500;
   z-index: 9999;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+}
+
+/* Ensure focused inputs scroll into view above the keyboard with enough clearance */
+@supports (-webkit-touch-callout: none) {
+  input:focus,
+  textarea:focus,
+  select:focus {
+    scroll-margin-bottom: 24px;
+  }
 }
 
 /* iOS specific fixes */
@@ -194,6 +210,30 @@ body {
 
     #root {
       padding-bottom: calc(4rem + env(safe-area-inset-bottom, 0px));
+    }
+  }
+}
+
+/* Prevent scroll from leaking through open bottom sheets to the page beneath */
+[data-vaul-drawer] {
+  touch-action: pan-y;
+  overscroll-behavior: contain;
+}
+
+/* iOS page transition: subtle slide-in from the right on route change */
+@supports (-webkit-touch-callout: none) {
+  .page-transition-enter {
+    animation: iosSlideIn 280ms cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+  }
+
+  @keyframes iosSlideIn {
+    from {
+      transform: translateX(30px);
+      opacity: 0.8;
+    }
+    to {
+      transform: translateX(0);
+      opacity: 1;
     }
   }
 }

--- a/public/pwa.css
+++ b/public/pwa.css
@@ -25,7 +25,7 @@ body {
 /* Note: iOS-specific padding is handled in the iOS section below */
 @media (max-width: 768px) {
   body:not(.ios-device) {
-    padding-bottom: calc(4rem + var(--safe-area-inset-bottom));
+    padding-bottom: calc(3rem + var(--safe-area-inset-bottom));
   }
 }
 
@@ -223,7 +223,7 @@ body {
 /* Lift the floating action button above the mobile nav + home indicator on iOS */
 @supports (-webkit-touch-callout: none) {
   .fab-nav-offset {
-    bottom: calc(5rem + env(safe-area-inset-bottom, 0px)) !important;
+    bottom: calc(4rem + env(safe-area-inset-bottom, 0px)) !important;
   }
 }
 

--- a/public/pwa.css
+++ b/public/pwa.css
@@ -220,6 +220,13 @@ body {
   overscroll-behavior: contain;
 }
 
+/* Lift the floating action button above the mobile nav + home indicator on iOS */
+@supports (-webkit-touch-callout: none) {
+  .fab-nav-offset {
+    bottom: calc(5rem + env(safe-area-inset-bottom, 0px)) !important;
+  }
+}
+
 /* iOS page transition: subtle slide-in from the right on route change */
 @supports (-webkit-touch-callout: none) {
   .page-transition-enter {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,15 @@
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { HashRouter, Routes, Route, Navigate } from "react-router-dom";
+import { HashRouter, Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { OfflineProvider } from "@/contexts/OfflineContext";
 import { TimeTrackingProvider } from "@/contexts/TimeTrackingContext";
 import { useAuth } from "@/hooks/useAuth";
-import { Suspense, lazy } from "react";
+import { Suspense, lazy, useState, useEffect } from "react";
 import { InstallPrompt } from "@/components/InstallPrompt";
 import { UpdateNotification } from "@/components/UpdateNotification";
+import { useStatusBar } from "@/hooks/useStatusBar";
 
 const isIosBuild = import.meta.env.VITE_IOS_BUILD === "true";
 import { MobileNav } from "@/components/MobileNav";
@@ -38,26 +39,50 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
   return <>{children}</>;
 };
 
+const AppShell = () => {
+  const [isDark, setIsDark] = useState(
+    () => window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = (e: MediaQueryListEvent) => setIsDark(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+  useStatusBar(isDark);
+  return null;
+};
+
+const AnimatedRoutes = () => {
+  const location = useLocation();
+  return (
+    <div key={location.pathname} className={isIosBuild ? "page-transition-enter" : ""}>
+      <Routes>
+        <Route path="/" element={<Index />} />
+        <Route path="/tasks" element={<TaskList />} />
+        <Route path="/projectlist" element={<ProjectList />} />
+        <Route path="/categories" element={<Categories />} />
+        <Route path="/archive" element={<Archive />} />
+        <Route path="/settings" element={<Settings />} />
+        <Route path="/report" element={<ProtectedRoute><Report /></ProtectedRoute>} />
+        {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </div>
+  );
+};
+
 const App = () => (
   <OfflineProvider>
     <AuthProvider>
       <TimeTrackingProvider>
         <TooltipProvider>
+          <AppShell />
           <Toaster />
           <Sonner />
           <HashRouter>
             <Suspense fallback={<PageLoader />}>
-              <Routes>
-                <Route path="/" element={<Index />} />
-                <Route path="/tasks" element={<TaskList />} />
-                <Route path="/projectlist" element={<ProjectList />} />
-                <Route path="/categories" element={<Categories />} />
-                <Route path="/archive" element={<Archive />} />
-                <Route path="/settings" element={<Settings />} />
-                <Route path="/report" element={<ProtectedRoute><Report /></ProtectedRoute>} />
-                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-                <Route path="*" element={<NotFound />} />
-              </Routes>
+              <AnimatedRoutes />
               <MobileNav />
             </Suspense>
           </HashRouter>

--- a/src/components/ArchiveEditDialog.tsx
+++ b/src/components/ArchiveEditDialog.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from "react";
 import {
-	Dialog,
-	DialogContent,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
+	AdaptiveDialog,
+	AdaptiveDialogContent,
+	AdaptiveDialogHeader,
+	AdaptiveDialogTitle,
+} from "@/components/ui/adaptive-dialog";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -260,16 +260,16 @@ export const ArchiveEditDialog: React.FC<ArchiveEditDialogProps> = ({
 	};
 
 	return (
-		<Dialog open={isOpen} onOpenChange={onClose}>
-			<DialogContent className="max-w-[90dvw] max-h-[90dvh] overflow-y-auto">
-				<DialogHeader>
+		<AdaptiveDialog open={isOpen} onOpenChange={onClose} snapPoints={[0.85, 1]}>
+			<AdaptiveDialogContent className="max-w-[90dvw] max-h-[90dvh] overflow-y-auto">
+				<AdaptiveDialogHeader>
 					<div className="flex items-center justify-between">
-						<DialogTitle className="flex items-center space-x-2">
+						<AdaptiveDialogTitle className="flex items-center space-x-2">
 							<Calendar className="w-5 h-5 text-blue-600" />
 							<span>{formatDate(day.startTime)}</span>
-						</DialogTitle>
+						</AdaptiveDialogTitle>
 					</div>
-				</DialogHeader>
+				</AdaptiveDialogHeader>
 
 				<div className="space-y-6 overflow-x-hidden">
 					<div className="flex flex-wrap justify-center sm:justify-end items-center gap-3 my-4">
@@ -621,7 +621,7 @@ export const ArchiveEditDialog: React.FC<ArchiveEditDialogProps> = ({
 						</AlertDialogFooter>
 					</AlertDialogContent>
 				</AlertDialog>
-			</DialogContent>
-		</Dialog>
+			</AdaptiveDialogContent>
+		</AdaptiveDialog>
 	);
 };

--- a/src/components/DeleteConfirmationDialog.tsx
+++ b/src/components/DeleteConfirmationDialog.tsx
@@ -1,45 +1,91 @@
-import React from 'react';
+import React from "react";
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle
-} from '@/components/ui/alert-dialog';
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+	AdaptiveDialog,
+	AdaptiveDialogContent,
+	AdaptiveDialogHeader,
+	AdaptiveDialogTitle,
+	AdaptiveDialogDescription,
+	AdaptiveDialogFooter,
+} from "@/components/ui/adaptive-dialog";
+import { Button } from "@/components/ui/button";
+import { useHaptics } from "@/hooks/useHaptics";
+
+const isIosBuild = import.meta.env.VITE_IOS_BUILD === "true";
 
 interface DeleteConfirmationDialogProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onConfirm: () => void;
-  taskTitle: string;
+	isOpen: boolean;
+	onClose: () => void;
+	onConfirm: () => void;
+	taskTitle: string;
 }
 
 export const DeleteConfirmationDialog: React.FC<
-  DeleteConfirmationDialogProps
+	DeleteConfirmationDialogProps
 > = ({ isOpen, onClose, onConfirm, taskTitle }) => {
-  return (
-    <AlertDialog open={isOpen} onOpenChange={onClose}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete Task</AlertDialogTitle>
-          <AlertDialogDescription>
-            Are you sure you want to delete "{taskTitle}"? This action cannot be
-            undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel onClick={onClose}>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={onConfirm}
-            className="bg-red-600 hover:bg-red-700 text-white"
-          >
-            Delete
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  );
+	const { heavyImpact } = useHaptics();
+
+	if (isIosBuild) {
+		return (
+			<AdaptiveDialog open={isOpen} onOpenChange={onClose} snapPoints={[0.3]}>
+				<AdaptiveDialogContent>
+					<AdaptiveDialogHeader>
+						<AdaptiveDialogTitle>Delete Task</AdaptiveDialogTitle>
+						<AdaptiveDialogDescription>
+							Are you sure you want to delete &ldquo;{taskTitle}&rdquo;? This action cannot be
+							undone.
+						</AdaptiveDialogDescription>
+					</AdaptiveDialogHeader>
+					<AdaptiveDialogFooter>
+						{/* Destructive action first on iOS (action-sheet convention) */}
+						<Button
+							onClick={() => {
+								heavyImpact();
+								onConfirm();
+								onClose();
+							}}
+							className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+						>
+							Delete
+						</Button>
+						<Button variant="outline" onClick={onClose}>
+							Cancel
+						</Button>
+					</AdaptiveDialogFooter>
+				</AdaptiveDialogContent>
+			</AdaptiveDialog>
+		);
+	}
+
+	return (
+		<AlertDialog open={isOpen} onOpenChange={onClose}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>Delete Task</AlertDialogTitle>
+					<AlertDialogDescription>
+						Are you sure you want to delete &ldquo;{taskTitle}&rdquo;? This action cannot be
+						undone.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel onClick={onClose}>Cancel</AlertDialogCancel>
+					<AlertDialogAction
+						onClick={onConfirm}
+						className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+					>
+						Delete
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
 };

--- a/src/components/IosPageHeader.tsx
+++ b/src/components/IosPageHeader.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import { ChevronLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface IosPageHeaderProps {
+	title?: ReactNode;
+	actions?: ReactNode;
+	/** Show back chevron. Pass true to use history.back(), or a path string to navigate there. */
+	back?: boolean | string;
+}
+
+export const IosPageHeader = ({ title, actions, back }: IosPageHeaderProps) => {
+	const navigate = useNavigate();
+
+	const handleBack = () => {
+		if (typeof back === "string") {
+			navigate(back);
+		} else {
+			navigate(-1);
+		}
+	};
+
+	return (
+		<header
+			className="sticky top-0 z-30 flex items-center justify-between bg-background/95 backdrop-blur-md border-b border-border print:hidden"
+			style={{ paddingTop: "env(safe-area-inset-top)" }}
+		>
+			<div className="flex items-center h-11 px-2 w-full">
+				{back ? (
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={handleBack}
+						className="flex items-center gap-0.5 text-primary pl-1 pr-2 min-h-[44px]"
+						aria-label="Go back"
+					>
+						<ChevronLeft className="h-5 w-5" />
+						<span className="text-sm">Back</span>
+					</Button>
+				) : (
+					<div className="w-20" />
+				)}
+
+				{title && (
+					<h1 className="flex-1 text-center text-[17px] font-semibold text-foreground truncate px-2">
+						{title}
+					</h1>
+				)}
+
+				{actions ? (
+					<div className="flex items-center gap-1 w-20 justify-end pr-2">
+						{actions}
+					</div>
+				) : (
+					<div className="w-20" />
+				)}
+			</div>
+		</header>
+	);
+};

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -55,7 +55,7 @@ export const MobileNav = memo(function MobileNav() {
 				paddingBottom: "max(env(safe-area-inset-bottom, 0px), 0px)"
 			}}
 		>
-			<div className={`grid ${gridClass} h-16`}>
+			<div className={`grid ${gridClass} h-12`}>
 				{navItems.map(({ path, icon: Icon, label }) => (
 					<Link
 						key={path}

--- a/src/components/MobileNav.tsx
+++ b/src/components/MobileNav.tsx
@@ -2,10 +2,12 @@ import { memo } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Home, Archive, Settings, PaperclipIcon, ClipboardList } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
+import { useHaptics } from "@/hooks/useHaptics";
 
 export const MobileNav = memo(function MobileNav() {
 	const location = useLocation();
 	const { isAuthenticated } = useAuth();
+	const { lightImpact } = useHaptics();
 
 	const isActive = (path: string) => {
 		return location.pathname === path;
@@ -58,6 +60,7 @@ export const MobileNav = memo(function MobileNav() {
 					<Link
 						key={path}
 						to={path}
+						onClick={lightImpact}
 						className={`flex flex-col items-center justify-center space-y-1 transition-colors touch-manipulation ${isActive(path)
 								? "text-primary"
 								: "text-muted-foreground hover:text-foreground"

--- a/src/components/NewTaskForm.tsx
+++ b/src/components/NewTaskForm.tsx
@@ -68,7 +68,7 @@ export const NewTaskForm: React.FC<NewTaskFormProps> = ({ onSubmit, defaultOpen 
       <Button
         variant="default"
         onClick={() => setIsOpen(true)}
-        className="fixed bottom-20 md:bottom-6 right-6 w-16 h-16 rounded-full text-white text-md shadow-2xl hover:shadow-3xl transition-all duration-200 flex items-center justify-center z-50 hover:scale-110"
+        className="fixed bottom-20 fab-nav-offset md:bottom-6 right-6 w-16 h-16 rounded-full text-white text-md shadow-2xl hover:shadow-3xl transition-all duration-200 flex items-center justify-center z-50 hover:scale-110"
         aria-label="New Task"
       >
         <Plus style={{ fontSize: "1.5rem", width: "1.5rem", height: "1.5rem" }} />

--- a/src/components/NewTaskForm.tsx
+++ b/src/components/NewTaskForm.tsx
@@ -68,7 +68,7 @@ export const NewTaskForm: React.FC<NewTaskFormProps> = ({ onSubmit, defaultOpen 
       <Button
         variant="default"
         onClick={() => setIsOpen(true)}
-        className="fixed bottom-20 fab-nav-offset md:bottom-6 right-6 w-16 h-16 rounded-full text-white text-md shadow-2xl hover:shadow-3xl transition-all duration-200 flex items-center justify-center z-50 hover:scale-110"
+        className="fixed bottom-16 fab-nav-offset md:bottom-6 right-6 w-16 h-16 rounded-full text-white text-md shadow-2xl hover:shadow-3xl transition-all duration-200 flex items-center justify-center z-50 hover:scale-110"
         aria-label="New Task"
       >
         <Plus style={{ fontSize: "1.5rem", width: "1.5rem", height: "1.5rem" }} />

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -1,43 +1,53 @@
-import type { ReactNode } from 'react';
-import SiteNavigationMenu from '@/components/Navigation';
+import type { ReactNode } from "react";
+import SiteNavigationMenu from "@/components/Navigation";
+import { IosPageHeader } from "@/components/IosPageHeader";
+
+const isIosBuild = import.meta.env.VITE_IOS_BUILD === "true";
 
 interface PageLayoutProps {
-  /** Page title. When provided, renders the full header section (icon, title, actions, description). */
-  title?: ReactNode;
-  /** Icon displayed to the left of the title. Only renders when title is provided. */
-  icon?: ReactNode;
-  /** Action buttons displayed to the right of the title. Only renders when title is provided. */
-  actions?: ReactNode;
-  /** Subtitle text displayed below the title. Only renders when title is provided. */
-  description?: ReactNode;
-  children: ReactNode;
+	/** Page title. When provided, renders the full header section (icon, title, actions, description). */
+	title?: ReactNode;
+	/** Icon displayed to the left of the title. Only renders when title is provided. */
+	icon?: ReactNode;
+	/** Action buttons displayed to the right of the title. Only renders when title is provided. */
+	actions?: ReactNode;
+	/** Subtitle text displayed below the title. Only renders when title is provided. */
+	description?: ReactNode;
+	children: ReactNode;
 }
 
 export const PageLayout = ({
-  title,
-  icon,
-  actions,
-  description,
-  children
+	title,
+	icon,
+	actions,
+	description,
+	children,
 }: PageLayoutProps) => {
-  return (
-    <div className="min-h-screen bg-background">
-      <SiteNavigationMenu />
-      {title !== undefined && (
-        <div className="max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
-          <div className="flex items-center justify-between">
-            <h1 className="md:text-2xl font-bold text-foreground flex items-center gap-2">
-              {icon}
-              {title}
-            </h1>
-            {actions && <div className="print:hidden">{actions}</div>}
-          </div>
-          {description && (
-            <p className="text-sm text-muted-foreground mt-1">{description}</p>
-          )}
-        </div>
-      )}
-      {children}
-    </div>
-  );
+	return (
+		<div className="min-h-screen bg-background">
+			{isIosBuild ? (
+				<IosPageHeader title={title} actions={actions} />
+			) : (
+				<SiteNavigationMenu />
+			)}
+			{!isIosBuild && title !== undefined && (
+				<div className="max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
+					<div className="flex items-center justify-between">
+						<h1 className="md:text-2xl font-bold text-foreground flex items-center gap-2">
+							{icon}
+							{title}
+						</h1>
+						{actions && <div className="print:hidden">{actions}</div>}
+					</div>
+					{description && (
+						<p className="text-sm text-muted-foreground mt-1">{description}</p>
+					)}
+				</div>
+			)}
+			{isIosBuild && description && (
+				<p className="text-sm text-muted-foreground px-4 pt-2">{description}</p>
+			)}
+			{children}
+		</div>
+	);
 };

--- a/src/components/StartDayDialog.tsx
+++ b/src/components/StartDayDialog.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter
-} from '@/components/ui/dialog';
+  AdaptiveDialog,
+  AdaptiveDialogContent,
+  AdaptiveDialogHeader,
+  AdaptiveDialogTitle,
+  AdaptiveDialogDescription,
+  AdaptiveDialogFooter,
+} from "@/components/ui/adaptive-dialog";
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -62,19 +62,19 @@ export const StartDayDialog: React.FC<StartDayDialogProps> = ({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle className="flex items-center space-x-2">
+    <AdaptiveDialog open={isOpen} onOpenChange={onClose} snapPoints={[0.5, 1]}>
+      <AdaptiveDialogContent className="max-w-md">
+        <AdaptiveDialogHeader>
+          <AdaptiveDialogTitle className="flex items-center space-x-2">
             <Calendar className="w-5 h-5 text-blue-600" />
             <span>Start Your Work Day</span>
-          </DialogTitle>
-          <DialogDescription>
+          </AdaptiveDialogTitle>
+          <AdaptiveDialogDescription>
             Choose the date and time when you started working today.
-          </DialogDescription>
-        </DialogHeader>
+          </AdaptiveDialogDescription>
+        </AdaptiveDialogHeader>
 
-        <div className="space-y-4 py-4">
+        <div className="space-y-4 py-4 px-4">
           <div>
             <Label>Date</Label>
             <Input
@@ -96,7 +96,7 @@ export const StartDayDialog: React.FC<StartDayDialogProps> = ({
           </div>
         </div>
 
-        <DialogFooter>
+        <AdaptiveDialogFooter>
           <Button variant="outline" onClick={onClose}>
             Cancel
           </Button>
@@ -107,8 +107,8 @@ export const StartDayDialog: React.FC<StartDayDialogProps> = ({
             <Clock className="w-4 h-4 mr-2" />
             Start Day
           </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </AdaptiveDialogFooter>
+      </AdaptiveDialogContent>
+    </AdaptiveDialog>
   );
 };

--- a/src/components/StartDayDialog.tsx
+++ b/src/components/StartDayDialog.tsx
@@ -74,7 +74,7 @@ export const StartDayDialog: React.FC<StartDayDialogProps> = ({
           </AdaptiveDialogDescription>
         </AdaptiveDialogHeader>
 
-        <div className="space-y-4 py-4 px-4">
+        <div className="space-y-4 py-4">
           <div>
             <Label>Date</Label>
             <Input

--- a/src/components/TaskEditDialog.tsx
+++ b/src/components/TaskEditDialog.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import {
   AdaptiveDialog,
   AdaptiveDialogContent,
+  AdaptiveDialogFooter,
   AdaptiveDialogHeader,
   AdaptiveDialogTitle,
 } from "@/components/ui/adaptive-dialog";
@@ -206,7 +207,7 @@ export const TaskEditDialog: React.FC<TaskEditDialogProps> = ({
 
   return (
     <AdaptiveDialog open={isOpen} onOpenChange={onClose} snapPoints={[0.85, 1]}>
-      <AdaptiveDialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <AdaptiveDialogContent className="max-w-2xl max-h-[90vh] flex flex-col overflow-hidden">
         <AdaptiveDialogHeader>
           <AdaptiveDialogTitle className="flex items-center space-x-2">
             <Clock className="w-5 h-5" />
@@ -214,6 +215,7 @@ export const TaskEditDialog: React.FC<TaskEditDialogProps> = ({
           </AdaptiveDialogTitle>
         </AdaptiveDialogHeader>
 
+        <div className="flex-1 min-h-0 overflow-y-auto">
         <div className="space-y-6">
           <Tabs defaultValue="details" className="w-full">
             <TabsList className="grid w-full grid-cols-2">
@@ -454,20 +456,21 @@ export const TaskEditDialog: React.FC<TaskEditDialogProps> = ({
             </TabsContent>
           </Tabs>
 
-          {/* Action Buttons */}
-          <div className="flex justify-end space-x-2">
-            <Button variant="ghost" onClick={handleCancel}>
-              Cancel
-            </Button>
-            <Button
-              onClick={handleSave}
-              disabled={!formData.title.trim() || !hasChanges}
-            >
-              <Save className="w-4 h-4 mr-2" />
-              {hasChanges ? 'Save Changes' : 'No Changes'}
-            </Button>
-          </div>
         </div>
+        </div>
+
+        <AdaptiveDialogFooter>
+          <Button variant="ghost" onClick={handleCancel}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={!formData.title.trim() || !hasChanges}
+          >
+            <Save className="w-4 h-4 mr-2" />
+            {hasChanges ? 'Save Changes' : 'No Changes'}
+          </Button>
+        </AdaptiveDialogFooter>
       </AdaptiveDialogContent>
     </AdaptiveDialog>
   );

--- a/src/components/TaskEditDialog.tsx
+++ b/src/components/TaskEditDialog.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle
-} from '@/components/ui/dialog';
+  AdaptiveDialog,
+  AdaptiveDialogContent,
+  AdaptiveDialogHeader,
+  AdaptiveDialogTitle,
+} from "@/components/ui/adaptive-dialog";
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
@@ -205,14 +205,14 @@ export const TaskEditDialog: React.FC<TaskEditDialogProps> = ({
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle className="flex items-center space-x-2">
+    <AdaptiveDialog open={isOpen} onOpenChange={onClose} snapPoints={[0.85, 1]}>
+      <AdaptiveDialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <AdaptiveDialogHeader>
+          <AdaptiveDialogTitle className="flex items-center space-x-2">
             <Clock className="w-5 h-5" />
             <span>Edit Task</span>
-          </DialogTitle>
-        </DialogHeader>
+          </AdaptiveDialogTitle>
+        </AdaptiveDialogHeader>
 
         <div className="space-y-6">
           <Tabs defaultValue="details" className="w-full">
@@ -468,7 +468,7 @@ export const TaskEditDialog: React.FC<TaskEditDialogProps> = ({
             </Button>
           </div>
         </div>
-      </DialogContent>
-    </Dialog>
+      </AdaptiveDialogContent>
+    </AdaptiveDialog>
   );
 };

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -1,7 +1,16 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { Task } from "@/contexts/TimeTrackingContext";
 import { useTimeTracking } from "@/hooks/useTimeTracking";
 import { Button } from "@/components/ui/button";
+import { useHaptics } from "@/hooks/useHaptics";
+import { useLongPress } from "@/hooks/useLongPress";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { Card, CardContent } from "@/components/ui/card";
 import { TaskEditDialog } from "@/components/TaskEditDialog";
 import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
@@ -32,12 +41,29 @@ export const TaskItem: React.FC<TaskItemProps> = ({
   const { categories } = useTimeTracking();
   const [showEditDialog, setShowEditDialog] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const { lightImpact, mediumImpact } = useHaptics();
+  const contextMenuTriggerRef = useRef<HTMLDivElement>(null);
+
+  const longPressHandlers = useLongPress(() => {
+    mediumImpact();
+    // Simulate a right-click to open the Radix context menu programmatically
+    if (contextMenuTriggerRef.current) {
+      contextMenuTriggerRef.current.dispatchEvent(
+        new MouseEvent("contextmenu", { bubbles: true, cancelable: true })
+      );
+    }
+  });
 
   const duration = task.duration || (isActive ? currentDuration : 0);
   const category = categories.find((c) => c.id === task.category);
 
+  const isIosBuild = import.meta.env.VITE_IOS_BUILD === "true";
+
   return (
     <>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div ref={contextMenuTriggerRef} {...longPressHandlers}>
       <Card
         className={`transition-all duration-200 ${
           isActive ? "ring-2 ring-blue-500 hover:shadow-md hover:shadow-blue-300 bg-white" : "hover:shadow-md"
@@ -104,31 +130,52 @@ export const TaskItem: React.FC<TaskItemProps> = ({
               </div>
             </div>
 
-            <div className="flex space-x-2 ml-4">
-              <Button
-                onClick={() => setShowDeleteDialog(true)}
-                size="sm"
-                variant="outline"
-                aria-label={`Delete task: ${task.title}`}
-                className="flex items-center space-x-1 min-h-[44px] min-w-[44px] text-red-600 hover:text-red-700 hover:bg-red-50"
-              >
-                <Trash2 className="w-3 h-3" />
-                <span className="hidden sm:block">Delete</span>
-              </Button>
-              <Button
-                onClick={() => setShowEditDialog(true)}
-                size="sm"
-                variant="outline"
-                aria-label={`Edit task: ${task.title}`}
-                className="flex items-center space-x-1 min-h-[44px] min-w-[44px]"
-              >
-                <Edit className="w-3 h-3" />
-                <span className="hidden sm:block">Edit</span>
-              </Button>
-            </div>
+            {!isIosBuild && (
+              <div className="flex space-x-2 ml-4">
+                <Button
+                  onClick={() => { mediumImpact(); setShowDeleteDialog(true); }}
+                  size="sm"
+                  variant="outline"
+                  aria-label={`Delete task: ${task.title}`}
+                  className="flex items-center space-x-1 min-h-[44px] min-w-[44px] text-red-600 hover:text-red-700 hover:bg-red-50"
+                >
+                  <Trash2 className="w-3 h-3" />
+                  <span className="hidden sm:block">Delete</span>
+                </Button>
+                <Button
+                  onClick={() => { lightImpact(); setShowEditDialog(true); }}
+                  size="sm"
+                  variant="outline"
+                  aria-label={`Edit task: ${task.title}`}
+                  className="flex items-center space-x-1 min-h-[44px] min-w-[44px]"
+                >
+                  <Edit className="w-3 h-3" />
+                  <span className="hidden sm:block">Edit</span>
+                </Button>
+              </div>
+            )}
           </div>
         </CardContent>
       </Card>
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem
+            onClick={() => { lightImpact(); setShowEditDialog(true); }}
+          >
+            <Edit className="w-4 h-4 mr-2" />
+            Edit Task
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            onClick={() => { mediumImpact(); setShowDeleteDialog(true); }}
+            className="text-destructive focus:text-destructive"
+          >
+            <Trash2 className="w-4 h-4 mr-2" />
+            Delete Task
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
 
       <TaskEditDialog
         task={task}

--- a/src/components/ui/adaptive-dialog.tsx
+++ b/src/components/ui/adaptive-dialog.tsx
@@ -1,0 +1,138 @@
+import * as React from "react"
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+	DialogDescription,
+	DialogFooter,
+} from "@/components/ui/dialog"
+import {
+	Drawer,
+	DrawerContent,
+	DrawerHeader,
+	DrawerTitle,
+	DrawerDescription,
+	DrawerFooter,
+} from "@/components/ui/drawer"
+
+const isIosBuild = import.meta.env.VITE_IOS_BUILD === "true"
+
+interface AdaptiveDialogProps {
+	open: boolean
+	onOpenChange: (open: boolean) => void
+	children: React.ReactNode
+	/** vaul snap points, iOS only */
+	snapPoints?: (number | string)[]
+}
+
+export const AdaptiveDialog = ({
+	open,
+	onOpenChange,
+	children,
+	snapPoints,
+}: AdaptiveDialogProps) => {
+	if (isIosBuild) {
+		return (
+			<Drawer open={open} onOpenChange={onOpenChange} snapPoints={snapPoints}>
+				{children}
+			</Drawer>
+		)
+	}
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			{children}
+		</Dialog>
+	)
+}
+
+interface AdaptiveDialogContentProps {
+	children: React.ReactNode
+	className?: string
+}
+
+export const AdaptiveDialogContent = ({
+	children,
+	className,
+}: AdaptiveDialogContentProps) => {
+	if (isIosBuild) {
+		return (
+			<DrawerContent className={className}>
+				{children}
+			</DrawerContent>
+		)
+	}
+	return (
+		<DialogContent className={className}>
+			{children}
+		</DialogContent>
+	)
+}
+
+export const AdaptiveDialogHeader = ({
+	children,
+	className,
+}: {
+	children: React.ReactNode
+	className?: string
+}) => {
+	if (isIosBuild) {
+		return <DrawerHeader className={className}>{children}</DrawerHeader>
+	}
+	return <DialogHeader className={className}>{children}</DialogHeader>
+}
+
+export const AdaptiveDialogTitle = React.forwardRef<
+	HTMLHeadingElement,
+	React.HTMLAttributes<HTMLHeadingElement>
+>(({ children, className, ...props }, ref) => {
+	if (isIosBuild) {
+		return (
+			<DrawerTitle ref={ref} className={className} {...props}>
+				{children}
+			</DrawerTitle>
+		)
+	}
+	return (
+		<DialogTitle ref={ref} className={className} {...props}>
+			{children}
+		</DialogTitle>
+	)
+})
+AdaptiveDialogTitle.displayName = "AdaptiveDialogTitle"
+
+export const AdaptiveDialogDescription = React.forwardRef<
+	HTMLParagraphElement,
+	React.HTMLAttributes<HTMLParagraphElement>
+>(({ children, className, ...props }, ref) => {
+	if (isIosBuild) {
+		return (
+			<DrawerDescription ref={ref} className={className} {...props}>
+				{children}
+			</DrawerDescription>
+		)
+	}
+	return (
+		<DialogDescription ref={ref} className={className} {...props}>
+			{children}
+		</DialogDescription>
+	)
+})
+AdaptiveDialogDescription.displayName = "AdaptiveDialogDescription"
+
+export const AdaptiveDialogFooter = ({
+	children,
+	className,
+}: {
+	children: React.ReactNode
+	className?: string
+}) => {
+	if (isIosBuild) {
+		return (
+			<DrawerFooter className={className}>
+				{children}
+			</DrawerFooter>
+		)
+	}
+	return <DialogFooter className={className}>{children}</DialogFooter>
+}

--- a/src/components/ui/adaptive-dialog.tsx
+++ b/src/components/ui/adaptive-dialog.tsx
@@ -32,9 +32,25 @@ export const AdaptiveDialog = ({
 	children,
 	snapPoints,
 }: AdaptiveDialogProps) => {
+	const [activeSnapPoint, setActiveSnapPoint] = React.useState<number | string | null>(
+		snapPoints?.[0] ?? null
+	)
+
+	React.useEffect(() => {
+		if (open) {
+			setActiveSnapPoint(snapPoints?.[0] ?? null)
+		}
+	}, [open]) // snapPoints are static per dialog instance
+
 	if (isIosBuild) {
 		return (
-			<Drawer open={open} onOpenChange={onOpenChange} snapPoints={snapPoints}>
+			<Drawer
+				open={open}
+				onOpenChange={onOpenChange}
+				snapPoints={snapPoints}
+				activeSnapPoint={activeSnapPoint}
+				setActiveSnapPoint={setActiveSnapPoint}
+			>
 				{children}
 			</Drawer>
 		)

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
+        sm: "h-10 rounded-md px-3",
         lg: "h-11 rounded-md px-8",
         icon: "h-10 w-10",
       },

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -60,7 +60,7 @@ const DialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-1.5 text-center sm:text-left",
+      "flex flex-col space-y-1.5 text-center sm:text-left pr-8",
       className
     )}
     {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import { Drawer as DrawerPrimitive } from "vaul"
 
 import { cn } from "@/lib/util"
+import { useKeyboardHeight } from "@/hooks/useKeyboardHeight"
 
 
 
@@ -38,22 +39,26 @@ DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
 const DrawerContent = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DrawerPortal>
-    <DrawerOverlay />
-    <DrawerPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
-        className
-      )}
-      {...props}
-    >
-      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
-      {children}
-    </DrawerPrimitive.Content>
-  </DrawerPortal>
-))
+>(({ className, children, style, ...props }, ref) => {
+  const keyboardHeight = useKeyboardHeight();
+  return (
+    <DrawerPortal>
+      <DrawerOverlay />
+      <DrawerPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background pb-[env(safe-area-inset-bottom)]",
+          className
+        )}
+        style={{ paddingBottom: keyboardHeight > 0 ? keyboardHeight : undefined, ...style }}
+        {...props}
+      >
+        <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+        {children}
+      </DrawerPrimitive.Content>
+    </DrawerPortal>
+  );
+})
 DrawerContent.displayName = "DrawerContent"
 
 const DrawerHeader = ({

--- a/src/contexts/TimeTrackingContext.tsx
+++ b/src/contexts/TimeTrackingContext.tsx
@@ -27,6 +27,8 @@ import {
 } from '@/utils/exportUtils';
 import { parseTaskChecklist } from '@/utils/checklistUtils';
 import { SCHEMA_VERSION } from '@/services/localStorageService';
+import { useAppLifecycle } from '@/hooks/useAppLifecycle';
+import { useHaptics } from '@/hooks/useHaptics';
 
 export interface Task {
   id: string;
@@ -229,6 +231,8 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
   const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
+  const { successNotify, errorNotify } = useHaptics();
+
   // Debounce refs to manage timeouts
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const currentTaskTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -425,6 +429,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
           "❌ Manual sync partially failed:",
           failed.map((f) => (f as PromiseRejectedResult).reason)
         );
+        errorNotify();
         // Do not mark sync as successful when any save failed
         return;
       }
@@ -433,10 +438,11 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
       setHasUnsavedChanges(false);
     } catch (error) {
       console.error('❌ Manual sync failed:', error);
+      errorNotify();
     } finally {
       setIsSyncing(false);
     }
-  }, [dataService, stableSaveCurrentDay, projects, categories, archivedDays, todoItems]);
+  }, [dataService, stableSaveCurrentDay, projects, categories, archivedDays, todoItems, errorNotify]);
 
   // Load current day data (for periodic sync)
   const loadCurrentDay = useCallback(async () => {
@@ -480,26 +486,22 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [dataService, isDayStarted, tasks, currentTask, dayStartTime]);
 
-  // iOS/Capacitor apps don't reliably fire beforeunload when backgrounded or killed.
-  // visibilitychange fires when the app is suspended, giving us a last chance to
-  // write a synchronous backup before JavaScript execution is frozen.
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.visibilityState !== "hidden") return;
-      if (!isDayStarted && tasks.length === 0) return;
-      try {
-        localStorage.setItem(
-          STORAGE_KEYS.CURRENT_DAY,
-          JSON.stringify({ isDayStarted, dayStartTime, tasks, currentTask, _v: SCHEMA_VERSION })
-        );
-      } catch {
-        // best effort
-      }
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  // On iOS/Capacitor, useAppLifecycle fires at the Swift layer (appStateChange)
+  // before WKWebView is frozen — more reliable than beforeunload or visibilitychange.
+  // On web, it falls back to visibilitychange automatically.
+  const handleBackground = useCallback(() => {
+    if (!isDayStarted && tasks.length === 0) return;
+    try {
+      localStorage.setItem(
+        STORAGE_KEYS.CURRENT_DAY,
+        JSON.stringify({ isDayStarted, dayStartTime, tasks, currentTask, _v: SCHEMA_VERSION })
+      );
+    } catch {
+      // best effort
+    }
   }, [isDayStarted, dayStartTime, tasks, currentTask]);
+
+  useAppLifecycle(handleBackground);
 
   // Sync to backend when coming back online
   useEffect(() => {
@@ -610,6 +612,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     setTasks(updatedTasks);
     setCurrentTask(newTask);
     setHasUnsavedChanges(true);
+    successNotify();
     // Save with freshly computed state to avoid reading from stale latestStateRef
     if (dataService) {
       dataService.saveCurrentDay({ isDayStarted, dayStartTime, currentTask: newTask, tasks: updatedTasks })
@@ -714,6 +717,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
         }
 
         setHasUnsavedChanges(false);
+        successNotify();
 
         // Show success notification to user
         toast({

--- a/src/hooks/useAppLifecycle.ts
+++ b/src/hooks/useAppLifecycle.ts
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { Capacitor } from "@capacitor/core";
+
+/**
+ * Calls onBackground when the app is suspended (native) or hidden (web).
+ * On iOS/Capacitor, uses @capacitor/app's appStateChange which fires at the
+ * Swift layer before WKWebView freezes — more reliable than visibilitychange.
+ * Falls back to visibilitychange on web.
+ */
+export function useAppLifecycle(onBackground: () => void) {
+	useEffect(() => {
+		if (Capacitor.isNativePlatform()) {
+			// Dynamic import avoids a hard dependency when running as a PWA
+			// (the plugin is present but the runtime only activates on native)
+			import("@capacitor/app").then(({ App }) => {
+				const listenerPromise = App.addListener("appStateChange", ({ isActive }) => {
+					if (!isActive) {
+						onBackground();
+					}
+				});
+				return () => {
+					listenerPromise.then((handle) => handle.remove());
+				};
+			});
+		} else {
+			const handleVisibilityChange = () => {
+				if (document.visibilityState === "hidden") {
+					onBackground();
+				}
+			};
+			document.addEventListener("visibilitychange", handleVisibilityChange);
+			return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+		}
+	// onBackground is intentionally excluded — callers should memoize with useCallback
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+}

--- a/src/hooks/useHaptics.ts
+++ b/src/hooks/useHaptics.ts
@@ -1,0 +1,51 @@
+import { Capacitor } from "@capacitor/core";
+
+let hapticsModule: typeof import("@capacitor/haptics") | null = null;
+
+async function getHaptics() {
+	if (!Capacitor.isNativePlatform()) return null;
+	if (!hapticsModule) {
+		hapticsModule = await import("@capacitor/haptics");
+	}
+	return hapticsModule;
+}
+
+export function useHaptics() {
+	const lightImpact = () => {
+		getHaptics().then((h) => {
+			if (h) h.Haptics.impact({ style: h.ImpactStyle.Light });
+		});
+	};
+
+	const mediumImpact = () => {
+		getHaptics().then((h) => {
+			if (h) h.Haptics.impact({ style: h.ImpactStyle.Medium });
+		});
+	};
+
+	const heavyImpact = () => {
+		getHaptics().then((h) => {
+			if (h) h.Haptics.impact({ style: h.ImpactStyle.Heavy });
+		});
+	};
+
+	const successNotify = () => {
+		getHaptics().then((h) => {
+			if (h) h.Haptics.notification({ type: h.NotificationType.Success });
+		});
+	};
+
+	const errorNotify = () => {
+		getHaptics().then((h) => {
+			if (h) h.Haptics.notification({ type: h.NotificationType.Error });
+		});
+	};
+
+	const warnNotify = () => {
+		getHaptics().then((h) => {
+			if (h) h.Haptics.notification({ type: h.NotificationType.Warning });
+		});
+	};
+
+	return { lightImpact, mediumImpact, heavyImpact, successNotify, errorNotify, warnNotify };
+}

--- a/src/hooks/useKeyboardHeight.ts
+++ b/src/hooks/useKeyboardHeight.ts
@@ -1,0 +1,34 @@
+import { useState, useEffect } from "react";
+import { Capacitor } from "@capacitor/core";
+
+/**
+ * Returns the current on-screen keyboard height in px (0 when hidden).
+ * Uses @capacitor/keyboard events on native; always returns 0 on web.
+ */
+export function useKeyboardHeight(): number {
+	const [height, setHeight] = useState(0);
+
+	useEffect(() => {
+		if (!Capacitor.isNativePlatform()) return;
+
+		let showHandle: { remove: () => void } | null = null;
+		let hideHandle: { remove: () => void } | null = null;
+
+		import("@capacitor/keyboard").then(({ Keyboard }) => {
+			Keyboard.addListener("keyboardWillShow", (info) => {
+				setHeight(info.keyboardHeight);
+			}).then((handle) => { showHandle = handle; });
+
+			Keyboard.addListener("keyboardWillHide", () => {
+				setHeight(0);
+			}).then((handle) => { hideHandle = handle; });
+		});
+
+		return () => {
+			showHandle?.remove();
+			hideHandle?.remove();
+		};
+	}, []);
+
+	return height;
+}

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,33 @@
+import { useRef, useCallback } from "react";
+
+/**
+ * Returns pointer event handlers that fire `callback` after the pointer has
+ * been held down for `delay` ms without moving.  Used to programmatically
+ * open a context menu on touch devices (where right-click is unavailable).
+ */
+export function useLongPress(callback: () => void, delay = 500) {
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const cancelledRef = useRef(false);
+
+	const start = useCallback(() => {
+		cancelledRef.current = false;
+		timerRef.current = setTimeout(() => {
+			if (!cancelledRef.current) callback();
+		}, delay);
+	}, [callback, delay]);
+
+	const cancel = useCallback(() => {
+		cancelledRef.current = true;
+		if (timerRef.current) {
+			clearTimeout(timerRef.current);
+			timerRef.current = null;
+		}
+	}, []);
+
+	return {
+		onPointerDown: start,
+		onPointerUp: cancel,
+		onPointerLeave: cancel,
+		onPointerCancel: cancel,
+	};
+}

--- a/src/hooks/useStatusBar.ts
+++ b/src/hooks/useStatusBar.ts
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { Capacitor } from "@capacitor/core";
+
+/**
+ * Syncs the iOS status bar text colour with the app's light/dark theme.
+ * Style.Dark = white text (for dark backgrounds).
+ * Style.Light = black text (for light backgrounds).
+ * No-op on web.
+ */
+export function useStatusBar(isDark: boolean) {
+	useEffect(() => {
+		if (!Capacitor.isNativePlatform()) return;
+
+		import("@capacitor/status-bar").then(({ StatusBar, Style }) => {
+			StatusBar.setStyle({ style: isDark ? Style.Dark : Style.Light });
+		});
+	}, [isDark]);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,10 @@ import App from './App.tsx';
 import '@radix-ui/themes/styles.css';
 import './index.css';
 
+if (import.meta.env.VITE_IOS_BUILD === "true") {
+  document.body.classList.add("ios-build");
+}
+
 createRoot(document.getElementById('root')!).render(
   <Theme accentColor="orange" grayColor="slate" radius="full">
     <App />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -87,21 +87,13 @@ const TimeTrackerContent = () => {
 	}
 
 	return (
-		<PageLayout>
+		<PageLayout title="Dashboard" icon={<DashboardIcon className="w-6 h-6" />}>
 			<div className="max-w-6xl mx-auto pt-4 pb-6 px-4 md:p-6 print:p-4 space-y-6">
 				<StartDayDialog
 					isOpen={showStartDayDialog}
 					onClose={() => setShowStartDayDialog(false)}
 					onStartDay={handleStartDayWithDateTime}
 				/>
-
-				{/* Dashboard header */}
-				<div className="flex items-center justify-between">
-					<h1 className="md:text-2xl font-bold text-foreground flex items-center space-x-1">
-						<DashboardIcon className="w-6 h-6 mr-1" />
-						<span>Dashboard</span>
-					</h1>
-				</div>
 
 				{/* Stats (always visible) */}
 				{!isDayStarted && (


### PR DESCRIPTION
## Summary

Update the experience to align with Apple Human Interface Guidelines (HIG) when using on mobile and iOS app (through Capacitor build).

## Type of Change

- [x] New feature
- [x] Update to existing feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Other (describe below)

## Related Issue

<!-- Link the issue this PR resolves, e.g. "Closes #12" -->
Closes #

## Changes Made

- P1: Convert TaskEditDialog, StartDayDialog, ArchiveEditDialog, and DeleteConfirmationDialog to adaptive bottom sheets on iOS using vaul Drawer via new AdaptiveDialog component; web rendering is unchanged. DeleteConfirmationDialog reverses button order per iOS action-sheet convention (destructive first, Cancel last).

- P2: Replace unreliable visibilitychange handler in TimeTrackingContext with useAppLifecycle hook that fires @capacitor/app's appStateChange at the Swift layer before WKWebView freezes, with a visibilitychange fallback for web.

- P3: Add useHaptics hook (light/medium/heavy impact, success/error notifications) wired to: tab-bar navigation, task Edit/Delete buttons, delete confirmation, startNewTask success, postDay success, and sync failure paths.

- P4: Add useStatusBar hook that syncs iOS status bar text colour with the system dark/light mode. Update apple-mobile-web-app-status-bar-style to black-translucent so the web view extends behind the status bar.

- P5: Gate desktop SiteNavigationMenu behind !isIosBuild in PageLayout; replace with new IosPageHeader (sticky, 17px SF-style title, back chevron, safe-area-inset-top padding). Inject ios-build class on body in main.tsx and prevent double-stacking of safe-area padding in pwa.css.

- P6: Configure Capacitor Keyboard plugin (resize: body) in capacitor.config.ts. Add useKeyboardHeight hook and apply its value as paddingBottom on DrawerContent so form fields scroll above the keyboard. Add scroll-margin-bottom rule to pwa.css for native scroll-into-view.

- P7: Add useLongPress hook and ContextMenu (right-click on desktop, long-press on iOS) to TaskItem with Edit and Delete actions. Hide always-visible action buttons on iOS builds.

- P8: Bump button sm size from h-9 to h-10 (40px); enforce min-height 44px on all non-hidden buttons at mobile widths via pwa.css.

- P9: Restore native iOS rubber-band bounce by overriding overscroll-behavior-y on #root inside the @supports iOS block. Add touch-action and overscroll-behavior: contain on vaul drawer to prevent scroll bleed through open sheets.

- P10: Wrap Routes in a keyed AnimatedRoutes component; apply page-transition-enter CSS animation (subtle 30px slide + fade, 280ms) on iOS route changes via @supports (-webkit-touch-callout: none).

## Checklist

> Complete all items that apply to your change. Check N/A for items that don't apply.

### Documentation

> Run `sync-docs` skill with Claude Code to automatically update relevant files.

- [x] Any notable changes added to the `README.md`
- [x] `CHANGELOG.md` updated accordingly
- [ ] N/A — no README changes

### General

- [x] Branch is up to date with `main`
- [x] No unrelated files included in this PR
- [x] Tested locally by invoking the `npm run test`, `npm run lint`, and `npm run build`

## Notes for Reviewers

<!-- Anything the reviewer should pay special attention to, or context that helps understand the changes. -->
