### PR TITLE
fix: Reduce DB calls when saving archived day edits

### DIFF
--- a/src/components/ArchiveEditDialog.tsx
+++ b/src/components/ArchiveEditDialog.tsx
@@ -37,6 +37,7 @@ import {
 	Calendar,
 	Clock,
 	Save,
+	Loader2,
 	Trash2,
 	Edit,
 	AlertTriangle,
@@ -103,6 +104,8 @@ export const ArchiveEditDialog: React.FC<ArchiveEditDialogProps> = ({
 	} = useTimeTracking();
 	const { toast } = useToast();
 	const [isEditing, setIsEditing] = useState(false);
+	const [isSaving, setIsSaving] = useState(false);
+	const [hasChanges, setHasChanges] = useState(false);
 	const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 	const [showRestoreDialog, setShowRestoreDialog] = useState(false);
 	const [editingTask, setEditingTask] = useState<Task | null>(null);
@@ -127,10 +130,28 @@ export const ArchiveEditDialog: React.FC<ArchiveEditDialogProps> = ({
 			});
 			setTasks([...day.tasks]);
 			setIsEditing(false);
+			setHasChanges(false);
 			setEditingTask(null);
 			setShowDeleteConfirm(false);
 		}
 	}, [day, isOpen]);
+
+	// Track whether the form differs from the saved day
+	useEffect(() => {
+		if (!isEditing || !day) {
+			setHasChanges(false);
+			return;
+		}
+		const initialData = {
+			date: formatDateForInput(day.startTime),
+			startTime: formatTimeForInput(day.startTime),
+			endTime: formatTimeForInput(day.endTime),
+			notes: day.notes || "",
+		};
+		const dayDataChanged = JSON.stringify(dayData) !== JSON.stringify(initialData);
+		const tasksChanged = JSON.stringify(tasks) !== JSON.stringify(day.tasks);
+		setHasChanges(dayDataChanged || tasksChanged);
+	}, [dayData, tasks, isEditing, day]);
 
 	const parseTimeInput = (timeStr: string, baseDate: Date): Date => {
 		if (!timeStr || !timeStr.includes(":")) {
@@ -200,12 +221,15 @@ export const ArchiveEditDialog: React.FC<ArchiveEditDialogProps> = ({
 			totalDuration: calculateTotalDuration(updatedTasks),
 		};
 
+		setIsSaving(true);
 		try {
 			await updateArchivedDay(day.id, updatedDay);
 			setIsEditing(false);
 		} catch (error) {
 			console.error("Failed to save archived day:", error);
 			toast({ title: "Save failed", description: "Failed to save changes. Please try again.", variant: "destructive" });
+		} finally {
+			setIsSaving(false);
 		}
 	};
 
@@ -309,9 +333,17 @@ export const ArchiveEditDialog: React.FC<ArchiveEditDialogProps> = ({
 								<Button onClick={handleCancel} variant="outline" size="sm">
 									Cancel
 								</Button>
-								<Button onClick={handleSaveDay} size="sm">
-									<Save className="w-4 h-4 mr-2" />
-									Save
+								<Button
+									onClick={handleSaveDay}
+									size="sm"
+									disabled={!hasChanges || isSaving}
+								>
+									{isSaving ? (
+										<Loader2 className="w-4 h-4 mr-2 animate-spin" />
+									) : (
+										<Save className="w-4 h-4 mr-2" />
+									)}
+									{isSaving ? "Saving..." : hasChanges ? "Save Changes" : "No Changes"}
 								</Button>
 							</>
 						)}

--- a/src/components/ArchiveEditDialog.tsx
+++ b/src/components/ArchiveEditDialog.tsx
@@ -191,34 +191,39 @@ export const ArchiveEditDialog: React.FC<ArchiveEditDialogProps> = ({
 		newEndTime.setMonth(selectedDate.getMonth());
 		newEndTime.setDate(selectedDate.getDate());
 
-		// Update all task timestamps to use the new date
-		const updatedTasks = tasks.map(task => {
-			const newTaskStartTime = new Date(task.startTime);
-			newTaskStartTime.setFullYear(selectedDate.getFullYear());
-			newTaskStartTime.setMonth(selectedDate.getMonth());
-			newTaskStartTime.setDate(selectedDate.getDate());
+		// Determine whether tasks need to be included in the update payload.
+		// A date change shifts every task's timestamps, so always send tasks then.
+		// Otherwise only send tasks if the user explicitly edited them.
+		const dateChanged = dayData.date !== formatDateForInput(day.startTime);
+		const tasksContentChanged = JSON.stringify(tasks) !== JSON.stringify(day.tasks);
+		const needsTaskUpdate = dateChanged || tasksContentChanged;
 
-			const newTaskEndTime = task.endTime ? new Date(task.endTime) : undefined;
-			if (newTaskEndTime) {
-				newTaskEndTime.setFullYear(selectedDate.getFullYear());
-				newTaskEndTime.setMonth(selectedDate.getMonth());
-				newTaskEndTime.setDate(selectedDate.getDate());
-			}
+		// Re-stamp task timestamps only when necessary
+		const updatedTasks = needsTaskUpdate
+			? tasks.map(task => {
+				const newTaskStartTime = new Date(task.startTime);
+				newTaskStartTime.setFullYear(selectedDate.getFullYear());
+				newTaskStartTime.setMonth(selectedDate.getMonth());
+				newTaskStartTime.setDate(selectedDate.getDate());
 
-			return {
-				...task,
-				startTime: newTaskStartTime,
-				endTime: newTaskEndTime,
-			};
-		});
+				const newTaskEndTime = task.endTime ? new Date(task.endTime) : undefined;
+				if (newTaskEndTime) {
+					newTaskEndTime.setFullYear(selectedDate.getFullYear());
+					newTaskEndTime.setMonth(selectedDate.getMonth());
+					newTaskEndTime.setDate(selectedDate.getDate());
+				}
+
+				return { ...task, startTime: newTaskStartTime, endTime: newTaskEndTime };
+			})
+			: tasks;
 
 		const updatedDay: Partial<DayRecord> = {
 			date: newStartTime.toDateString(),
 			startTime: newStartTime,
 			endTime: newEndTime,
 			notes: dayData.notes || undefined,
-			tasks: updatedTasks,
 			totalDuration: calculateTotalDuration(updatedTasks),
+			...(needsTaskUpdate ? { tasks: updatedTasks } : {}),
 		};
 
 		setIsSaving(true);

--- a/src/contexts/TimeTrackingContext.tsx
+++ b/src/contexts/TimeTrackingContext.tsx
@@ -801,8 +801,10 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
   ) => {
     if (!dataService) return;
 
-    try {
+    // Capture original for targeted rollback on error
+    const originalDay = archivedDays.find(d => d.id === dayId);
 
+    try {
       // Optimistic update - update local state immediately for responsive UI
       setArchivedDays(prev =>
         prev.map(day => (day.id === dayId ? { ...day, ...updates } : day))
@@ -814,9 +816,15 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     } catch (error) {
       console.error('❌ Error updating archived day:', error);
 
-      // On error, refresh from database to restore consistent state
-      const refreshedDays = await dataService.getArchivedDays();
-      setArchivedDays(refreshedDays);
+      // Roll back only the affected day rather than re-fetching the entire archive
+      if (originalDay) {
+        setArchivedDays(prev =>
+          prev.map(day => (day.id === dayId ? originalDay : day))
+        );
+      } else {
+        const refreshedDays = await dataService.getArchivedDays();
+        setArchivedDays(refreshedDays);
+      }
 
       throw error; // Re-throw so the UI can handle it
     }


### PR DESCRIPTION
## Summary

Minimize the amount of calls to the database during archiving and editing of archived tasks. Simplifies three calls down to one.

## Type of Change

- [ ] New feature
- [x] Update to existing feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (describe below)

## Related Issue

<!-- Link the issue this PR resolves, e.g. "Closes #12" -->
Closes #

## Changes Made

<!-- List the specific files added or modified and what changed in each. -->

- ArchiveEditDialog.tsx: Only include tasks in the update payload when tasks actually changed or the date changed (date shift re-stamps all task times). Currently it always passes tasks, triggering a SELECT + UPSERT even for notes-only edits.
- TimeTrackingContext.tsx: On error, roll back just the one day using the pre-update snapshot instead of re-fetching all archived days from the DB
- handleSaveDay now checks two conditions before including tasks in the update:
    - tasksContentChanged — user explicitly edited, deleted, or added a task
    - dateChanged — the date was moved (which re-stamps every task’s startTime/endTime)

## Checklist

> Complete all items that apply to your change. Check N/A for items that don't apply.

### Documentation

> Run `sync-docs` skill with Claude Code to automatically update relevant files.

- [ ] Any notable changes added to the `README.md`
- [ ] `CHANGELOG.md` updated accordingly
- [ ] N/A — no README changes

### General

- [x] Branch is up to date with `main`
- [x] No unrelated files included in this PR
- [x] Tested locally by invoking the `npm run test`, `npm run lint`, and `npm run build`

## Notes for Reviewers

<!-- Anything the reviewer should pay special attention to, or context that helps understand the changes. -->