### PR TITLE
feat: add duplicate task button to BackdatedEntryDialog

### DIFF
--- a/src/components/BackdatedEntryDialog.tsx
+++ b/src/components/BackdatedEntryDialog.tsx
@@ -27,7 +27,7 @@ import { DayRecord, Task } from "@/contexts/TimeTrackingContext";
 import { useTimeTracking } from "@/hooks/useTimeTracking";
 import { useHaptics } from "@/hooks/useHaptics";
 import { formatDuration } from "@/utils/timeUtil";
-import { Calendar, Plus, Trash2, Loader2 } from "lucide-react";
+import { Calendar, Plus, Trash2, Loader2, Copy } from "lucide-react";
 
 interface BackdatedEntryDialogProps {
 	isOpen: boolean;
@@ -218,13 +218,29 @@ export const BackdatedEntryDialog: React.FC<BackdatedEntryDialogProps> = ({
 		setTasks(prev => prev.filter(t => t.id !== id));
 	};
 
+	const duplicateTask = (id: string) => {
+		setTasks(prev => {
+			const idx = prev.findIndex(t => t.id === id);
+			if (idx === -1) return prev;
+			const src = prev[idx];
+			const copy: BackdatedTask = {
+				...src,
+				id: Date.now().toString() + Math.random().toString(36).slice(2, 6),
+				title: src.title ? `${src.title} (copy)` : "",
+			};
+			const next = [...prev];
+			next.splice(idx + 1, 0, copy);
+			return next;
+		});
+	};
+
 	const updateTask = (id: string, field: keyof BackdatedTask, value: string) => {
 		setTasks(prev =>
 			prev.map(t => (t.id === id ? { ...t, [field]: value } : t))
 		);
 	};
 
-	const isValid = errors.length === 0 || true;
+	const isValid = errors.length === 0;
 
 	return (
 		<AdaptiveDialog open={isOpen} onOpenChange={onClose} snapPoints={[0.85, 1]}>
@@ -362,6 +378,16 @@ export const BackdatedEntryDialog: React.FC<BackdatedEntryDialogProps> = ({
 														{formatDuration(taskDuration)}
 													</Badge>
 												)}
+												<Button
+													type="button"
+													onClick={() => duplicateTask(task.id)}
+													size="sm"
+													variant="ghost"
+													className="h-7 w-7 p-0"
+													aria-label={`Duplicate task ${index + 1}`}
+												>
+													<Copy className="w-3.5 h-3.5" />
+												</Button>
 												{tasks.length > 1 && (
 													<Button
 														type="button"


### PR DESCRIPTION
## Summary

- Adds a **duplicate task** button (copy icon) on each task row in the Add Past Entry dialog — inserts a clone immediately below with same times, project, category, description, and a `(copy)` title suffix for easy identification
- Fixes validation bypass: `isValid = errors.length === 0 || true` → `isValid = errors.length === 0` so the Submit button correctly disables when there are validation errors

## Test plan

- [ ] Open Archive → Add Past Entry
- [ ] Add a task with title, times, project/category
- [ ] Click the copy icon — verify duplicate appears below with `(copy)` suffix and same field values
- [ ] Verify copy button visible on single task (no remove button yet shown)
- [ ] Submit with empty task title — verify Submit is disabled
- [ ] Submit valid form — verify saves and dialog closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)