### PR TITLE
feat: add automated Electron desktop release workflow

### DIFF
--- a/.github/workflows/electron-release.yml
+++ b/.github/workflows/electron-release.yml
@@ -1,0 +1,57 @@
+name: Electron Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    if: ${{ !github.event.release.prerelease && !github.event.release.draft }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            build_script: electron:build -- --mac
+          - os: windows-latest
+            build_script: electron:build -- --win
+
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: write
+
+    env:
+      VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+      VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+      CSC_IDENTITY_AUTO_DISCOVERY: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Electron app
+        run: pnpm run ${{ matrix.build_script }}
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: |
+            dist-electron-build/*.dmg
+            dist-electron-build/*.exe
+            dist-electron-build/*.blockmap
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Automated Electron desktop release CI — when the existing version-bump release workflow publishes a new GitHub Release, a new `electron-release.yml` workflow builds the Electron app for macOS (DMG) and Windows (NSIS) on `release: published` and uploads the installers as release assets via `softprops/action-gh-release`.
+  — `.github/workflows/electron-release.yml` (new)
 - Electron desktop build target — the app can now be packaged as a native Mac (DMG) or Windows (NSIS) desktop app via Electron. `electron/main.ts` creates a `BrowserWindow` (1280×800, `contextIsolation: true`, `nodeIntegration: false`) with a CSP header that allows `self`, `data:`, and `https://*.supabase.co`. Dev mode loads `http://localhost:8080`; production serves `dist/` via a custom `app://` protocol handler (required because the app uses `BrowserRouter` — `file://` + pushState breaks without a real origin). `vite.electron.config.ts` compiles the main process to CJS (`dist-electron/main.cjs`) in isolation from the app Vite config. New scripts: `electron:build:main`, `electron:dev`, `electron:preview`, `electron:build`. CI updated to use pnpm exclusively (`pnpm/action-setup@v4`, `pnpm install --frozen-lockfile`); `package-lock.json` removed in favour of `pnpm-lock.yaml` as the single lock file.
   — `electron/main.ts` (new), `electron/tsconfig.json` (new), `vite.electron.config.ts` (new), `package.json` (`packageManager`, `main`, scripts, electron-builder `build` config), `.gitignore` (`dist-electron/`, `dist-electron-build/`), `.github/workflows/test.yml` (pnpm)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md - AI Assistant Codebase Guide
 
-**Last Updated:** 2026-05-30
-**Version:** 2.4.0
+**Last Updated:** 2026-06-10
+**Version:** 2.4.1
 
 Timetraked is a React 18 + TypeScript time tracking PWA for freelancers and consultants, with dual storage (localStorage guest mode and optional Supabase cloud sync). A native iOS app is also available via Capacitor.
 
@@ -192,6 +192,7 @@ pnpm run electron:build        # full production build + package via electron-bu
 - The app uses `BrowserRouter` (not `HashRouter`). Production loads via a registered `app://` custom protocol (using `protocol.handle`) that serves `dist/` and falls back to `index.html` for unknown paths, giving pushState routing a real origin to work against. Dev mode loads `http://localhost:8080` directly — no protocol handler needed
 - The electron-builder config lives in the `"build"` key of `package.json`; output goes to `dist-electron-build/` (gitignored)
 - `dist-electron/` (compiled main) and `dist-electron-build/` (packaged app) are both gitignored
+- `.github/workflows/electron-release.yml` builds macOS (DMG) and Windows (NSIS) installers and attaches them to the GitHub Release whenever `release.yml` publishes a new version-bump release
 
 **When adding Electron-specific features:**
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/electron-release.yml`, which runs on `release: published` (the event emitted by the existing `release.yml` version-bump workflow)
- Builds the Electron app for macOS (DMG) and Windows (NSIS) via `pnpm run electron:build -- --mac` / `--win` on `macos-latest` / `windows-latest`
- Uploads the built `.dmg`, `.exe`, and `.blockmap` files to the published release as assets via `softprops/action-gh-release`
- Skips draft/prerelease releases

## How it fits with the existing release flow

`release.yml` already bumps `package.json`'s version, tags it, and publishes a GitHub Release when a PR with a `feat`/`fix`/`major`/etc. title merges to `main`. This new workflow listens for that `release: published` event and attaches the desktop installers to the same release.

## Test plan

- [ ] Merge a PR with a version-bumping title (e.g. `fix: ...`) to confirm `release.yml` still publishes a release as before
- [ ] Confirm `electron-release.yml` triggers on the published release and successfully builds + attaches DMG and NSIS installers to the release assets
- [ ] Verify draft/prerelease releases do not trigger a build
