### PR TITLE
fix: prevent archived day from reappearing after hard refresh

### DIFF
--- a/src/contexts/TimeTrackingContext.tsx
+++ b/src/contexts/TimeTrackingContext.tsx
@@ -466,17 +466,21 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     }
   }, [dataService, loading]);
 
-  // Save on window close to prevent data loss
+  // Save on window close to prevent data loss.
+  // Uses latestStateRef to avoid stale-closure races (e.g. hard-refresh immediately
+  // after archiving, before React re-renders and re-registers this handler).
   useEffect(() => {
     const handleBeforeUnload = (_event: BeforeUnloadEvent) => {
-      if (!dataService || (!isDayStarted && tasks.length === 0)) return;
+      if (!dataService) return;
+      const state = latestStateRef.current;
+      if (!state.isDayStarted && state.tasks.length === 0) return;
       // Async saves cannot be reliably awaited during beforeunload, so write the
       // current state synchronously to localStorage as a guaranteed crash backup.
       // Supabase-mode users will have this local copy available for recovery on next load.
       try {
         localStorage.setItem(
           STORAGE_KEYS.CURRENT_DAY,
-          JSON.stringify({ isDayStarted, dayStartTime, tasks, currentTask, _v: SCHEMA_VERSION })
+          JSON.stringify({ ...state, _v: SCHEMA_VERSION })
         );
       } catch {
         // localStorage unavailable (quota exceeded, private mode); best effort only.
@@ -485,22 +489,24 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
 
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, [dataService, isDayStarted, tasks, currentTask, dayStartTime]);
+  }, [dataService]);
 
   // On iOS/Capacitor, useAppLifecycle fires at the Swift layer (appStateChange)
   // before WKWebView is frozen — more reliable than beforeunload or visibilitychange.
   // On web, it falls back to visibilitychange automatically.
+  // Uses latestStateRef to avoid the same stale-closure race as beforeunload.
   const handleBackground = useCallback(() => {
-    if (!isDayStarted && tasks.length === 0) return;
+    const state = latestStateRef.current;
+    if (!state.isDayStarted && state.tasks.length === 0) return;
     try {
       localStorage.setItem(
         STORAGE_KEYS.CURRENT_DAY,
-        JSON.stringify({ isDayStarted, dayStartTime, tasks, currentTask, _v: SCHEMA_VERSION })
+        JSON.stringify({ ...state, _v: SCHEMA_VERSION })
       );
     } catch {
       // best effort
     }
-  }, [isDayStarted, dayStartTime, tasks, currentTask]);
+  }, []);
 
   useAppLifecycle(handleBackground);
 
@@ -709,6 +715,10 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     setCurrentTask(null);
     setTasks([]);
     setIsDayStarted(false);
+
+    // Immediately sync the ref so beforeunload/handleBackground can't race and
+    // overwrite localStorage with the old (pre-archive) state before React re-renders.
+    latestStateRef.current = { isDayStarted: false, dayStartTime: null, currentTask: null, tasks: [] };
 
     // Save immediately since this is a critical action
     if (dataService) {


### PR DESCRIPTION
## Summary

- **Root cause:** `beforeunload` and `handleBackground` captured stale closure values via their `useEffect`/`useCallback` deps. If the user hard-refreshed immediately after archiving — before React re-rendered and re-registered the handler — the old handler fired with `isDayStarted=true` and the pre-archive task list, overwriting the correctly-cleared localStorage entry.
- **Fix 1:** Both handlers now read `latestStateRef.current` instead of closed-over state vars, eliminating the stale-closure window entirely.
- **Fix 2:** `archiveDay` updates `latestStateRef.current` synchronously (before any `await`) so the ref reflects the cleared state the instant the setters are called, not after the next React render.

## Test plan

- [ ] Start a day, add tasks, archive the day
- [ ] Immediately hard-refresh (Cmd+Shift+R) — should show "Start Day" screen, not the archived tasks
- [ ] Repeat with a normal refresh (Cmd+R) to confirm no regression
- [ ] Verify the archived day still appears correctly in the archive/history view

🤖 Generated with [Claude Code](https://claude.com/claude-code)