### PR TITLE
feat: Add Kanban task planning board

### DIFF
--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from "react";
+import { PlannedTaskStatus } from "@/contexts/TimeTrackingContext";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
+import { KanbanColumn } from "@/components/KanbanColumn";
+import { PlannedTaskDialog } from "@/components/PlannedTaskDialog";
+import { Button } from "@/components/ui/button";
+import { Plus } from "lucide-react";
+
+const COLUMNS: { status: PlannedTaskStatus; title: string }[] = [
+	{ status: "todo", title: "To Do" },
+	{ status: "in_progress", title: "In Progress" },
+	{ status: "blocked", title: "Blocked" },
+	{ status: "done", title: "Done" },
+];
+
+export const KanbanBoard: React.FC = () => {
+	const { plannedTasks, isDayStarted, isDayStale } = useTimeTracking();
+	const [showNewTaskDialog, setShowNewTaskDialog] = useState(false);
+
+	const tasksByStatus = (status: PlannedTaskStatus) =>
+		[...plannedTasks]
+			.filter((t) => t.status === status)
+			.sort((a, b) => a.priority - b.priority || a.createdAt.localeCompare(b.createdAt));
+
+	return (
+		<>
+			<div className="flex justify-end mb-4">
+				<Button onClick={() => setShowNewTaskDialog(true)}>
+					<Plus className="w-4 h-4 mr-1" />
+					New Task
+				</Button>
+			</div>
+
+			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+				{COLUMNS.map(({ status, title }) => (
+					<KanbanColumn
+						key={status}
+						status={status}
+						title={title}
+						tasks={tasksByStatus(status)}
+						isDayStarted={isDayStarted}
+						isDayStale={isDayStale}
+					/>
+				))}
+			</div>
+
+			<PlannedTaskDialog
+				isOpen={showNewTaskDialog}
+				onClose={() => setShowNewTaskDialog(false)}
+			/>
+		</>
+	);
+};

--- a/src/components/KanbanColumn.tsx
+++ b/src/components/KanbanColumn.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from "react";
+import { PlannedTask, PlannedTaskStatus } from "@/contexts/TimeTrackingContext";
+import { PlannedTaskCard } from "@/components/PlannedTaskCard";
+import { PlannedTaskDialog } from "@/components/PlannedTaskDialog";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@radix-ui/themes";
+import { Plus } from "lucide-react";
+
+interface KanbanColumnProps {
+	status: PlannedTaskStatus;
+	title: string;
+	tasks: PlannedTask[];
+	isDayStarted: boolean;
+	isDayStale: boolean;
+}
+
+const COLUMN_BADGE_COLORS: Record<PlannedTaskStatus, React.ComponentProps<typeof Badge>["color"]> = {
+	todo: undefined,
+	in_progress: "indigo",
+	done: "green",
+	blocked: "red",
+};
+
+export const KanbanColumn: React.FC<KanbanColumnProps> = ({
+	status,
+	title,
+	tasks,
+	isDayStarted,
+	isDayStale,
+}) => {
+	const [showAddDialog, setShowAddDialog] = useState(false);
+
+	return (
+		<>
+			<Card className="flex flex-col h-full">
+				<CardHeader className="pb-2 pt-3 px-3">
+					<CardTitle className="flex items-center justify-between text-sm font-semibold">
+						<span className="text-foreground">{title}</span>
+						<Badge
+							color={COLUMN_BADGE_COLORS[status]}
+							variant="soft"
+							radius="full"
+							size="1"
+						>
+							{tasks.length}
+						</Badge>
+					</CardTitle>
+				</CardHeader>
+
+				<CardContent className="flex-1 space-y-2 px-3 pb-3 overflow-y-auto">
+					{tasks.map((task) => (
+						<PlannedTaskCard
+							key={task.id}
+							task={task}
+							isDayStarted={isDayStarted}
+							isDayStale={isDayStale}
+						/>
+					))}
+
+					{tasks.length === 0 && (
+						<p className="text-xs text-muted-foreground text-center py-4">
+							No tasks
+						</p>
+					)}
+
+					{status === "todo" && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => setShowAddDialog(true)}
+							className="w-full text-muted-foreground hover:text-foreground border border-dashed border-border"
+						>
+							<Plus className="w-3 h-3 mr-1" />
+							Add task
+						</Button>
+					)}
+				</CardContent>
+			</Card>
+
+			<PlannedTaskDialog
+				isOpen={showAddDialog}
+				onClose={() => setShowAddDialog(false)}
+				defaultStatus={status}
+			/>
+		</>
+	);
+};

