### PR TITLE
fix: resolve clients/projects save failures with three targeted fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `forceSyncToDatabase` used the `projects` closure variable, which is stale when called immediately after a project mutation (before React re-renders). Project add, edit, delete, archive, and restore via `ProjectList` all called `forceSyncToDatabase` right after the mutation, causing the pre-mutation project list to be written to storage while the icon incorrectly turned green. Added `projectsRef` (mirroring `clientsRef`) updated synchronously by every project mutation and at load; `forceSyncToDatabase` now reads `projectsRef.current` so the correct list is always saved.
+  — `src/contexts/TimeTrackingContext.tsx`
+- `addClient`, `archiveClient`, and `restoreClient` called `setHasUnsavedChanges(true)` even though callers immediately persist the change via `persistClient` / `persistClients`. Since clients are excluded from `forceSyncToDatabase`'s bulk save, the only path to clear the flag was unrelated to the client write, leaving the save icon orange after every client operation despite the data being safely written. Removed the `setHasUnsavedChanges(true)` calls from all three client mutators.
+  — `src/contexts/TimeTrackingContext.tsx`
+- The project load merge always started from hardcoded defaults and only appended saved projects whose name+client did not match any default. Any edit to a default project (hourly rate, color, `isBillable`) was silently discarded on reload and replaced by the hardcoded default values. Changed the merge to replace the default entry with the saved version when name+client match, so user edits to default projects survive page reloads.
+  — `src/contexts/TimeTrackingContext.tsx`
 - `BackdatedEntryDialog` imported `useTimeTracking` from `@/contexts/TimeTrackingContext` (not exported there) — corrected to import the hook from `@/hooks/useTimeTracking` and types (`DayRecord`, `Task`) from the context
   — `src/components/BackdatedEntryDialog.tsx`
 

--- a/src/contexts/TimeTrackingContext.tsx
+++ b/src/contexts/TimeTrackingContext.tsx
@@ -298,6 +298,9 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
   const plannedLoadedRef = useRef(false);
   // Tracks current plannedTasks for use in callbacks without closing over state.
   const plannedTasksRef = useRef<PlannedTask[]>([]);
+  // Mirrors the latest projects list so forceSyncToDatabase() saves fresh data
+  // even when called immediately after a mutation (before React re-renders).
+  const projectsRef = useRef<Project[]>(convertDefaultProjects(DEFAULT_PROJECTS));
   // Mirrors the latest clients list so persistClients() saves fresh data
   // without depending on render-time closures. Updated synchronously by every
   // client mutation (and at load) so a save fired immediately after a mutation
@@ -362,18 +365,21 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
         const loadedProjects = await dataService.getProjects();
         let resolvedProjects: Project[];
         if (loadedProjects.length > 0) {
-          // Merge default projects with saved projects, avoiding duplicates
+          // Merge: start from defaults so missing defaults always appear, but
+          // prefer the saved version when name+client matches a default (so
+          // user edits to hourly rate, color, etc. survive reloads).
           const defaultProjects = convertDefaultProjects(DEFAULT_PROJECTS);
           const mergedProjects = [...defaultProjects];
 
-          // Add saved projects that don't conflict with default ones
           loadedProjects.forEach((savedProject: Project) => {
-            const existsInDefaults = defaultProjects.some(
+            const defaultIndex = mergedProjects.findIndex(
               defaultProject =>
                 defaultProject.name === savedProject.name &&
                 defaultProject.client === savedProject.client
             );
-            if (!existsInDefaults) {
+            if (defaultIndex !== -1) {
+              mergedProjects[defaultIndex] = savedProject;
+            } else {
               mergedProjects.push(savedProject);
             }
           });
@@ -389,6 +395,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
           ...project,
           archived: project.archived ?? false
         }));
+        projectsRef.current = resolvedProjects;
         setProjects(resolvedProjects);
 
         // Load clients, then reconcile against the client name strings
