### PR TITLE
fix: use pnpm in release workflow instead of npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: npm
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Configure Git
         run: |
@@ -144,7 +146,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Get current version
         id: current_version
@@ -171,7 +173,7 @@ jobs:
 
       - name: Commit version bump
         run: |
-          git add package.json package-lock.json || true
+          git add package.json pnpm-lock.yaml || true
           if git diff --cached --quiet; then
             echo "No version changes to commit"
           else


### PR DESCRIPTION
## Summary

- The Release workflow was failing immediately because `actions/setup-node` had `cache: npm`, which requires a `package-lock.json` — but this project uses pnpm (`pnpm-lock.yaml` only)
- Replaced `cache: npm` with `pnpm/action-setup@v4` for proper pnpm support
- Switched `npm ci` to `pnpm install --frozen-lockfile`
- Fixed the version-bump commit step to stage `pnpm-lock.yaml` instead of `package-lock.json`

## Root cause

```
##[error]Dependencies lock file is not found. Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock
```

Failed run: https://github.com/AdamJ/TimeTrackerPro/actions/runs/27069250200

## Test plan
- [ ] Merge this PR — the push to main will trigger a new Release workflow run with the corrected pnpm setup

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfxfwVHGTb95pNZFFh9R6E)_