### PR TITLE
feat: add project filter to report page

### DIFF
--- a/src/pages/Report.tsx
+++ b/src/pages/Report.tsx
@@ -19,6 +19,13 @@ import {
   PopoverContent,
   PopoverTrigger
 } from '@/components/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
@@ -27,6 +34,7 @@ import {
   groupByCalendarWeek,
   groupByDateRange,
   getMostRecentCompleteWeek,
+  filterWeekByProject,
   formatDuration,
   serializeWeekForPrompt,
   weekKey,
@@ -368,6 +376,8 @@ function SavedSummaryBanner({
 // Main Page
 // ---------------------------------------------------------------------------
 
+const ALL_PROJECTS_VALUE = "all-projects";
+
 export default function Report() {
   const { archivedDays: rawArchivedDays, todoItems } = useTimeTracking();
   const archivedDays = useMemo(
@@ -383,14 +393,23 @@ export default function Report() {
   const [isCustomRange, setIsCustomRange] = useState(false);
   const [calendarIndex, setCalendarIndex] = useState(0);
   const [tone, setTone] = useState<ReportTone>('standup');
+  const [selectedProject, setSelectedProject] = useState<string>('');
+
+  const filteredWeek = useMemo(
+    () => selectedWeek ? filterWeekByProject(selectedWeek, selectedProject) : null,
+    [selectedWeek, selectedProject]
+  );
 
   const { summary, state, error, generate, load, updateSummary, reset } =
     useReportSummary();
 
-  // Derive the localStorage key for the current week+tone
+  // Derive the localStorage key for the current week+tone+project.
   // Empty string when no week is selected yet; useReportStorage will return null
-  // for this key and save() is gated behind the generate button (requires selectedWeek)
-  const currentWeekKey = selectedWeek ? weekKey(selectedWeek.weekStart) : "";
+  // for this key and save() is gated behind the generate button (requires selectedWeek).
+  // Including the project keeps project-filtered summaries separate from full-week summaries.
+  const currentWeekKey = selectedWeek
+    ? `${weekKey(selectedWeek.weekStart)}${selectedProject ? `_${selectedProject}` : ""}`
+    : "";
   const {
     saved: savedSummary,
     save: saveSummary,
@@ -399,13 +418,13 @@ export default function Report() {
 
   // Auto-save whenever generation succeeds or the user edits the summary
   useEffect(() => {
-    if (state !== "success" || !summary || !selectedWeek) return;
+    if (state !== "success" || !summary || !filteredWeek) return;
     // Debounce saves to avoid write-on-every-keystroke (important for iOS WebView)
     const timer = setTimeout(() => {
-      saveSummary(summary, selectedWeek.label);
+      saveSummary(summary, filteredWeek.label);
     }, 300);
     return () => clearTimeout(timer);
-  }, [state, summary, selectedWeek, saveSummary]);
+  }, [state, summary, filteredWeek, saveSummary]);
 
   useEffect(() => {
     const initial = getMostRecentCompleteWeek(calendarWeeks);
@@ -417,6 +436,7 @@ export default function Report() {
     if (next < calendarWeeks.length) {
       setCalendarIndex(next);
       setSelectedWeek(calendarWeeks[next]);
+      setSelectedProject('');
       setIsCustomRange(false);
       reset();
     }
@@ -427,6 +447,7 @@ export default function Report() {
     if (next >= 0) {
       setCalendarIndex(next);
       setSelectedWeek(calendarWeeks[next]);
+      setSelectedProject('');
       setIsCustomRange(false);
       reset();
     }
@@ -435,6 +456,7 @@ export default function Report() {
   function handleCustomRange(from: Date, to: Date) {
     const group = groupByDateRange(archivedDays, from, to);
     setSelectedWeek(group);
+    setSelectedProject('');
     setIsCustomRange(true);
     reset();
   }
@@ -444,9 +466,14 @@ export default function Report() {
     reset();
   }
 
+  function handleProjectChange(v: string) {
+    setSelectedProject(v);
+    reset();
+  }
+
   function handleGenerate() {
-    if (!selectedWeek) return;
-    generate(selectedWeek, tone, todoItems);
+    if (!filteredWeek) return;
+    generate(filteredWeek, tone, todoItems);
   }
 
   function handleSummaryUpdate(v: string) {
@@ -463,7 +490,7 @@ export default function Report() {
 
   const canGoPrev = !isCustomRange && calendarIndex < calendarWeeks.length - 1;
   const canGoNext = !isCustomRange && calendarIndex > 0;
-  const hasNoData = selectedWeek?.days.length === 0;
+  const hasNoData = filteredWeek?.days.length === 0;
 
   // Empty state — no archived data at all
   if (archivedDays.length === 0) {
@@ -546,6 +573,7 @@ export default function Report() {
                     onClick={() => {
                       setIsCustomRange(false);
                       setSelectedWeek(calendarWeeks[calendarIndex]);
+                      setSelectedProject('');
                       reset();
                     }}
                   >
@@ -555,16 +583,43 @@ export default function Report() {
               )}
             </div>
 
+            {/* Project filter */}
+            {selectedWeek && selectedWeek.projects.length > 0 && (
+              <div className="space-y-2">
+                <Label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  Project
+                </Label>
+                <Select
+                  value={selectedProject || ALL_PROJECTS_VALUE}
+                  onValueChange={v =>
+                    handleProjectChange(v === ALL_PROJECTS_VALUE ? '' : v)
+                  }
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={ALL_PROJECTS_VALUE}>All projects</SelectItem>
+                    {selectedWeek.projects.map(p => (
+                      <SelectItem key={p} value={p}>
+                        {p}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
             {/* Week preview */}
-            {selectedWeek && <WeekPreview week={selectedWeek} />}
+            {filteredWeek && <WeekPreview week={filteredWeek} />}
 
             {/* Tone selector */}
-            {selectedWeek && !hasNoData && (
+            {filteredWeek && !hasNoData && (
               <ToneSelector value={tone} onChange={handleToneChange} />
             )}
 
             {/* Generate button */}
-            {selectedWeek && !hasNoData && state !== 'loading' && (
+            {filteredWeek && !hasNoData && state !== 'loading' && (
               <Button className="w-full" onClick={handleGenerate}>
                 {state === 'success'
                   ? 'Regenerate summary'
@@ -573,13 +628,13 @@ export default function Report() {
             )}
 
             {/* Dev-only prompt preview */}
-            {import.meta.env.DEV && selectedWeek && (
+            {import.meta.env.DEV && filteredWeek && (
               <details className="text-xs text-muted-foreground border rounded-md overflow-hidden">
                 <summary className="cursor-pointer select-none px-3 py-2 bg-muted/30 hover:bg-muted/50 transition-colors">
                   Prompt preview (dev only)
                 </summary>
                 <pre className="px-3 py-3 whitespace-pre-wrap text-[11px] leading-relaxed overflow-x-auto bg-muted/10">
-                  {serializeWeekForPrompt(selectedWeek)}
+                  {serializeWeekForPrompt(filteredWeek)}
                 </pre>
               </details>
             )}
@@ -618,18 +673,18 @@ export default function Report() {
               </div>
             )}
 
-            {state === 'loading' && selectedWeek && (
-              <GeneratingState weekLabel={selectedWeek.label} />
+            {state === 'loading' && filteredWeek && (
+              <GeneratingState weekLabel={filteredWeek.label} />
             )}
 
             {state === 'error' && error && (
               <ErrorState message={error} onRetry={handleGenerate} />
             )}
 
-            {state === 'success' && summary && selectedWeek && (
+            {state === 'success' && summary && filteredWeek && (
               <SummaryOutput
                 summary={summary}
-                weekLabel={selectedWeek.label}
+                weekLabel={filteredWeek.label}
                 onUpdate={handleSummaryUpdate}
                 onRegenerate={handleGenerate}
               />

--- a/src/utils/reportUtils.test.ts
+++ b/src/utils/reportUtils.test.ts
@@ -223,9 +223,11 @@ describe("getMostRecentCompleteWeek", () => {
 	});
 
 	it("returns a past week as the most recent complete week", () => {
-		const days = [
-			makeDay("2026-01-15", [{ project: "A", duration: 3600000 }]),
-		];
+		// Use a date guaranteed to be in the past regardless of when CI runs
+		const pastDate = new Date(Date.now() - 365 * 86400000)
+			.toISOString()
+			.slice(0, 10);
+		const days = [makeDay(pastDate, [{ project: "A", duration: 3600000 }])];
 		const weeks = groupByCalendarWeek(days);
 		const result = getMostRecentCompleteWeek(weeks);
 		expect(result).not.toBeNull();

--- a/src/utils/reportUtils.test.ts
+++ b/src/utils/reportUtils.test.ts
@@ -1,0 +1,245 @@
+// src/utils/reportUtils.test.ts
+import { describe, it, expect } from "vitest";
+import {
+	filterWeekByProject,
+	formatDuration,
+	groupByCalendarWeek,
+	getMostRecentCompleteWeek,
+	getWeekStart,
+	ArchivedDay,
+	WeekGroup,
+} from "@/utils/reportUtils";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDay(
+	date: string,
+	tasks: { project?: string; duration: number }[]
+): ArchivedDay {
+	return {
+		id: date,
+		date,
+		startTime: `${date}T09:00:00.000Z`,
+		endTime: `${date}T17:00:00.000Z`,
+		totalDuration: tasks.reduce((s, t) => s + t.duration, 0),
+		tasks: tasks.map((t, i) => ({
+			id: `${date}-task-${i}`,
+			title: `Task ${i}`,
+			startTime: `${date}T09:00:00.000Z`,
+			endTime: `${date}T10:00:00.000Z`,
+			duration: t.duration,
+			project: t.project,
+		})),
+	};
+}
+
+function makeWeek(days: ArchivedDay[]): WeekGroup {
+	const projects = [
+		...new Set(
+			days
+				.flatMap(d => d.tasks.map(t => t.project))
+				.filter((p): p is string => Boolean(p))
+		),
+	];
+	const totalDuration = days.reduce((s, d) => s + d.totalDuration, 0);
+	const weekStart = getWeekStart(new Date(days[0].date));
+	return {
+		weekStart,
+		weekEnd: new Date(weekStart.getTime() + 6 * 86400000),
+		label: "Test week",
+		days,
+		totalDuration,
+		projects,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// formatDuration
+// ---------------------------------------------------------------------------
+
+describe("formatDuration", () => {
+	it("formats hours and minutes", () => {
+		expect(formatDuration(3 * 3600000 + 45 * 60000)).toBe("3h 45m");
+	});
+
+	it("formats whole hours with no minutes", () => {
+		expect(formatDuration(2 * 3600000)).toBe("2h");
+	});
+
+	it("formats minutes only when under an hour", () => {
+		expect(formatDuration(30 * 60000)).toBe("30m");
+	});
+
+	it("returns 0m for zero", () => {
+		expect(formatDuration(0)).toBe("0m");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// filterWeekByProject
+// ---------------------------------------------------------------------------
+
+describe("filterWeekByProject", () => {
+	const days = [
+		makeDay("2026-05-25", [
+			{ project: "Alpha", duration: 3600000 },
+			{ project: "Beta", duration: 1800000 },
+		]),
+		makeDay("2026-05-26", [{ project: "Alpha", duration: 7200000 }]),
+		makeDay("2026-05-27", [{ project: "Beta", duration: 3600000 }]),
+	];
+	const week = makeWeek(days);
+
+	it("returns the original week reference when project is empty string", () => {
+		expect(filterWeekByProject(week, "")).toBe(week);
+	});
+
+	it("filters tasks to only those matching the selected project", () => {
+		const result = filterWeekByProject(week, "Alpha");
+		for (const day of result.days) {
+			for (const task of day.tasks) {
+				expect(task.project).toBe("Alpha");
+			}
+		}
+	});
+
+	it("excludes days that have no tasks for the selected project", () => {
+		const result = filterWeekByProject(week, "Alpha");
+		// 2026-05-27 has only Beta tasks — should be absent
+		expect(result.days.find(d => d.date === "2026-05-27")).toBeUndefined();
+		expect(result.days).toHaveLength(2);
+	});
+
+	it("recomputes totalDuration from matching tasks only", () => {
+		const result = filterWeekByProject(week, "Alpha");
+		// Alpha: 3 600 000 (day 1) + 7 200 000 (day 2) = 10 800 000
+		expect(result.totalDuration).toBe(10800000);
+	});
+
+	it("sets projects to an array containing only the selected project", () => {
+		const result = filterWeekByProject(week, "Beta");
+		expect(result.projects).toEqual(["Beta"]);
+	});
+
+	it("preserves week metadata (label, weekStart, weekEnd)", () => {
+		const result = filterWeekByProject(week, "Alpha");
+		expect(result.label).toBe(week.label);
+		expect(result.weekStart).toBe(week.weekStart);
+		expect(result.weekEnd).toBe(week.weekEnd);
+	});
+
+	it("returns empty days and zero duration when the project is not in the week", () => {
+		const result = filterWeekByProject(week, "Gamma");
+		expect(result.days).toHaveLength(0);
+		expect(result.totalDuration).toBe(0);
+	});
+
+	it("handles a week where a day has multiple tasks from the same project", () => {
+		const multiTaskDays = [
+			makeDay("2026-05-25", [
+				{ project: "Alpha", duration: 1800000 },
+				{ project: "Alpha", duration: 900000 },
+				{ project: "Beta", duration: 3600000 },
+			]),
+		];
+		const multiWeek = makeWeek(multiTaskDays);
+		const result = filterWeekByProject(multiWeek, "Alpha");
+		expect(result.days).toHaveLength(1);
+		expect(result.days[0].tasks).toHaveLength(2);
+		expect(result.totalDuration).toBe(2700000);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// groupByCalendarWeek
+// ---------------------------------------------------------------------------
+
+describe("groupByCalendarWeek", () => {
+	it("returns an empty array for no days", () => {
+		expect(groupByCalendarWeek([])).toHaveLength(0);
+	});
+
+	it("groups adjacent days into the same calendar week", () => {
+		const days = [
+			makeDay("2026-05-25", [{ project: "A", duration: 3600000 }]),
+			makeDay("2026-05-26", [{ project: "A", duration: 3600000 }]),
+		];
+		const weeks = groupByCalendarWeek(days);
+		expect(weeks).toHaveLength(1);
+		expect(weeks[0].days).toHaveLength(2);
+	});
+
+	it("separates days from different calendar weeks", () => {
+		const days = [
+			makeDay("2026-05-25", [{ project: "A", duration: 3600000 }]),
+			makeDay("2026-06-01", [{ project: "A", duration: 3600000 }]),
+		];
+		const weeks = groupByCalendarWeek(days);
+		expect(weeks).toHaveLength(2);
+	});
+
+	it("returns weeks sorted most-recent-first", () => {
+		const days = [
+			makeDay("2026-05-18", [{ project: "A", duration: 3600000 }]),
+			makeDay("2026-05-25", [{ project: "A", duration: 3600000 }]),
+		];
+		const weeks = groupByCalendarWeek(days);
+		expect(weeks[0].weekStart.getTime()).toBeGreaterThan(
+			weeks[1].weekStart.getTime()
+		);
+	});
+
+	it("collects unique projects per week without duplicates", () => {
+		const days = [
+			makeDay("2026-05-25", [
+				{ project: "Alpha", duration: 3600000 },
+				{ project: "Beta", duration: 1800000 },
+				{ project: "Alpha", duration: 900000 },
+			]),
+		];
+		const weeks = groupByCalendarWeek(days);
+		expect(weeks[0].projects.sort()).toEqual(["Alpha", "Beta"]);
+	});
+
+	it("sums totalDuration across all days in the week", () => {
+		const days = [
+			makeDay("2026-05-25", [{ duration: 3600000 }]),
+			makeDay("2026-05-26", [{ duration: 7200000 }]),
+		];
+		const weeks = groupByCalendarWeek(days);
+		expect(weeks[0].totalDuration).toBe(10800000);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// getMostRecentCompleteWeek
+// ---------------------------------------------------------------------------
+
+describe("getMostRecentCompleteWeek", () => {
+	it("returns null for an empty list", () => {
+		expect(getMostRecentCompleteWeek([])).toBeNull();
+	});
+
+	it("returns a past week as the most recent complete week", () => {
+		const days = [
+			makeDay("2026-01-15", [{ project: "A", duration: 3600000 }]),
+		];
+		const weeks = groupByCalendarWeek(days);
+		const result = getMostRecentCompleteWeek(weeks);
+		expect(result).not.toBeNull();
+		expect(result!.weekEnd.getTime()).toBeLessThan(Date.now());
+	});
+
+	it("falls back to the first (most recent) week when none are complete", () => {
+		// Use a future date so no week is "complete"
+		const futureDate = new Date(Date.now() + 30 * 86400000)
+			.toISOString()
+			.slice(0, 10);
+		const days = [makeDay(futureDate, [{ project: "A", duration: 3600000 }])];
+		const weeks = groupByCalendarWeek(days);
+		const result = getMostRecentCompleteWeek(weeks);
+		expect(result).toBe(weeks[0]);
+	});
+});

--- a/src/utils/reportUtils.ts
+++ b/src/utils/reportUtils.ts
@@ -398,3 +398,31 @@ export function getMostRecentCompleteWeek(
   const complete = weeks.find(w => w.weekEnd < now);
   return complete ?? weeks[0];
 }
+
+/**
+ * Returns a new WeekGroup containing only tasks matching the given project name.
+ * Days with no matching tasks are excluded and totalDuration is recomputed.
+ * Pass an empty string to return the original week unchanged.
+ */
+export function filterWeekByProject(week: WeekGroup, project: string): WeekGroup {
+  if (!project) return week;
+
+  const filteredDays = week.days
+    .map(day => ({
+      ...day,
+      tasks: day.tasks.filter(t => t.project === project)
+    }))
+    .filter(day => day.tasks.length > 0);
+
+  const totalDuration = filteredDays.reduce(
+    (sum, day) => sum + day.tasks.reduce((s, t) => s + t.duration, 0),
+    0
+  );
+
+  return {
+    ...week,
+    days: filteredDays,
+    totalDuration,
+    projects: [project]
+  };
+}


### PR DESCRIPTION
Adds a project dropdown to the weekly report page so users can scope the
week preview, AI prompt, and generated summary to a single project. Also
introduces filterWeekByProject utility and a full test suite for reportUtils.

- reportUtils: add filterWeekByProject(week, project) — filters days/tasks by project name, excludes empty days, recomputes totalDuration
- reportUtils.test.ts: new test file covering filterWeekByProject, formatDuration, groupByCalendarWeek, and getMostRecentCompleteWeek
- Report.tsx: add selectedProject state + filteredWeek memo; render a project Select below week navigation when the week has ≥1 project; pass filteredWeek to WeekPreview, generate(), and auto-save; include project in localStorage key so filtered summaries don't collide with full-week summaries; reset project on week change