### PR TITLE
fix: restore PageLayout header visibility and add mobile actions slot

### DIFF
--- a/src/components/PageLayout.test.tsx
+++ b/src/components/PageLayout.test.tsx
@@ -34,7 +34,9 @@ describe("PageLayout", () => {
 				<p>x</p>
 			</PageLayout>
 		);
-		expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+		// Actions render in both the desktop header and the mobile strip
+		const buttons = screen.getAllByRole("button", { name: "Add" });
+		expect(buttons.length).toBeGreaterThan(0);
 	});
 
 	it("renders description when title is provided", () => {

--- a/src/components/PageLayout.tsx
+++ b/src/components/PageLayout.tsx
@@ -24,18 +24,25 @@ export const PageLayout = ({
 		<div className="min-h-screen bg-background">
 			<SiteNavigationMenu />
 			{title !== undefined && (
-				<div className="hidden max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
-					<div className="flex items-center justify-between">
-						<h1 className="md:text-2xl font-bold text-foreground flex items-center gap-2">
-							{icon}
-							{title}
-						</h1>
-						{actions && <div className="print:hidden">{actions}</div>}
+				<>
+					<div className="hidden md:block max-w-6xl mx-auto pt-4 pb-2 px-4 md:p-6 print:p-4">
+						<div className="flex items-center justify-between">
+							<h1 className="md:text-2xl font-bold text-foreground flex items-center gap-2">
+								{icon}
+								{title}
+							</h1>
+							{actions && <div className="print:hidden">{actions}</div>}
+						</div>
+						{description && (
+							<p className="text-sm text-muted-foreground mt-1">{description}</p>
+						)}
 					</div>
-					{description && (
-						<p className="text-sm text-muted-foreground mt-1">{description}</p>
+					{actions && (
+						<div className="md:hidden flex justify-end px-4 py-2 border-b border-border print:hidden">
+							{actions}
+						</div>
 					)}
-				</div>
+				</>
 			)}
 			{children}
 		</div>


### PR DESCRIPTION
## Summary

Restores the page header section (title, icon, actions) that was accidentally hidden at all breakpoints, and adds a mobile-specific actions bar so page-level action buttons are accessible on narrow viewports.

## Type of Change

- [ ] New feature
- [ ] Update to existing feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Other (describe below)

## Related Issue

Closes #

## Changes Made

- `src/components/PageLayout.tsx` — Added `md:block` to the desktop header div class so it renders on ≥768 px viewports (was permanently `display:none` due to bare `hidden` class)
- `src/components/PageLayout.tsx` — Added a `md:hidden` actions bar that renders the `actions` prop below the nav on mobile, giving narrow viewports access to page-level action buttons (e.g. Add Category, Reset to Defaults) that previously never rendered

## Root Cause

Commit `0130933` removed the iOS/Capacitor build and resolved a merge conflict by applying `hidden` to the header div without the matching `md:block` override. The intended class was `hidden md:block` — hide on mobile, show on desktop — but the `md:block` part was dropped. As a result the entire header section, including the `actions` slot, was `display:none` at every breakpoint, silently preventing any action button (and any sheet it triggers) from rendering on mobile.

## Checklist

### Documentation

- [ ] Any notable changes added to the `README.md`
- [ ] `CHANGELOG.md` updated accordingly
- [x] N/A — no README changes

### General

- [x] Branch is up to date with `main`
- [x] No unrelated files included in this PR
- [x] Tested locally by invoking the `npm run test`, `npm run lint`, and `npm run build`

## Notes for Reviewers

The mobile actions bar (`md:hidden` strip) only renders when the `actions` prop is provided and the page has a `title`, so pages without actions are unaffected. The strip uses `border-b border-border` to visually anchor it below the nav, matching the existing desktop header style.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CQMMD3NwoJywWphB2woG6M)_