### PR TITLE
fix: replace mobile bottom-sheet usage with modals

### DIFF
--- a/src/components/ui/adaptive-dialog.tsx
+++ b/src/components/ui/adaptive-dialog.tsx
@@ -7,33 +7,12 @@ import {
 	DialogDescription,
 	DialogFooter,
 } from "@/components/ui/dialog"
-import {
-	Drawer,
-	DrawerContent,
-	DrawerHeader,
-	DrawerTitle,
-	DrawerDescription,
-	DrawerFooter,
-} from "@/components/ui/drawer"
-
-function useIsMobile() {
-	const [isMobile, setIsMobile] = React.useState(
-		() => typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches
-	)
-	React.useEffect(() => {
-		const mq = window.matchMedia("(max-width: 767px)")
-		const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches)
-		mq.addEventListener("change", handler)
-		return () => mq.removeEventListener("change", handler)
-	}, [])
-	return isMobile
-}
 
 interface AdaptiveDialogProps {
 	open: boolean
 	onOpenChange: (open: boolean) => void
 	children: React.ReactNode
-	/** vaul snap points, mobile only */
+	/** unused — kept for API compatibility */
 	snapPoints?: (number | string)[]
 }
 
@@ -41,32 +20,7 @@ export const AdaptiveDialog = ({
 	open,
 	onOpenChange,
 	children,
-	snapPoints,
 }: AdaptiveDialogProps) => {
-	const isMobile = useIsMobile()
-	const [activeSnapPoint, setActiveSnapPoint] = React.useState<number | string | null>(
-		snapPoints?.[0] ?? null
-	)
-
-	React.useEffect(() => {
-		if (open) {
-			setActiveSnapPoint(snapPoints?.[0] ?? null)
-		}
-	}, [open]) // snapPoints are static per dialog instance
-
-	if (isMobile) {
-		return (
-			<Drawer
-				open={open}
-				onOpenChange={onOpenChange}
-				snapPoints={snapPoints}
-				activeSnapPoint={activeSnapPoint}
-				setActiveSnapPoint={setActiveSnapPoint}
-			>
-				{children}
-			</Drawer>
-		)
-	}
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			{children}
@@ -83,14 +37,6 @@ export const AdaptiveDialogContent = ({
 	children,
 	className,
 }: AdaptiveDialogContentProps) => {
-	const isMobile = useIsMobile()
-	if (isMobile) {
-		return (
-			<DrawerContent className={className}>
-				{children}
-			</DrawerContent>
-		)
-	}
 	return (
 		<DialogContent className={className}>
 			{children}
@@ -105,10 +51,6 @@ export const AdaptiveDialogHeader = ({
 	children: React.ReactNode
 	className?: string
 }) => {
-	const isMobile = useIsMobile()
-	if (isMobile) {
-		return <DrawerHeader className={className}>{children}</DrawerHeader>
-	}
 	return <DialogHeader className={className}>{children}</DialogHeader>
 }
 
@@ -116,14 +58,6 @@ export const AdaptiveDialogTitle = React.forwardRef<
 	HTMLHeadingElement,
 	React.HTMLAttributes<HTMLHeadingElement>
 >(({ children, className, ...props }, ref) => {
-	const isMobile = useIsMobile()
-	if (isMobile) {
-		return (
-			<DrawerTitle ref={ref} className={className} {...props}>
-				{children}
-			</DrawerTitle>
-		)
-	}
 	return (
 		<DialogTitle ref={ref} className={className} {...props}>
 			{children}
@@ -136,14 +70,6 @@ export const AdaptiveDialogDescription = React.forwardRef<
 	HTMLParagraphElement,
 	React.HTMLAttributes<HTMLParagraphElement>
 >(({ children, className, ...props }, ref) => {
-	const isMobile = useIsMobile()
-	if (isMobile) {
-		return (
-			<DrawerDescription ref={ref} className={className} {...props}>
-				{children}
-			</DrawerDescription>
-		)
-	}
 	return (
 		<DialogDescription ref={ref} className={className} {...props}>
 			{children}
@@ -159,13 +85,5 @@ export const AdaptiveDialogFooter = ({
 	children: React.ReactNode
 	className?: string
 }) => {
-	const isMobile = useIsMobile()
-	if (isMobile) {
-		return (
-			<DrawerFooter className={className}>
-				{children}
-			</DrawerFooter>
-		)
-	}
 	return <DialogFooter className={className}>{children}</DialogFooter>
 }


### PR DESCRIPTION
## Summary

Removes the mobile bottom-sheet (vaul Drawer) behavior from `AdaptiveDialog`. All dialogs now render as standard Radix modals on every screen size, including mobile.

## Type of Change

- [ ] New feature
- [x] Update to existing feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (describe below)

## Related Issue

<!-- Link the issue this PR resolves, e.g. "Closes #12" -->
Closes #

## Changes Made

- `src/components/ui/adaptive-dialog.tsx` — removed `useIsMobile` hook, all `Drawer` imports, and the mobile branch. Every `Adaptive*` export now delegates directly to the corresponding `Dialog*` component. The `snapPoints` prop is retained in the interface for API compatibility but has no effect.

## Checklist

> Complete all items that apply to your change. Check N/A for items that don't apply.

### Documentation

> Run `sync-docs` skill with Claude Code to automatically update relevant files.

- [ ] Any notable changes added to the `README.md`
- [ ] `CHANGELOG.md` updated accordingly
- [x] N/A — no README changes

### General

- [ ] Branch is up to date with `main`
- [x] No unrelated files included in this PR
- [ ] Tested locally by invoking the `npm run test`, `npm run lint`, and `npm run build`

## Notes for Reviewers

The six dialogs that use `AdaptiveDialog` (`TaskEditDialog`, `StartDayDialog`, `ArchiveEditDialog`, `DeleteConfirmationDialog`, `StaleDayDialog`, `PlannedTaskDialog`) require no changes — they consume the same exported API and will automatically get modal behavior.