--- a/src/components/PlannedTaskCard.tsx
+++ b/src/components/PlannedTaskCard.tsx
@@ -1,0 +1,240 @@
+import React, { useRef, useState } from "react";
+import { PlannedTask, PlannedTaskStatus } from "@/contexts/TimeTrackingContext";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
+import { useHaptics } from "@/hooks/useHaptics";
+import { useLongPress } from "@/hooks/useLongPress";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+	ContextMenu,
+	ContextMenuContent,
+	ContextMenuItem,
+	ContextMenuSeparator,
+	ContextMenuSub,
+	ContextMenuSubContent,
+	ContextMenuSubTrigger,
+	ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { DeleteConfirmationDialog } from "@/components/DeleteConfirmationDialog";
+import { PlannedTaskDialog } from "@/components/PlannedTaskDialog";
+import { MarkdownDisplay } from "@/components/MarkdownDisplay";
+import { Badge } from "@radix-ui/themes";
+import { ArrowRight, Edit, Trash2, Play, MoveRight } from "lucide-react";
+
+interface PlannedTaskCardProps {
+	task: PlannedTask;
+	isDayStarted: boolean;
+	isDayStale: boolean;
+}
+
+const STATUS_LABELS: Record<PlannedTaskStatus, string> = {
+	todo: "To Do",
+	in_progress: "In Progress",
+	done: "Done",
+	blocked: "Blocked",
+};
+
+const OTHER_STATUSES = (current: PlannedTaskStatus): PlannedTaskStatus[] =>
+	(["todo", "in_progress", "done", "blocked"] as PlannedTaskStatus[]).filter(
+		(s) => s !== current
+	);
+
+export const PlannedTaskCard: React.FC<PlannedTaskCardProps> = ({
+	task,
+	isDayStarted,
+	isDayStale,
+}) => {
+	const { categories, deletePlannedTask, movePlannedTask, pullPlannedTaskToDay } =
+		useTimeTracking();
+	const { lightImpact, mediumImpact } = useHaptics();
+	const contextMenuTriggerRef = useRef<HTMLDivElement>(null);
+	const [showEditDialog, setShowEditDialog] = useState(false);
+	const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+	const longPressHandlers = useLongPress(() => {
+		mediumImpact();
+		if (contextMenuTriggerRef.current) {
+			contextMenuTriggerRef.current.dispatchEvent(
+				new MouseEvent("contextmenu", { bubbles: true, cancelable: true })
+			);
+		}
+	});
+
+	const category = categories.find((c) => c.id === task.category);
+	const canPull = isDayStarted && !isDayStale && task.status !== "done";
+
+	return (
+		<>
+			<ContextMenu>
+				<ContextMenuTrigger asChild>
+					<div ref={contextMenuTriggerRef} {...longPressHandlers}>
+						<Card className="hover:shadow-md transition-all duration-200">
+							<CardContent className="p-3">
+								<div className="flex items-start justify-between gap-2">
+									<div className="flex-1 min-w-0">
+										<h3 className="font-semibold text-foreground text-sm leading-snug">
+											{task.title}
+										</h3>
+
+										{task.description && (
+											<div className="mt-1 text-xs text-muted-foreground line-clamp-2">
+												<MarkdownDisplay content={task.description} />
+											</div>
+										)}
+
+										<div className="flex flex-wrap gap-1 mt-2">
+											{category && (
+												<Badge
+													radius="full"
+													size="1"
+													style={{ backgroundColor: category.color, color: "#fff" }}
+												>
+													{category.name}
+												</Badge>
+											)}
+											{task.project && (
+												<Badge color="gray" variant="outline" radius="full" size="1">
+													{task.project}
+												</Badge>
+											)}
+											{task.client && (
+												<Badge color="cyan" radius="full" size="1">
+													{task.client}
+												</Badge>
+											)}
+											{task.linkedTaskId && (
+												<Badge color="green" variant="soft" radius="full" size="1">
+													<ArrowRight className="w-2.5 h-2.5 inline mr-0.5" />
+													Pulled to day
+												</Badge>
+											)}
+										</div>
+									</div>
+
+									<div className="flex flex-col gap-1 shrink-0">
+										{canPull && (
+											<Button
+												size="sm"
+												variant="outline"
+												onClick={() => pullPlannedTaskToDay(task.id)}
+												className="h-7 px-2 text-xs"
+												title="Pull to active day and start timing"
+											>
+												<Play className="w-3 h-3 mr-1" />
+												Pull
+											</Button>
+										)}
+
+										<DropdownMenu>
+											<DropdownMenuTrigger asChild>
+												<Button
+													size="sm"
+													variant="ghost"
+													onClick={() => lightImpact()}
+													className="h-7 px-2 text-xs"
+													title="Move to another column"
+												>
+													<MoveRight className="w-3 h-3 mr-1" />
+													Move
+												</Button>
+											</DropdownMenuTrigger>
+											<DropdownMenuContent align="end">
+												{OTHER_STATUSES(task.status).map((s) => (
+													<DropdownMenuItem
+														key={s}
+														onClick={() => movePlannedTask(task.id, s)}
+													>
+														{STATUS_LABELS[s]}
+													</DropdownMenuItem>
+												))}
+											</DropdownMenuContent>
+										</DropdownMenu>
+
+										<Button
+											size="sm"
+											variant="ghost"
+											onClick={() => { lightImpact(); setShowEditDialog(true); }}
+											className="h-7 px-2 text-xs"
+											aria-label={`Edit: ${task.title}`}
+										>
+											<Edit className="w-3 h-3" />
+										</Button>
+
+										<Button
+											size="sm"
+											variant="ghost"
+											onClick={() => { mediumImpact(); setShowDeleteDialog(true); }}
+											className="h-7 px-2 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+											aria-label={`Delete: ${task.title}`}
+										>
+											<Trash2 className="w-3 h-3" />
+										</Button>
+									</div>
+								</div>
+							</CardContent>
+						</Card>
+					</div>
+				</ContextMenuTrigger>
+
+				<ContextMenuContent>
+					{canPull && (
+						<>
+							<ContextMenuItem onClick={() => pullPlannedTaskToDay(task.id)}>
+								<Play className="w-4 h-4 mr-2" />
+								Pull to Day
+							</ContextMenuItem>
+							<ContextMenuSeparator />
+						</>
+					)}
+					<ContextMenuItem onClick={() => { lightImpact(); setShowEditDialog(true); }}>
+						<Edit className="w-4 h-4 mr-2" />
+						Edit Task
+					</ContextMenuItem>
+					<ContextMenuSub>
+						<ContextMenuSubTrigger>
+							<MoveRight className="w-4 h-4 mr-2" />
+							Move to
+						</ContextMenuSubTrigger>
+						<ContextMenuSubContent>
+							{OTHER_STATUSES(task.status).map((s) => (
+								<ContextMenuItem key={s} onClick={() => movePlannedTask(task.id, s)}>
+									{STATUS_LABELS[s]}
+								</ContextMenuItem>
+							))}
+						</ContextMenuSubContent>
+					</ContextMenuSub>
+					<ContextMenuSeparator />
+					<ContextMenuItem
+						onClick={() => { mediumImpact(); setShowDeleteDialog(true); }}
+						className="text-destructive focus:text-destructive"
+					>
+						<Trash2 className="w-4 h-4 mr-2" />
+						Delete Task
+					</ContextMenuItem>
+				</ContextMenuContent>
+			</ContextMenu>
+
+			<PlannedTaskDialog
+				task={task}
+				isOpen={showEditDialog}
+				onClose={() => setShowEditDialog(false)}
+			/>
+
+			<DeleteConfirmationDialog
+				isOpen={showDeleteDialog}
+				onClose={() => setShowDeleteDialog(false)}
+				onConfirm={() => {
+					deletePlannedTask(task.id);
+					setShowDeleteDialog(false);
+				}}
+				taskTitle={task.title}
+			/>
+		</>
+	);
+};

