### PR TITLE
fix: add discard day option to avoid forced archiving

### DIFF
--- a/src/components/DaySummary.tsx
+++ b/src/components/DaySummary.tsx
@@ -10,13 +10,15 @@ interface DaySummaryProps {
   totalDuration: number;
   dayStartTime: Date;
   onPostDay: () => void;
+  onDiscardDay: () => void;
 }
 
 export const DaySummary: React.FC<DaySummaryProps> = ({
   tasks,
   totalDuration,
   dayStartTime,
-  onPostDay
+  onPostDay,
+  onDiscardDay
 }) => {
   return (
     <div className="space-y-6">
@@ -61,6 +63,13 @@ export const DaySummary: React.FC<DaySummaryProps> = ({
               className="w-full bg-green-600 hover:bg-green-700 text-white"
             >
               Post Time to Archive
+            </Button>
+            <Button
+              variant="outline"
+              onClick={onDiscardDay}
+              className="w-full border-destructive text-destructive hover:bg-destructive/10 hover:text-destructive"
+            >
+              Discard Day
             </Button>
           </div>
         </CardContent>

--- a/src/contexts/TimeTrackingContext.tsx
+++ b/src/contexts/TimeTrackingContext.tsx
@@ -131,6 +131,7 @@ interface TimeTrackingContextType {
   // Actions
   startDay: (startDateTime?: Date) => void;
   endDay: () => void;
+  discardDay: () => void;
   startNewTask: (
     title: string,
     description?: string,
@@ -569,6 +570,18 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
             duration: 7000
           });
         });
+    }
+  };
+
+  const discardDay = () => {
+    setIsDayStarted(false);
+    setDayStartTime(null);
+    setCurrentTask(null);
+    setTasks([]);
+    setHasUnsavedChanges(true);
+    if (dataService) {
+      dataService.saveCurrentDay({ isDayStarted: false, dayStartTime: null, currentTask: null, tasks: [] })
+        .catch(error => console.error("❌ Error saving state after discarding day:", error));
     }
   };
 
@@ -1081,6 +1094,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
         categories,
         startDay,
         endDay,
+        discardDay,
         startNewTask,
         updateTask,
         deleteTask,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -23,6 +23,7 @@ const TimeTrackerContent = () => {
 		archivedDays,
 		startDay,
 		endDay,
+		discardDay,
 		postDay,
 		deleteTask,
 		startNewTask,
@@ -48,6 +49,10 @@ const TimeTrackerContent = () => {
 
 	const handlePostDay = () => {
 		postDay();
+	};
+
+	const handleDiscardDay = () => {
+		discardDay();
 	};
 
 	const handleNewTask = (
@@ -80,6 +85,7 @@ const TimeTrackerContent = () => {
 						totalDuration={getTotalDayDuration()}
 						dayStartTime={dayStartTime}
 						onPostDay={handlePostDay}
+						onDiscardDay={handleDiscardDay}
 					/>
 				</div>
 			</PageLayout>


### PR DESCRIPTION
## Summary
- Adds `discardDay` action to `TimeTrackingContext` — clears tasks, dayStartTime, currentTask without archiving
- `DaySummary` gains `onDiscardDay` prop and renders a "Discard Day" button below "Post Time to Archive"
- Closes #130

## Test plan
- [x] Start a day, add tasks, click End Day
- [x] Verify "Discard Day" button appears on the Day Summary screen
- [x] Click "Discard Day" — should return to "Start Your Work Day" screen with no tasks
- [x] Verify archive is unaffected (no new entry created)
- [x] Verify "Post Time to Archive" still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)