@@ -522,7 +529,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
       // doesn't silently leave other saves in an unknown state.
       const results = await Promise.allSettled([
         stableSaveCurrentDay(),
-        dataService.saveProjects(projects),
+        dataService.saveProjects(projectsRef.current),
         dataService.saveCategories(categories),
         dataService.saveArchivedDays(archivedDays),
         dataService.saveTodos(todoItems),
@@ -548,7 +555,7 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     } finally {
       setIsSyncing(false);
     }
-  }, [dataService, stableSaveCurrentDay, projects, categories, archivedDays, todoItems, plannedTasks, errorNotify]);
+  }, [dataService, stableSaveCurrentDay, categories, archivedDays, todoItems, plannedTasks, errorNotify]);
 
   // Load current day data (for periodic sync)
   const loadCurrentDay = useCallback(async () => {
@@ -902,50 +909,57 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
   };
 
   // Project management functions - NO AUTOMATIC SAVING
+  // projectsRef is updated synchronously so forceSyncToDatabase() always reads
+  // the latest list even when called immediately after a mutation.
   const addProject = (project: Omit<Project, 'id'>) => {
     const newProject: Project = {
       ...project,
       id: Date.now().toString()
     };
-    setProjects(prev => [...prev, newProject]);
+    const next = [...projectsRef.current, newProject];
+    projectsRef.current = next;
+    setProjects(next);
     setHasUnsavedChanges(true);
   };
 
   const updateProject = (projectId: string, updates: Partial<Project>) => {
-    setProjects(prev =>
-      prev.map(project =>
-        project.id === projectId ? { ...project, ...updates } : project
-      )
+    const next = projectsRef.current.map(project =>
+      project.id === projectId ? { ...project, ...updates } : project
     );
+    projectsRef.current = next;
+    setProjects(next);
     setHasUnsavedChanges(true);
   };
 
   const deleteProject = (projectId: string) => {
-    setProjects(prev => prev.filter(project => project.id !== projectId));
+    const next = projectsRef.current.filter(project => project.id !== projectId);
+    projectsRef.current = next;
+    setProjects(next);
     setHasUnsavedChanges(true);
   };
 
   const resetProjectsToDefaults = () => {
     const defaultProjects = convertDefaultProjects(DEFAULT_PROJECTS);
+    projectsRef.current = defaultProjects;
     setProjects(defaultProjects);
     setHasUnsavedChanges(true);
   };
 
   const archiveProject = (projectId: string) => {
-    setProjects(prev =>
-      prev.map(project =>
-        project.id === projectId ? { ...project, archived: true } : project
-      )
+    const next = projectsRef.current.map(project =>
+      project.id === projectId ? { ...project, archived: true } : project
     );
+    projectsRef.current = next;
+    setProjects(next);
     setHasUnsavedChanges(true);
   };
 
   const restoreProject = (projectId: string) => {
-    setProjects(prev =>
-      prev.map(project =>
-        project.id === projectId ? { ...project, archived: false } : project
-      )
+    const next = projectsRef.current.map(project =>
+      project.id === projectId ? { ...project, archived: false } : project
     );
+    projectsRef.current = next;
+    setProjects(next);
     setHasUnsavedChanges(true);
   };
 
@@ -990,7 +1004,6 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     const next = [...clientsRef.current, newClient];
     clientsRef.current = next;
     setClients(next);
-    setHasUnsavedChanges(true);
     return newClient;
   };
 
@@ -1018,7 +1031,6 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     );
     clientsRef.current = next;
     setClients(next);
-    setHasUnsavedChanges(true);
     return null;
   };
 
@@ -1028,7 +1040,6 @@ export const TimeTrackingProvider: React.FC<{ children: React.ReactNode }> = ({
     );
     clientsRef.current = next;
     setClients(next);
-    setHasUnsavedChanges(true);
   };
 
   // Archive management functions


### PR DESCRIPTION
Bug 1 — stale closure in forceSyncToDatabase:
ProjectList.tsx calls addProject/updateProject/archiveProject and then
immediately awaits forceSyncToDatabase(). Because React state updates are
asynchronous, the `projects` captured in forceSyncToDatabase's useCallback
closure is the pre-mutation list — so the just-added/changed project is
never included in the save. Fix: add a projectsRef (mirroring the existing
clientsRef pattern) that is updated synchronously in every project mutation
and during loadData. forceSyncToDatabase now reads projectsRef.current
instead of the closure variable, and `projects` is removed from its dep
array.

Bug 2 — client mutations wrongly set hasUnsavedChanges:
addClient, archiveClient, and restoreClient called setHasUnsavedChanges(true)
even though callers immediately persist the change via persistClient /
persistClients. This left the save icon orange after every client operation
even when the data was already written. Since clients are excluded from
forceSyncToDatabase's bulk save, clearing hasUnsavedChanges via that path
was unrelated to whether the client data was safe. Fix: remove the
setHasUnsavedChanges(true) calls from the three client mutators.

Bug 3 — saved edits to default projects discarded on reload:
The project load merge always started from hardcoded defaults and only
appended saved projects whose name+client didn't match any default. A saved
modified default (same name+client, different hourlyRate or color) was
silently dropped and replaced by the hardcoded version. Fix: when a saved
project matches a default by name+client, replace the default entry with the
saved one rather than skipping it.

https://claude.ai/code/session_01K9hQPH6ddsadiAF19VGnJQ