--- a/src/components/PlannedTaskDialog.tsx
+++ b/src/components/PlannedTaskDialog.tsx
@@ -1,0 +1,225 @@
+import React, { useState, useEffect } from "react";
+import {
+	AdaptiveDialog,
+	AdaptiveDialogContent,
+	AdaptiveDialogFooter,
+	AdaptiveDialogHeader,
+	AdaptiveDialogTitle,
+} from "@/components/ui/adaptive-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { MarkdownDisplay } from "@/components/MarkdownDisplay";
+import { Save } from "lucide-react";
+import { PlannedTask, PlannedTaskStatus } from "@/contexts/TimeTrackingContext";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
+
+interface PlannedTaskDialogProps {
+	task?: PlannedTask;
+	isOpen: boolean;
+	onClose: () => void;
+	defaultStatus?: PlannedTaskStatus;
+}
+
+const STATUS_LABELS: Record<PlannedTaskStatus, string> = {
+	todo: "To Do",
+	in_progress: "In Progress",
+	done: "Done",
+	blocked: "Blocked",
+};
+
+export const PlannedTaskDialog: React.FC<PlannedTaskDialogProps> = ({
+	task,
+	isOpen,
+	onClose,
+	defaultStatus = "todo",
+}) => {
+	const { addPlannedTask, updatePlannedTask, projects, categories } = useTimeTracking();
+
+	const [title, setTitle] = useState("");
+	const [description, setDescription] = useState("");
+	const [status, setStatus] = useState<PlannedTaskStatus>(defaultStatus);
+	const [project, setProject] = useState("none");
+	const [category, setCategory] = useState("none");
+	const [descTab, setDescTab] = useState<"edit" | "preview">("edit");
+	const [hasChanges, setHasChanges] = useState(false);
+
+	const isEditMode = !!task;
+
+	useEffect(() => {
+		if (isOpen) {
+			if (task) {
+				setTitle(task.title);
+				setDescription(task.description ?? "");
+				setStatus(task.status);
+				setProject(projects.find((p) => p.name === task.project)?.id ?? "none");
+				setCategory(task.category ?? "none");
+			} else {
+				setTitle("");
+				setDescription("");
+				setStatus(defaultStatus);
+				setProject("none");
+				setCategory("none");
+			}
+			setDescTab("edit");
+			setHasChanges(false);
+		}
+	}, [isOpen, task, projects, defaultStatus]);
+
+	useEffect(() => {
+		if (!isOpen || !task) return;
+		const originalProject = projects.find((p) => p.name === task.project)?.id ?? "none";
+		const changed =
+			title !== task.title ||
+			description !== (task.description ?? "") ||
+			status !== task.status ||
+			project !== originalProject ||
+			category !== (task.category ?? "none");
+		setHasChanges(changed);
+	}, [title, description, status, project, category, task, projects, isOpen]);
+
+	const handleSave = () => {
+		if (!title.trim()) return;
+
+		const selectedProject = projects.find((p) => p.id === project);
+		const data = {
+			title: title.trim(),
+			description: description.trim() || undefined,
+			project: selectedProject?.name,
+			client: selectedProject?.client,
+			category: category === "none" ? undefined : category,
+			priority: task?.priority ?? 0,
+			linkedTaskId: task?.linkedTaskId,
+		};
+
+		if (isEditMode && task) {
+			updatePlannedTask(task.id, { ...data, status });
+		} else {
+			addPlannedTask(data);
+		}
+		onClose();
+	};
+
+	const canSave = title.trim().length > 0 && (!isEditMode || hasChanges);
+
+	return (
+		<AdaptiveDialog open={isOpen} onOpenChange={onClose} snapPoints={[0.85, 1]}>
+			<AdaptiveDialogContent className="max-w-lg">
+				<AdaptiveDialogHeader>
+					<AdaptiveDialogTitle>
+						{isEditMode ? "Edit Planned Task" : "New Planned Task"}
+					</AdaptiveDialogTitle>
+				</AdaptiveDialogHeader>
+
+				<div className="space-y-4 py-2">
+					<div>
+						<Label htmlFor="planned-title">Title *</Label>
+						<Input
+							id="planned-title"
+							value={title}
+							onChange={(e) => setTitle(e.target.value)}
+							placeholder="What needs to be done?"
+							onKeyDown={(e) => e.key === "Enter" && canSave && handleSave()}
+						/>
+					</div>
+
+					<div>
+						<Label>Description</Label>
+						<Tabs value={descTab} onValueChange={(v) => setDescTab(v as "edit" | "preview")}>
+							<TabsList className="mb-2">
+								<TabsTrigger value="edit">Edit</TabsTrigger>
+								<TabsTrigger value="preview" disabled={!description.trim()}>
+									Preview
+								</TabsTrigger>
+							</TabsList>
+							<TabsContent value="edit">
+								<Textarea
+									value={description}
+									onChange={(e) => setDescription(e.target.value)}
+									placeholder="Optional details, links, checklist items..."
+									rows={4}
+								/>
+							</TabsContent>
+							<TabsContent value="preview">
+								<div className="min-h-[96px] rounded-md border border-input bg-background px-3 py-2">
+									<MarkdownDisplay content={description} />
+								</div>
+							</TabsContent>
+						</Tabs>
+					</div>
+
+					{isEditMode && (
+						<div>
+							<Label htmlFor="planned-status">Status</Label>
+							<Select value={status} onValueChange={(v) => setStatus(v as PlannedTaskStatus)}>
+								<SelectTrigger id="planned-status">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{(Object.keys(STATUS_LABELS) as PlannedTaskStatus[]).map((s) => (
+										<SelectItem key={s} value={s}>
+											{STATUS_LABELS[s]}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					)}
+
+					<div>
+						<Label htmlFor="planned-category">Category</Label>
+						<Select value={category} onValueChange={setCategory}>
+							<SelectTrigger id="planned-category">
+								<SelectValue placeholder="No category" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="none">No category</SelectItem>
+								{categories.map((c) => (
+									<SelectItem key={c.id} value={c.id}>
+										{c.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+
+					<div>
+						<Label htmlFor="planned-project">Project</Label>
+						<Select value={project} onValueChange={setProject}>
+							<SelectTrigger id="planned-project">
+								<SelectValue placeholder="No project" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="none">No project</SelectItem>
+								{projects.map((p) => (
+									<SelectItem key={p.id} value={p.id}>
+										{p.name}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				</div>
+
+				<AdaptiveDialogFooter>
+					<Button variant="outline" onClick={onClose}>
+						Cancel
+					</Button>
+					<Button onClick={handleSave} disabled={!canSave}>
+						<Save className="w-4 h-4 mr-1" />
+						{isEditMode ? "Save Changes" : "Add Task"}
+					</Button>
+				</AdaptiveDialogFooter>
+			</AdaptiveDialogContent>
+		</AdaptiveDialog>
+	);
+};

--- a/src/components/StaleDayDialog.tsx
+++ b/src/components/StaleDayDialog.tsx
@@ -1,0 +1,82 @@
+import React, { useState, useEffect } from "react";
+import {
+	AdaptiveDialog,
+	AdaptiveDialogContent,
+	AdaptiveDialogHeader,
+	AdaptiveDialogTitle,
+	AdaptiveDialogDescription,
+	AdaptiveDialogFooter,
+} from "@/components/ui/adaptive-dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { TimePicker } from "@/components/ui/scroll-time-picker";
+import { useTimeTracking } from "@/hooks/useTimeTracking";
+import { AlertTriangle } from "lucide-react";
+
+function formatDateLabel(date: Date): string {
+	return date.toLocaleDateString(undefined, {
+		weekday: "long",
+		month: "long",
+		day: "numeric"
+	});
+}
+
+export const StaleDayDialog: React.FC = () => {
+	const { isDayStale, dayStartTime, endDay, discardDay } = useTimeTracking();
+	const [selectedTime, setSelectedTime] = useState("23:59");
+
+	useEffect(() => {
+		if (isDayStale) {
+			setSelectedTime("23:59");
+		}
+	}, [isDayStale]);
+
+	const handleEndDay = () => {
+		if (!dayStartTime) return;
+		const [hours, minutes] = selectedTime.split(":").map(Number);
+		const endDateTime = new Date(dayStartTime);
+		endDateTime.setHours(hours, minutes, 0, 0);
+		endDay(endDateTime);
+	};
+
+	return (
+		<AdaptiveDialog open={isDayStale} onOpenChange={() => {}} snapPoints={[0.6, 1]}>
+			<AdaptiveDialogContent>
+				<AdaptiveDialogHeader>
+					<AdaptiveDialogTitle className="flex items-center gap-2">
+						<AlertTriangle className="w-5 h-5 text-warning" />
+						<span>Unfinished Work Day</span>
+					</AdaptiveDialogTitle>
+					<AdaptiveDialogDescription>
+						You have an open work day from{" "}
+						<strong>{dayStartTime ? formatDateLabel(dayStartTime) : "a previous day"}</strong>.
+						When did you finish working?
+					</AdaptiveDialogDescription>
+				</AdaptiveDialogHeader>
+
+				<div className="py-4">
+					<Label htmlFor="stale-end-time">End Time</Label>
+					<TimePicker
+						id="stale-end-time"
+						value={selectedTime}
+						onValueChange={setSelectedTime}
+						aria-label="Select the time you finished working"
+					/>
+				</div>
+
+				<AdaptiveDialogFooter>
+					<Button
+						variant="outline"
+						onClick={discardDay}
+						className="text-destructive border-destructive hover:bg-destructive/10 hover:text-destructive"
+					>
+						Discard Day
+					</Button>
+					<Button onClick={handleEndDay}>
+						End Day at {selectedTime}
+					</Button>
+				</AdaptiveDialogFooter>
+			</AdaptiveDialogContent>
+		</AdaptiveDialog>
+	);
+};

--- a/src/contexts/TimeTrackingContext.tsx
+++ b/src/contexts/TimeTrackingContext.tsx
@@ -73,6 +73,22 @@ export interface TodoItem {
   completedAt?: string; // ISO string — set when toggled to done, cleared when toggled back
 }
 
+export type PlannedTaskStatus = "todo" | "in_progress" | "done" | "blocked";
+
+export interface PlannedTask {
+  id: string;
+  title: string;
+  description?: string;
+  status: PlannedTaskStatus;
+  project?: string;
+  client?: string;
+  category?: string;
+  priority: number;        // integer sort order within column; lower = higher; default 0
+  linkedTaskId?: string;   // id of the timed Task created via "Pull to Day" (display only)
+  createdAt: string;       // ISO string
+  updatedAt: string;       // ISO string
+}
+
 export interface TimeEntry {
   id: string;
   date: string;
@@ -128,9 +144,12 @@ interface TimeTrackingContextType {
   // Categories
   categories: TaskCategory[];
 
+  // Stale day detection
+  isDayStale: boolean;
+
   // Actions
   startDay: (startDateTime?: Date) => void;
-  endDay: () => void;
+  endDay: (endDateTime?: Date) => void;
   discardDay: () => void;
   startNewTask: (
     title: string,
@@ -138,7 +157,7 @@ interface TimeTrackingContextType {
     project?: string,
     client?: string,
     category?: string
-  ) => void;
+  ) => string;
   updateTask: (taskId: string, updates: Partial<Task>) => void;
   deleteTask: (taskId: string) => void;
   postDay: (notes?: string) => void;
@@ -173,6 +192,14 @@ interface TimeTrackingContextType {
     csvContent: string
   ) => Promise<{ success: boolean; message: string; importedCount: number }>;
   // generateInvoiceData: (clientName: string, startDate: Date, endDate: Date) => any;
+
+  // Planned tasks (kanban board)
+  plannedTasks: PlannedTask[];
+  addPlannedTask: (data: Omit<PlannedTask, "id" | "createdAt" | "updatedAt" | "status">) => void;
+  updatePlannedTask: (id: string, updates: Partial<PlannedTask>) => void;
+  deletePlannedTask: (id: string) => void;
+  movePlannedTask: (id: string, status: PlannedTaskStatus) => void;
+  pullPlannedTaskToDay: (id: string) => void;
 
   // Calculated values
   getTotalDayDuration: () => number;
@@ -231,8 +258,10 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
   const [isSyncing, setIsSyncing] = useState(false);
   const [lastSyncTime, setLastSyncTime] = useState<Date | null>(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const [dayEndTime, setDayEndTime] = useState<Date | null>(null);
+  const [plannedTasks, setPlannedTasks] = useState<PlannedTask[]>([]);
 
-  const { successNotify, errorNotify } = useHaptics();
+  const { successNotify, errorNotify, lightImpact, mediumImpact } = useHaptics();
 
   // Debounce refs to manage timeouts
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -245,6 +274,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
   const dataServiceRef = useRef<DataService | null>(null);
   // Guards against saving todos during the initial data load.
   const todoLoadedRef = useRef(false);
+  const plannedLoadedRef = useRef(false);
 
   // Initialize data service when auth state changes
   useEffect(() => {
@@ -336,13 +366,18 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
         const loadedTodos = await dataService.getTodos();
         setTodoItems(loadedTodos);
 
+        // Load planned tasks
+        const loadedPlannedTasks = await dataService.getPlannedTasks();
+        setPlannedTasks(loadedPlannedTasks);
+
         // If switching from localStorage to Supabase, migrate data
         if (currentAuthStateRef.current && dataService) {
           await dataService.migrateFromLocalStorage();
         }
 
-        // Allow todo save effect to fire for user-initiated changes going forward
+        // Allow todo/planned-task save effects to fire for user-initiated changes
         todoLoadedRef.current = true;
+        plannedLoadedRef.current = true;
       } catch (error) {
         console.error('Error loading data:', error);
       } finally {
@@ -421,7 +456,8 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
         dataService.saveProjects(projects),
         dataService.saveCategories(categories),
         dataService.saveArchivedDays(archivedDays),
-        dataService.saveTodos(todoItems)
+        dataService.saveTodos(todoItems),
+        dataService.savePlannedTasks(plannedTasks)
       ]);
 
       const failed = results.filter((r) => r.status === "rejected");
@@ -443,7 +479,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     } finally {
       setIsSyncing(false);
     }
-  }, [dataService, stableSaveCurrentDay, projects, categories, archivedDays, todoItems, errorNotify]);
+  }, [dataService, stableSaveCurrentDay, projects, categories, archivedDays, todoItems, plannedTasks, errorNotify]);
 
   // Load current day data (for periodic sync)
   const loadCurrentDay = useCallback(async () => {
@@ -523,6 +559,11 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     return () => clearInterval(timer);
   }, []);
 
+  const isDayStale =
+    isDayStarted &&
+    !!dayStartTime &&
+    dayStartTime.toDateString() !== new Date().toDateString();
+
   const startDay = (startDateTime?: Date) => {
     const now = startDateTime || new Date();
 
@@ -543,18 +584,20 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   };
 
-  const endDay = () => {
+  const endDay = (endDateTime?: Date) => {
+    const effectiveEndTime = endDateTime ?? new Date();
     let finalTasks = tasks;
     if (currentTask) {
       const endedTask = {
         ...currentTask,
-        endTime: new Date(),
-        duration: new Date().getTime() - currentTask.startTime.getTime()
+        endTime: effectiveEndTime,
+        duration: effectiveEndTime.getTime() - currentTask.startTime.getTime()
       };
       finalTasks = tasks.map(t => (t.id === currentTask.id ? endedTask : t));
       setTasks(finalTasks);
       setCurrentTask(null);
     }
+    setDayEndTime(effectiveEndTime);
     setIsDayStarted(false);
     setHasUnsavedChanges(true);
     // Save with freshly computed state to avoid reading from stale latestStateRef
@@ -591,7 +634,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     project?: string,
     client?: string,
     category?: string
-  ) => {
+  ): string => {
     const now = new Date();
 
     // End current task if exists and compute the updated task list synchronously
@@ -632,6 +675,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
         .then(() => setLastSyncTime(new Date()))
         .catch(error => console.error("❌ Error saving after starting task:", error));
     }
+    return newTask.id;
   };
 
   const updateTask = (taskId: string, updates: Partial<Task>) => {
@@ -688,7 +732,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
       tasks: tasks,
       totalDuration: getTotalDayDuration(),
       startTime: dayStartTime,
-      endTime: new Date(),
+      endTime: dayEndTime ?? new Date(),
       notes
     };
 
@@ -706,6 +750,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
 
     // Clear current day data
     setDayStartTime(null);
+    setDayEndTime(null);
     setCurrentTask(null);
     setTasks([]);
     setIsDayStarted(false);
@@ -1004,6 +1049,12 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     dataServiceRef.current.saveTodos(todoItems);
   }, [todoItems]);
 
+  // Persist planned tasks whenever plannedTasks changes due to a user action.
+  useEffect(() => {
+    if (!plannedLoadedRef.current || !dataServiceRef.current) return;
+    dataServiceRef.current.savePlannedTasks(plannedTasks);
+  }, [plannedTasks]);
+
   // Stable callbacks — no todoItems in deps. Functional updates ensure each
   // callback always operates on the latest state without closing over it.
   const addTodoItem = useCallback((text: string) => {
@@ -1033,6 +1084,57 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
   const clearCompletedTodos = useCallback(() => {
     setTodoItems(prev => prev.filter(item => !item.completed));
   }, []);
+
+  // === PLANNED TASKS ===
+
+  const addPlannedTask = useCallback((data: Omit<PlannedTask, "id" | "createdAt" | "updatedAt" | "status">) => {
+    const now = new Date().toISOString();
+    const newTask: PlannedTask = {
+      ...data,
+      id: `planned-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+      status: "todo",
+      createdAt: now,
+      updatedAt: now
+    };
+    setPlannedTasks(prev => [...prev, newTask]);
+    successNotify();
+  }, [successNotify]);
+
+  const updatePlannedTask = useCallback((id: string, updates: Partial<PlannedTask>) => {
+    setPlannedTasks(prev => prev.map(t =>
+      t.id === id ? { ...t, ...updates, updatedAt: new Date().toISOString() } : t
+    ));
+  }, []);
+
+  const deletePlannedTask = useCallback((id: string) => {
+    setPlannedTasks(prev => prev.filter(t => t.id !== id));
+    mediumImpact();
+  }, [mediumImpact]);
+
+  const movePlannedTask = useCallback((id: string, status: PlannedTaskStatus) => {
+    setPlannedTasks(prev => prev.map(t =>
+      t.id === id ? { ...t, status, updatedAt: new Date().toISOString() } : t
+    ));
+    lightImpact();
+  }, [lightImpact]);
+
+  const pullPlannedTaskToDay = (id: string) => {
+    if (!isDayStarted) {
+      toast({ title: "Start your work day first", description: "Go to the Dashboard and start your day before pulling tasks." });
+      return;
+    }
+    if (isDayStale) {
+      toast({ title: "Resolve your previous day first", description: "Your previous work day is still open. Please end or discard it." });
+      return;
+    }
+    const task = plannedTasks.find(t => t.id === id);
+    if (!task) return;
+    const newTaskId = startNewTask(task.title, task.description, task.project, task.client, task.category);
+    setPlannedTasks(prev => prev.map(t =>
+      t.id === id ? { ...t, status: "in_progress" as PlannedTaskStatus, linkedTaskId: newTaskId, updatedAt: new Date().toISOString() } : t
+    ));
+    toast({ title: `Task started: ${task.title}` });
+  };
 
   const importFromCSV = async (
     csvContent: string
@@ -1075,6 +1177,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     <TimeTrackingContext.Provider
       value={{
         isDayStarted,
+        isDayStale,
         dayStartTime,
         currentTask,
         tasks,
@@ -1099,6 +1202,12 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
         updateTask,
         deleteTask,
         postDay,
+        plannedTasks,
+        addPlannedTask,
+        updatePlannedTask,
+        deletePlannedTask,
+        movePlannedTask,
+        pullPlannedTaskToDay,
         addProject,
         updateProject,
         deleteProject,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,7 @@
 import { useTimeTracking } from "@/hooks/useTimeTracking";
 import { DaySummary } from "@/components/DaySummary";
 import { StartDayDialog } from "@/components/StartDayDialog";
+import { StaleDayDialog } from "@/components/StaleDayDialog";
 import { TaskItem } from "@/components/TaskItem";
 import { NewTaskForm } from "@/components/NewTaskForm";
 import { Button } from "@/components/ui/button";
@@ -17,6 +18,7 @@ const EPOCH = new Date(0);
 const TimeTrackerContent = () => {
 	const {
 		isDayStarted,
+		isDayStale,
 		dayStartTime,
 		currentTask,
 		tasks,
@@ -96,10 +98,11 @@ const TimeTrackerContent = () => {
 		<PageLayout title="Dashboard" icon={<DashboardIcon className="w-6 h-6" />}>
 			<div className="max-w-6xl mx-auto pt-4 pb-6 px-4 md:p-6 print:p-4 space-y-6">
 				<StartDayDialog
-					isOpen={showStartDayDialog}
+					isOpen={showStartDayDialog && !isDayStale}
 					onClose={() => setShowStartDayDialog(false)}
 					onStartDay={handleStartDayWithDateTime}
 				/>
+				<StaleDayDialog />
 
 				{/* Stats (always visible) */}
 				{!isDayStarted && (

--- a/src/pages/TaskList.tsx
+++ b/src/pages/TaskList.tsx
@@ -1,140 +1,15 @@
-import { useTimeTracking } from "@/hooks/useTimeTracking";
-import { TaskItem } from "@/components/TaskItem";
-import { NewTaskForm } from "@/components/NewTaskForm";
-import { DaySummary } from "@/components/DaySummary";
 import { PageLayout } from "@/components/PageLayout";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CircleStop, ClipboardList, LayoutDashboard } from "lucide-react";
-import { Link } from "react-router-dom";
+import { KanbanBoard } from "@/components/KanbanBoard";
+import { LayoutGrid } from "lucide-react";
 
 const TaskList = () => {
-	const {
-		isDayStarted,
-		dayStartTime,
-		currentTask,
-		tasks,
-		endDay,
-		postDay,
-		deleteTask,
-		startNewTask,
-		getTotalDayDuration,
-		getCurrentTaskDuration,
-	} = useTimeTracking();
-
-	const handleEndDay = () => {
-		endDay();
-	};
-
-	const handlePostDay = () => {
-		postDay();
-	};
-
-	const handleNewTask = (
-		title: string,
-		description?: string,
-		project?: string,
-		client?: string,
-		category?: string
-	) => {
-		startNewTask(title, description, project, client, category);
-	};
-
-	const handleTaskDelete = (taskId: string) => {
-		deleteTask(taskId);
-	};
-
-	// Show day summary after day ends but before it is posted
-	if (!isDayStarted && dayStartTime && tasks.length > 0) {
-		return (
-			<PageLayout>
-				<div className="max-w-4xl mx-auto p-6 space-y-6">
-					<DaySummary
-						tasks={tasks}
-						totalDuration={getTotalDayDuration()}
-						dayStartTime={dayStartTime}
-						onPostDay={handlePostDay}
-					/>
-				</div>
-			</PageLayout>
-		);
-	}
-
-	if (!isDayStarted) {
-		return (
-			<PageLayout
-				title="Tasks"
-				icon={<ClipboardList className="w-5 h-5" />}
-			>
-				<div className="max-w-4xl mx-auto pt-4 pb-6 px-4 md:p-6">
-					<Card className="bg-muted border-border">
-						<CardHeader>
-							<CardTitle className="flex items-center space-x-2 text-primary">
-								<ClipboardList className="w-5 h-5" />
-								<span>No Active Work Day</span>
-							</CardTitle>
-						</CardHeader>
-						<CardContent className="space-y-4">
-							<p className="text-foreground">
-								Start your work day on the dashboard before adding tasks.
-							</p>
-							<Button asChild className="w-full">
-								<Link to="/" className="flex items-center justify-center space-x-2">
-									<LayoutDashboard className="w-4 h-4" />
-									<span>Go to Dashboard</span>
-								</Link>
-							</Button>
-						</CardContent>
-					</Card>
-				</div>
-			</PageLayout>
-		);
-	}
-
 	return (
 		<PageLayout
 			title="Tasks"
-			icon={<ClipboardList className="w-5 h-5" />}
+			icon={<LayoutGrid className="w-5 h-5" />}
 		>
-			<div className="max-w-4xl mx-auto pt-4 pb-6 px-4 md:p-6 space-y-6">
-				<NewTaskForm onSubmit={handleNewTask} />
-				{tasks.length === 0 ? (
-					<div className="text-center py-8 text-muted-foreground" aria-live="polite">
-						<ClipboardList className="w-10 h-10 mx-auto mb-3 opacity-40" />
-						<p className="font-medium">No tasks yet</p>
-						<p className="text-sm mt-1">Use the button above to start tracking your first task.</p>
-					</div>
-				) : (
-					<div className="space-y-4">
-						<h2 className="flex justify-between text-lg font-semibold text-foreground" aria-live="polite" aria-atomic="true">
-							Tasks ({tasks.length})
-							{dayStartTime && (
-								<p className="text-sm text-muted-foreground">
-									Day started at: {dayStartTime.toLocaleTimeString()}
-								</p>
-							)}
-						</h2>
-						{tasks.map((task) => (
-							<TaskItem
-								key={task.id}
-								task={task}
-								isActive={currentTask?.id === task.id}
-								currentDuration={
-									currentTask?.id === task.id ? getCurrentTaskDuration() : 0
-								}
-								onDelete={handleTaskDelete}
-							/>
-						))}
-					</div>
-				)}
-				<Button
-					variant="outline"
-					onClick={handleEndDay}
-					className="w-full font-bold bg-destructive/10 border-destructive text-destructive hover:bg-destructive/20 hover:text-destructive"
-				>
-					<CircleStop className="w-4 h-4" />
-					End Day
-				</Button>
+			<div className="max-w-7xl mx-auto pt-4 pb-6 px-4 md:p-6">
+				<KanbanBoard />
 			</div>
 		</PageLayout>
 	);

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -1,4 +1,4 @@
-import { DayRecord, Project, TodoItem } from "@/contexts/TimeTrackingContext";
+import { DayRecord, Project, TodoItem, PlannedTask } from "@/contexts/TimeTrackingContext";
 import { Task } from "@/contexts/TimeTrackingContext";
 import { TaskCategory } from "@/config/categories";
 import { LocalStorageService } from "@/services/localStorageService";
@@ -37,6 +37,10 @@ export interface DataService {
 	// Todo items operations
 	saveTodos: (todos: TodoItem[]) => Promise<void>;
 	getTodos: () => Promise<TodoItem[]>;
+
+	// Planned tasks operations
+	savePlannedTasks: (tasks: PlannedTask[]) => Promise<void>;
+	getPlannedTasks: () => Promise<PlannedTask[]>;
 
 	// Migration operations
 	migrateFromLocalStorage: () => Promise<void>;

--- a/src/services/localStorageService/constants.ts
+++ b/src/services/localStorageService/constants.ts
@@ -3,7 +3,8 @@ export const STORAGE_KEYS = {
 	ARCHIVED_DAYS: "timetracker_archived_days",
 	PROJECTS: "timetracker_projects",
 	CATEGORIES: "timetracker_categories",
-	TODOS: "timetracker_todos"
+	TODOS: "timetracker_todos",
+	PLANNED_TASKS: "timetracker_planned_tasks"
 };
 
 // Increment this when the stored data format changes in a breaking way.

--- a/src/services/localStorageService/index.ts
+++ b/src/services/localStorageService/index.ts
@@ -1,4 +1,4 @@
-import type { DayRecord, Project, TodoItem } from "@/contexts/TimeTrackingContext";
+import type { DayRecord, Project, TodoItem, PlannedTask } from "@/contexts/TimeTrackingContext";
 import type { TaskCategory } from "@/config/categories";
 import type { DataService, CurrentDayData } from "@/services/dataService";
 import { saveCurrentDay, getCurrentDay } from "./currentDay";
@@ -11,6 +11,7 @@ import {
 import { saveProjects, getProjects } from "./projects";
 import { saveCategories, getCategories } from "./categories";
 import { saveTodos, getTodos } from "./todos";
+import { savePlannedTasks, getPlannedTasks } from "./plannedTasks";
 
 export { STORAGE_KEYS, SCHEMA_VERSION } from "./constants";
 
@@ -61,6 +62,14 @@ export class LocalStorageService implements DataService {
 
 	getTodos(): Promise<TodoItem[]> {
 		return getTodos();
+	}
+
+	savePlannedTasks(tasks: PlannedTask[]): Promise<void> {
+		return savePlannedTasks(tasks);
+	}
+
+	getPlannedTasks(): Promise<PlannedTask[]> {
+		return getPlannedTasks();
 	}
 
 	async migrateFromLocalStorage(): Promise<void> {

--- a/src/services/localStorageService/plannedTasks.ts
+++ b/src/services/localStorageService/plannedTasks.ts
@@ -1,0 +1,23 @@
+import { PlannedTask } from "@/contexts/TimeTrackingContext";
+import { STORAGE_KEYS, SCHEMA_VERSION } from "./constants";
+import { readVersioned } from "./utils";
+
+export async function savePlannedTasks(tasks: PlannedTask[]): Promise<void> {
+	try {
+		localStorage.setItem(
+			STORAGE_KEYS.PLANNED_TASKS,
+			JSON.stringify({ data: tasks, _v: SCHEMA_VERSION })
+		);
+	} catch (error) {
+		console.warn("Failed to save planned tasks to localStorage:", error);
+	}
+}
+
+export async function getPlannedTasks(): Promise<PlannedTask[]> {
+	try {
+		return readVersioned<PlannedTask>(STORAGE_KEYS.PLANNED_TASKS, "data");
+	} catch (error) {
+		console.error("Error loading planned tasks from localStorage:", error);
+		return [];
+	}
+}

--- a/src/services/supabaseService.ts
+++ b/src/services/supabaseService.ts
@@ -9,7 +9,7 @@ import {
 	clearDataCaches,
 	trackAuthCall
 } from "@/lib/supabase";
-import { Task, DayRecord, Project, TodoItem } from "@/contexts/TimeTrackingContext";
+import { Task, DayRecord, Project, TodoItem, PlannedTask } from "@/contexts/TimeTrackingContext";
 import { TaskCategory } from "@/config/categories";
 import { DataService, CurrentDayData } from "@/services/dataService";
 import { LocalStorageService } from "@/services/localStorageService";
@@ -876,6 +876,99 @@ export class SupabaseService implements DataService {
 		}));
 	}
 
+	async savePlannedTasks(tasks: PlannedTask[]): Promise<void> {
+		const user = await this.requireUser();
+
+		if (tasks.length === 0) {
+			await supabase.from("planned_tasks").delete().eq("user_id", user.id);
+			trackDbCall("delete", "planned_tasks");
+			return;
+		}
+
+		const { data: existingRows } = await supabase
+			.from("planned_tasks")
+			.select("id")
+			.eq("user_id", user.id);
+		trackDbCall("select", "planned_tasks");
+
+		const existingIds = new Set(existingRows?.map((r: { id: string }) => r.id) || []);
+		const newIds = new Set(tasks.map((t) => t.id));
+
+		const toDelete = Array.from(existingIds).filter((id) => !newIds.has(id));
+		if (toDelete.length > 0) {
+			const { error: deleteError } = await supabase
+				.from("planned_tasks")
+				.delete()
+				.eq("user_id", user.id)
+				.in("id", toDelete);
+			trackDbCall("delete", "planned_tasks");
+			if (deleteError) throw deleteError;
+		}
+
+		const toUpsert = tasks.map((t) => ({
+			id: t.id,
+			user_id: user.id,
+			title: t.title,
+			description: t.description ?? null,
+			status: t.status,
+			project_name: t.project ?? null,
+			client: t.client ?? null,
+			category_id: t.category ?? null,
+			priority: t.priority,
+			linked_task_id: t.linkedTaskId ?? null,
+			created_at: t.createdAt
+		}));
+
+		const { error } = await supabase
+			.from("planned_tasks")
+			.upsert(toUpsert, { onConflict: "id" });
+		trackDbCall("upsert", "planned_tasks");
+		if (error) throw error;
+	}
+
+	async getPlannedTasks(): Promise<PlannedTask[]> {
+		const user = await this.requireUser();
+
+		const { data, error } = await supabase
+			.from("planned_tasks")
+			.select("*")
+			.eq("user_id", user.id)
+			.order("priority", { ascending: true })
+			.order("created_at", { ascending: true });
+		trackDbCall("select", "planned_tasks");
+
+		if (error) {
+			console.error("❌ Error loading planned tasks:", error);
+			throw error;
+		}
+
+		return (data || []).map((row: {
+			id: string;
+			title: string;
+			description: string | null;
+			status: string;
+			project_name: string | null;
+			client: string | null;
+			category_id: string | null;
+			priority: number;
+			linked_task_id: string | null;
+			created_at: string;
+			updated_at: string;
+		}) => ({
+			id: row.id,
+			title: row.title,
+			description: row.description ?? undefined,
+			status: row.status as PlannedTask["status"],
+			project: row.project_name ?? undefined,
+			client: row.client ?? undefined,
+			category: row.category_id ?? undefined,
+			priority: row.priority,
+			linkedTaskId: row.linked_task_id ?? undefined,
+			createdAt: row.created_at,
+			updatedAt: row.updated_at
+		}));
+	}
+
 	async migrateFromLocalStorage(): Promise<void> {
 		try {
 			const localService = new LocalStorageService();
@@ -885,6 +978,7 @@ export class SupabaseService implements DataService {
 			const currentDay = await localService.getCurrentDay();
 			const archivedDays = await localService.getArchivedDays();
 			const todos = await localService.getTodos();
+			const plannedTasks = await localService.getPlannedTasks();
 
 			const hasProjects = projects.length > 0;
 			const hasCategories = categories.length > 0;
@@ -892,8 +986,9 @@ export class SupabaseService implements DataService {
 				currentDay && (currentDay.tasks.length > 0 || currentDay.isDayStarted);
 			const hasArchivedDays = archivedDays.length > 0;
 			const hasTodos = todos.length > 0;
+			const hasPlannedTasks = plannedTasks.length > 0;
 
-			if (!hasProjects && !hasCategories && !hasCurrentDay && !hasArchivedDays && !hasTodos) {
+			if (!hasProjects && !hasCategories && !hasCurrentDay && !hasArchivedDays && !hasTodos && !hasPlannedTasks) {
 				return;
 			}
 
@@ -941,6 +1036,10 @@ export class SupabaseService implements DataService {
 				if (hasTodos) {
 					await this.saveTodos(todos);
 				}
+
+				if (hasPlannedTasks) {
+					await this.savePlannedTasks(plannedTasks);
+				}
 			} else {
 
 				if (hasProjects) await this.saveProjects(projects);
@@ -948,6 +1047,7 @@ export class SupabaseService implements DataService {
 				if (hasCurrentDay) await this.saveCurrentDay(currentDay);
 				if (hasArchivedDays) await this.saveArchivedDays(archivedDays);
 				if (hasTodos) await this.saveTodos(todos);
+				if (hasPlannedTasks) await this.savePlannedTasks(plannedTasks);
 			}
 
 		} catch (error) {
@@ -964,6 +1064,7 @@ export class SupabaseService implements DataService {
 			const projects = await this.getProjects();
 			const categories = await this.getCategories();
 			const todos = await this.getTodos();
+			const plannedTasks = await this.getPlannedTasks();
 
 			if (currentDay) {
 				await localService.saveCurrentDay(currentDay);
@@ -983,6 +1084,10 @@ export class SupabaseService implements DataService {
 
 			if (todos.length > 0) {
 				await localService.saveTodos(todos);
+			}
+
+			if (plannedTasks.length > 0) {
+				await localService.savePlannedTasks(plannedTasks);
 			}
 
 		} catch (error) {

--- a/supabase/migrations/20260525_planned_tasks.sql
+++ b/supabase/migrations/20260525_planned_tasks.sql
@@ -1,0 +1,40 @@
+-- Planned tasks table for kanban board feature
+-- Tasks created here are planning artifacts separate from time-tracked tasks (current_day.tasks)
+
+CREATE TABLE IF NOT EXISTS planned_tasks (
+  id             text PRIMARY KEY,
+  user_id        uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  title          text NOT NULL,
+  description    text,
+  status         text NOT NULL DEFAULT 'todo',
+  project_name   text,
+  client         text,
+  category_id    text,
+  priority       integer NOT NULL DEFAULT 0,
+  linked_task_id text,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  inserted_at    timestamptz DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_planned_tasks_user_id ON planned_tasks(user_id);
+CREATE INDEX IF NOT EXISTS idx_planned_tasks_status   ON planned_tasks(status);
+CREATE INDEX IF NOT EXISTS idx_planned_tasks_priority ON planned_tasks(priority);
+
+CREATE TRIGGER trg_update_planned_tasks_updated_at
+BEFORE UPDATE ON planned_tasks
+FOR EACH ROW EXECUTE PROCEDURE update_updated_at_column();
+
+ALTER TABLE planned_tasks ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own planned tasks"
+  ON planned_tasks FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their own planned tasks"
+  ON planned_tasks FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their own planned tasks"
+  ON planned_tasks FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their own planned tasks"
+  ON planned_tasks FOR DELETE USING (auth.uid() = user_id);


### PR DESCRIPTION
Introduces a full-featured Kanban board at /tasks for planning work ahead of time with four status columns (To Do, In Progress, Blocked, Done). Planned tasks are a separate entity from time-tracked tasks, enabling cross-day carry-over naturally.

Key additions:
- PlannedTask entity with status, priority, and linkedTaskId fields
- Dual storage: localStorage (guest) and Supabase (authenticated)
- "Pull to Day" action starts timing a planned task immediately, marking it in_progress and linking it to the active work day
- Stale day fix: endDay() now accepts an optional end time; a StaleDayDialog auto-opens when an unfinished day from a previous date is detected, letting the user set the correct end time before the day records with accurate durations